### PR TITLE
chore: add Eq derive to BlockingEdge

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -163,7 +163,7 @@ pub enum IssueType {
 ///
 /// Mapped from GitHub's native `blockedBy` relationship.
 /// The edge direction is: `source` is blocked by `target`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BlockingEdge {
     /// Issue number that is blocked.
     pub source: u64,


### PR DESCRIPTION
BlockingEdge derives PartialEq but was missing Eq. Since all fields are u64 (which implements Eq), adding Eq is zero-cost and enables graph engine deduplication and set operations requiring full Eq semantics.