### PR TITLE
chore: align tokio dep in unblock-core to workspace = true

### DIFF
--- a/crates/unblock-core/Cargo.toml
+++ b/crates/unblock-core/Cargo.toml
@@ -16,7 +16,7 @@ petgraph = { workspace = true }
 chrono = { workspace = true }
 snafu = { workspace = true }
 tracing = { workspace = true }
-tokio = { version = "1", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
Replace literal `version = "1"` with `workspace = true` on the production tokio dependency so it tracks the workspace-pinned version. Features = ["sync"] is preserved to document the minimal requirement.