### PR TITLE
chore: add inline HTTP status code comments to status_code() match arms

### DIFF
--- a/crates/unblock-core/src/errors.rs
+++ b/crates/unblock-core/src/errors.rs
@@ -119,9 +119,13 @@ impl DomainError {
     #[must_use]
     pub fn status_code(&self) -> u16 {
         match self {
+            // 404 Not Found
             Self::IssueNotFound { .. } | Self::FieldNotFound { .. } => 404,
+            // 400 Bad Request
             Self::Validation { .. } => 400,
+            // 422 Unprocessable Entity
             Self::CircularDependency { .. } => 422,
+            // 409 Conflict
             Self::AlreadyClaimed { .. }
             | Self::IssueBlocked { .. }
             | Self::IssueDeferred { .. }


### PR DESCRIPTION
Adds // 404, // 400, // 422, // 409 comments above each match arm in DomainError::status_code() for immediate readability at a glance.