### PR TITLE
feat: complete GitHub Error enum with missing fields and status_code()

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -148,6 +148,7 @@ mod tests {
             msg.starts_with("Cannot connect to GitHub: "),
             "unexpected display: {msg}"
         );
+        assert_eq!(err.status_code(), 503);
     }
 
     #[test]

--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -10,6 +10,8 @@
 use snafu::prelude::*;
 use unblock_core::errors::DomainError;
 
+use chrono::{DateTime, Utc};
+
 /// Infrastructure-level errors for the GitHub API client.
 ///
 /// Each variant represents a specific infrastructure failure mode. Domain errors
@@ -30,8 +32,10 @@ pub enum Error {
     },
 
     /// A non-2xx response from the GitHub REST API.
-    #[snafu(display("GitHub API error: {message}"))]
+    #[snafu(display("GitHub API error ({status}): {message}"))]
     GitHubApi {
+        /// HTTP status code from the API response.
+        status: u16,
         /// Human-readable error message from the API response.
         message: String,
     },
@@ -51,12 +55,18 @@ pub enum Error {
     },
 
     /// GitHub returned HTTP 429 — rate limit exceeded.
-    #[snafu(display("GitHub rate limit exceeded"))]
-    RateLimited,
+    #[snafu(display("GitHub rate limit exceeded — resets at {reset_at}"))]
+    RateLimited {
+        /// When the rate limit resets (from the `X-RateLimit-Reset` header).
+        reset_at: DateTime<Utc>,
+    },
 
     /// Circuit breaker is open due to repeated GitHub failures (Phase 2 stub).
-    #[snafu(display("Circuit breaker open — GitHub consistently failing"))]
-    CircuitBreakerOpen,
+    #[snafu(display("Circuit breaker open — GitHub consistently failing (tripped at {since:?})"))]
+    CircuitBreakerOpen {
+        /// The instant the circuit breaker was tripped.
+        since: std::time::Instant,
+    },
 
     /// No Projects V2 project is configured or discoverable.
     #[snafu(display("Projects V2 not configured — run `setup` first"))]
@@ -68,6 +78,25 @@ pub enum Error {
         /// Description of the git remote detection failure.
         message: String,
     },
+}
+
+impl Error {
+    /// Returns the HTTP status code associated with this error variant.
+    ///
+    /// Used by the MCP error conversion layer to map infrastructure errors to
+    /// protocol-level error codes without coupling to the variant list.
+    #[must_use]
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::Domain { source } => source.status_code(),
+            Self::GitHubApi { status, .. } => *status,
+            Self::GitHubGraphQL { .. } => 422,
+            Self::GitHubUnavailable { .. } | Self::CircuitBreakerOpen { .. } => 503,
+            Self::RateLimited { .. } => 429,
+            Self::ProjectNotConfigured => 412,
+            Self::GitRemote { .. } => 500,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -87,10 +116,11 @@ mod tests {
     #[test]
     fn github_api_display() {
         let err = GitHubApiSnafu {
+            status: 404_u16,
             message: "Not Found".to_owned(),
         }
         .build();
-        assert_eq!(err.to_string(), "GitHub API error: Not Found");
+        assert_eq!(err.to_string(), "GitHub API error (404): Not Found");
     }
 
     #[test]
@@ -122,16 +152,29 @@ mod tests {
 
     #[test]
     fn rate_limited_display() {
-        let err = RateLimitedSnafu.build();
-        assert_eq!(err.to_string(), "GitHub rate limit exceeded");
+        let reset_at = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc);
+        let err = RateLimitedSnafu { reset_at }.build();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("rate limit exceeded"),
+            "unexpected display: {msg}"
+        );
+        assert!(
+            msg.contains("2026-01-01"),
+            "display must include reset_at: {msg}"
+        );
     }
 
     #[test]
     fn circuit_breaker_open_display() {
-        let err = CircuitBreakerOpenSnafu.build();
-        assert_eq!(
-            err.to_string(),
-            "Circuit breaker open \u{2014} GitHub consistently failing"
+        let since = std::time::Instant::now();
+        let err = CircuitBreakerOpenSnafu { since }.build();
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with("Circuit breaker open"),
+            "unexpected display: {msg}"
         );
     }
 
@@ -161,6 +204,7 @@ mod tests {
         let errors: Vec<Error> = vec![
             Error::from(IssueNotFoundSnafu { number: 1_u64 }.build()),
             GitHubApiSnafu {
+                status: 500_u16,
                 message: "err".to_owned(),
             }
             .build(),
@@ -168,8 +212,14 @@ mod tests {
                 errors: "err".to_owned(),
             }
             .build(),
-            RateLimitedSnafu.build(),
-            CircuitBreakerOpenSnafu.build(),
+            RateLimitedSnafu {
+                reset_at: Utc::now(),
+            }
+            .build(),
+            CircuitBreakerOpenSnafu {
+                since: std::time::Instant::now(),
+            }
+            .build(),
             ProjectNotConfiguredSnafu.build(),
             GitRemoteSnafu {
                 message: "err".to_owned(),
@@ -182,5 +232,63 @@ mod tests {
             _ = dyn_err;
             assert!(!err.to_string().is_empty());
         }
+    }
+
+    #[test]
+    fn status_code_domain_delegates() {
+        let err = Error::from(IssueNotFoundSnafu { number: 7_u64 }.build());
+        assert_eq!(err.status_code(), 404);
+    }
+
+    #[test]
+    fn status_code_github_api() {
+        let err = GitHubApiSnafu {
+            status: 403_u16,
+            message: "Forbidden".to_owned(),
+        }
+        .build();
+        assert_eq!(err.status_code(), 403);
+    }
+
+    #[test]
+    fn status_code_github_graphql() {
+        let err = GitHubGraphQLSnafu {
+            errors: "bad field".to_owned(),
+        }
+        .build();
+        assert_eq!(err.status_code(), 422);
+    }
+
+    #[test]
+    fn status_code_rate_limited() {
+        let err = RateLimitedSnafu {
+            reset_at: Utc::now(),
+        }
+        .build();
+        assert_eq!(err.status_code(), 429);
+    }
+
+    #[test]
+    fn status_code_circuit_breaker_open() {
+        let err = CircuitBreakerOpenSnafu {
+            since: std::time::Instant::now(),
+        }
+        .build();
+        assert_eq!(err.status_code(), 503);
+    }
+
+    #[test]
+    fn status_code_project_not_configured() {
+        let err = ProjectNotConfiguredSnafu.build();
+        assert_eq!(err.status_code(), 412);
+    }
+
+    #[test]
+    fn status_code_git_remote() {
+        let err = GitRemoteSnafu {
+            message: "no origin".to_owned(),
+        }
+        .build();
+        assert_eq!(err.status_code(), 500);
     }
 }


### PR DESCRIPTION
Add status field to GitHubApi, reset_at to RateLimited, since to CircuitBreakerOpen. Implement status_code() method on Error following the DomainError pattern. Add unit tests for every variant's status code.