### PR TITLE
feat: implement DomainError enum with 11 variants per ARCH §13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,13 +375,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -946,6 +973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1001,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,9 +1036,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1165,6 +1270,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1685,11 +1802,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unblock-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
  "petgraph",
+ "proptest",
  "serde",
  "serde_json",
  "snafu",
@@ -1774,6 +1898,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"
@@ -2178,6 +2311,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/unblock-core/src/errors.rs
+++ b/crates/unblock-core/src/errors.rs
@@ -153,7 +153,7 @@ mod tests {
         }
         .build();
         assert!(err.to_string().contains("bot-1"));
-        assert!(err.to_string().contains("7"));
+        assert!(err.to_string().contains('7'));
         assert_eq!(err.status_code(), 409);
     }
 
@@ -194,7 +194,7 @@ mod tests {
     fn issue_not_closed_display_and_status() {
         let err = IssueNotClosedSnafu { number: 3_u64 }.build();
         let msg = err.to_string();
-        assert!(msg.contains("3"));
+        assert!(msg.contains('3'));
         assert!(msg.contains("not closed"));
         assert_eq!(err.status_code(), 409);
     }
@@ -302,7 +302,8 @@ mod tests {
 
         for err in &errors {
             // This line would fail to compile if DomainError didn't impl Error
-            let _dyn_err: &dyn std::error::Error = err;
+            let dyn_err: &dyn std::error::Error = err;
+            _ = dyn_err;
             assert!(!err.to_string().is_empty());
         }
     }

--- a/crates/unblock-core/src/errors.rs
+++ b/crates/unblock-core/src/errors.rs
@@ -1,4 +1,309 @@
 //! Domain error types using snafu.
 //!
+//! Defines `DomainError` with variants for all domain-level failure modes.
+//! Each variant carries the relevant context and maps to an HTTP status code
+//! via `DomainError::status_code`.
+//!
 //! Variants: `IssueNotFound`, `AlreadyClaimed`, `IssueBlocked`, `IssueDeferred`,
-//! `IssueClosed`, `CircularDependency`, `DuplicateDependency`, `Validation`.
+//! `IssueClosed`, `IssueNotClosed`, `IssueAlreadyOpen`, `CircularDependency`,
+//! `DuplicateDependency`, `FieldNotFound`, `Validation`.
+
+use snafu::prelude::*;
+
+/// Domain-level errors for the unblock system.
+///
+/// Each variant represents a specific business-rule violation or lookup failure.
+/// Use the generated snafu context selectors (e.g. [`IssueNotFoundSnafu`]) to
+/// construct errors ergonomically.
+///
+/// The [`status_code`](DomainError::status_code) method maps each variant to
+/// the appropriate HTTP status code for MCP error conversion.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum DomainError {
+    /// The requested issue does not exist.
+    #[snafu(display("Issue not found: #{number}"))]
+    IssueNotFound {
+        /// The issue number that was not found.
+        number: u64,
+    },
+
+    /// The issue is already claimed by another agent.
+    #[snafu(display("Issue #{number} is already claimed by {agent}"))]
+    AlreadyClaimed {
+        /// The issue number.
+        number: u64,
+        /// The agent that currently holds the claim.
+        agent: String,
+    },
+
+    /// The issue has unresolved blocking dependencies.
+    #[snafu(display("Issue #{number} is blocked by: {blockers:?}"))]
+    IssueBlocked {
+        /// The issue number.
+        number: u64,
+        /// Issue numbers that block this issue.
+        blockers: Vec<u64>,
+    },
+
+    /// The issue is deferred until a future date.
+    #[snafu(display("Issue #{number} is deferred until {until}"))]
+    IssueDeferred {
+        /// The issue number.
+        number: u64,
+        /// Human-readable deferral timestamp or date string.
+        until: String,
+    },
+
+    /// The issue is already closed.
+    #[snafu(display("Issue #{number} is already closed"))]
+    IssueClosed {
+        /// The issue number.
+        number: u64,
+    },
+
+    /// The issue is not closed, so it cannot be reopened.
+    #[snafu(display("Issue #{number} is not closed — cannot reopen"))]
+    IssueNotClosed {
+        /// The issue number.
+        number: u64,
+    },
+
+    /// The issue is already open.
+    #[snafu(display("Issue #{number} is already open"))]
+    IssueAlreadyOpen {
+        /// The issue number.
+        number: u64,
+    },
+
+    /// Adding the dependency would create a cycle in the graph.
+    #[snafu(display("Circular dependency: adding #{source} → #{target} creates cycle"))]
+    CircularDependency {
+        /// The source issue number of the proposed edge.
+        #[snafu(source(false))]
+        source: u64,
+        /// The target issue number of the proposed edge.
+        target: u64,
+    },
+
+    /// The blocking relationship already exists.
+    #[snafu(display("Blocking relationship already exists: #{source} → #{target}"))]
+    DuplicateDependency {
+        /// The source issue number.
+        #[snafu(source(false))]
+        source: u64,
+        /// The target issue number.
+        target: u64,
+    },
+
+    /// A referenced field does not exist.
+    #[snafu(display("Field not found: {name}"))]
+    FieldNotFound {
+        /// The name of the missing field.
+        name: String,
+    },
+
+    /// Input validation failed.
+    #[snafu(display("Validation: {message}"))]
+    Validation {
+        /// Description of the validation failure.
+        message: String,
+    },
+}
+
+impl DomainError {
+    /// Returns the HTTP status code associated with this error variant.
+    ///
+    /// Used by the MCP error conversion layer to map domain errors to
+    /// protocol-level error codes without coupling to the variant list.
+    #[must_use]
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::IssueNotFound { .. } | Self::FieldNotFound { .. } => 404,
+            Self::Validation { .. } => 400,
+            Self::CircularDependency { .. } => 422,
+            Self::AlreadyClaimed { .. }
+            | Self::IssueBlocked { .. }
+            | Self::IssueDeferred { .. }
+            | Self::IssueClosed { .. }
+            | Self::IssueNotClosed { .. }
+            | Self::IssueAlreadyOpen { .. }
+            | Self::DuplicateDependency { .. } => 409,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn issue_not_found_display_and_status() {
+        let err = IssueNotFoundSnafu { number: 42_u64 }.build();
+        assert!(!err.to_string().is_empty());
+        assert!(err.to_string().contains("42"));
+        assert_eq!(err.status_code(), 404);
+    }
+
+    #[test]
+    fn already_claimed_display_and_status() {
+        let err = AlreadyClaimedSnafu {
+            number: 7_u64,
+            agent: "bot-1".to_owned(),
+        }
+        .build();
+        assert!(err.to_string().contains("bot-1"));
+        assert!(err.to_string().contains("7"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn issue_blocked_display_and_status() {
+        let err = IssueBlockedSnafu {
+            number: 10_u64,
+            blockers: vec![1_u64, 2],
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(!msg.is_empty());
+        assert!(msg.contains("10"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn issue_deferred_display_and_status() {
+        let err = IssueDeferredSnafu {
+            number: 5_u64,
+            until: "2026-04-01".to_owned(),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("2026-04-01"));
+        assert!(!msg.is_empty());
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn issue_closed_display_and_status() {
+        let err = IssueClosedSnafu { number: 99_u64 }.build();
+        assert!(err.to_string().contains("99"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn issue_not_closed_display_and_status() {
+        let err = IssueNotClosedSnafu { number: 3_u64 }.build();
+        let msg = err.to_string();
+        assert!(msg.contains("3"));
+        assert!(msg.contains("not closed"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn issue_already_open_display_and_status() {
+        let err = IssueAlreadyOpenSnafu { number: 15_u64 }.build();
+        let msg = err.to_string();
+        assert!(msg.contains("15"));
+        assert!(msg.contains("already open"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn circular_dependency_display_and_status() {
+        let err = CircularDependencySnafu {
+            source: 1_u64,
+            target: 2_u64,
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains('1'));
+        assert!(msg.contains('2'));
+        assert!(msg.contains("cycle"));
+        assert_eq!(err.status_code(), 422);
+    }
+
+    #[test]
+    fn duplicate_dependency_display_and_status() {
+        let err = DuplicateDependencySnafu {
+            source: 4_u64,
+            target: 5_u64,
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains('4'));
+        assert!(msg.contains('5'));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn field_not_found_display_and_status() {
+        let err = FieldNotFoundSnafu {
+            name: "priority".to_owned(),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("priority"));
+        assert_eq!(err.status_code(), 404);
+    }
+
+    #[test]
+    fn validation_display_and_status() {
+        let err = ValidationSnafu {
+            message: "GITHUB_TOKEN is required".to_owned(),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("GITHUB_TOKEN"));
+        assert_eq!(err.status_code(), 400);
+    }
+
+    #[test]
+    fn all_variants_implement_error_trait() {
+        // Verify DomainError implements std::error::Error by using it as &dyn Error
+        let errors: Vec<DomainError> = vec![
+            IssueNotFoundSnafu { number: 1_u64 }.build(),
+            AlreadyClaimedSnafu {
+                number: 1_u64,
+                agent: "a".to_owned(),
+            }
+            .build(),
+            IssueBlockedSnafu {
+                number: 1_u64,
+                blockers: vec![2_u64],
+            }
+            .build(),
+            IssueDeferredSnafu {
+                number: 1_u64,
+                until: "tomorrow".to_owned(),
+            }
+            .build(),
+            IssueClosedSnafu { number: 1_u64 }.build(),
+            IssueNotClosedSnafu { number: 1_u64 }.build(),
+            IssueAlreadyOpenSnafu { number: 1_u64 }.build(),
+            CircularDependencySnafu {
+                source: 1_u64,
+                target: 2_u64,
+            }
+            .build(),
+            DuplicateDependencySnafu {
+                source: 1_u64,
+                target: 2_u64,
+            }
+            .build(),
+            FieldNotFoundSnafu {
+                name: "x".to_owned(),
+            }
+            .build(),
+            ValidationSnafu {
+                message: "bad".to_owned(),
+            }
+            .build(),
+        ];
+
+        for err in &errors {
+            // This line would fail to compile if DomainError didn't impl Error
+            let _dyn_err: &dyn std::error::Error = err;
+            assert!(!err.to_string().is_empty());
+        }
+    }
+}

--- a/crates/unblock-core/src/lib.rs
+++ b/crates/unblock-core/src/lib.rs
@@ -22,5 +22,5 @@ pub mod cache;
 /// Environment-based configuration.
 pub mod config;
 
-/// Domain error types.
+/// Domain error types with HTTP status code mapping.
 pub mod errors;


### PR DESCRIPTION
Implement the complete DomainError enum in unblock-core/src/errors.rs using snafu derive macros. All 11 variants from the architecture doc are included: IssueNotFound, AlreadyClaimed, IssueBlocked, IssueDeferred, IssueClosed, IssueNotClosed, IssueAlreadyOpen, CircularDependency, DuplicateDependency, FieldNotFound, and Validation.

Each variant has doc comments, Display via snafu, and status_code() mapping to the correct HTTP code per ARCH §13.1 table.

Includes 12 unit tests covering every variant's Display output and status code, plus an error-trait verification test for all variants.