### PR TITLE
test: add unit test for would_create_cycle self-loop edge case

### DIFF
--- a/crates/unblock-core/src/graph.rs
+++ b/crates/unblock-core/src/graph.rs
@@ -865,6 +865,14 @@ mod tests {
         assert!(!graph.would_create_cycle(1, 2));
     }
 
+    #[test]
+    fn would_create_cycle_self_loop() {
+        // A node blocking itself is always a cycle, even with no existing edges.
+        let issues = vec![make_issue(1, IssueState::Open, Priority::P2)];
+        let graph = DependencyGraph::build(&issues, &[]);
+        assert!(graph.would_create_cycle(1, 1));
+    }
+
     // ── detect_all_cycles ─────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Verify that would_create_cycle(X, X) returns true when source and target are the same node, documenting reliance on petgraph's has_path_connecting treating a node as reachable from itself.