### PR TITLE
chore: add PartialEq and Eq derives to IssueSummary

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -175,7 +175,7 @@ pub struct BlockingEdge {
 ///
 /// Contains only the fields needed for display and sorting, avoiding the
 /// full weight of [`Issue`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IssueSummary {
     /// GitHub issue number.
     pub number: u64,


### PR DESCRIPTION
All fields already support Eq, making this a zero-cost derive that enables equality comparisons for graph engine and test assertions.