### PR TITLE
docs: reorder error bullet lists in config.rs to match validation seq…

### DIFF
--- a/crates/unblock-core/src/config.rs
+++ b/crates/unblock-core/src/config.rs
@@ -117,8 +117,8 @@ impl Config {
     /// Returns [`DomainError::Validation`](crate::errors::DomainError::Validation) if:
     /// - `GITHUB_TOKEN` is not set or is an empty string.
     /// - `UNBLOCK_REPO` is set but does not match the expected `owner/repo` format.
-    /// - `UNBLOCK_CACHE_TTL` is set but cannot be parsed as `u64`.
     /// - `UNBLOCK_PROJECT` is set but cannot be parsed as `u64`.
+    /// - `UNBLOCK_CACHE_TTL` is set but cannot be parsed as `u64`.
     pub fn load() -> Result<Self, crate::errors::DomainError> {
         Self::load_from(|key| std::env::var(key))
     }
@@ -134,8 +134,8 @@ impl Config {
     /// Returns [`DomainError::Validation`](crate::errors::DomainError::Validation) if:
     /// - `GITHUB_TOKEN` is not set or is an empty string.
     /// - `UNBLOCK_REPO` is set but does not match the expected `owner/repo` format.
-    /// - `UNBLOCK_CACHE_TTL` is set but cannot be parsed as `u64`.
     /// - `UNBLOCK_PROJECT` is set but cannot be parsed as `u64`.
+    /// - `UNBLOCK_CACHE_TTL` is set but cannot be parsed as `u64`.
     pub fn load_from(
         env: impl Fn(&str) -> Result<String, VarError>,
     ) -> Result<Self, crate::errors::DomainError> {


### PR DESCRIPTION
…uence

The # Errors doc comments on load() and load_from() listed UNBLOCK_CACHE_TTL before UNBLOCK_PROJECT, but the code validates UNBLOCK_PROJECT first (line 167) then UNBLOCK_CACHE_TTL (line 179). Swap the two bullets so documentation matches implementation order.

Resolves: unblock-b6b.14