### PR TITLE
feat: add IssueComment struct and comments field to Issue

### DIFF
--- a/crates/unblock-core/src/cache.rs
+++ b/crates/unblock-core/src/cache.rs
@@ -179,6 +179,10 @@ mod tests {
             updated_at: Utc::now(),
             url: format!("https://github.com/test/repo/issues/{number}"),
             comments: vec![],
+            blocked_by: vec![],
+            blocking: vec![],
+            parent: None,
+            sub_issues: vec![],
         }
     }
 

--- a/crates/unblock-core/src/cache.rs
+++ b/crates/unblock-core/src/cache.rs
@@ -178,6 +178,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             url: format!("https://github.com/test/repo/issues/{number}"),
+            comments: vec![],
         }
     }
 

--- a/crates/unblock-core/src/graph.rs
+++ b/crates/unblock-core/src/graph.rs
@@ -63,7 +63,7 @@ impl DependencyGraph {
     ///         story_points: None, defer_until: None, labels: vec![],
     ///         milestone: None, assignees: vec![], state: IssueState::Open,
     ///         body: None, created_at: Utc::now(), updated_at: Utc::now(),
-    ///         url: String::new(),
+    ///         url: String::new(), comments: vec![],
     ///     },
     /// ];
     /// let edges: Vec<BlockingEdge> = vec![];
@@ -427,6 +427,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
             url: String::new(),
+            comments: vec![],
         }
     }
 

--- a/crates/unblock-core/src/graph.rs
+++ b/crates/unblock-core/src/graph.rs
@@ -64,6 +64,8 @@ impl DependencyGraph {
     ///         milestone: None, assignees: vec![], state: IssueState::Open,
     ///         body: None, created_at: Utc::now(), updated_at: Utc::now(),
     ///         url: String::new(), comments: vec![],
+    ///         blocked_by: vec![], blocking: vec![],
+    ///         parent: None, sub_issues: vec![],
     ///     },
     /// ];
     /// let edges: Vec<BlockingEdge> = vec![];
@@ -428,6 +430,10 @@ mod tests {
             updated_at: Utc::now(),
             url: String::new(),
             comments: vec![],
+            blocked_by: vec![],
+            blocking: vec![],
+            parent: None,
+            sub_issues: vec![],
         }
     }
 

--- a/crates/unblock-core/src/lib.rs
+++ b/crates/unblock-core/src/lib.rs
@@ -10,7 +10,7 @@
 //! - **Config** — environment-based configuration
 //! - **Errors** — domain error types with snafu
 
-/// Domain types: `Issue`, `IssueComment`, `Status`, `Priority`, `ReadyState`, `BlockingEdge`, `BodySections`.
+/// Domain types: `Issue`, `IssueComment`, `RelatedIssue`, `Status`, `Priority`, `ReadyState`, `BlockingEdge`, `BodySections`.
 pub mod types;
 
 /// Dependency graph engine: build, ready set, cascade, cycle detection.

--- a/crates/unblock-core/src/lib.rs
+++ b/crates/unblock-core/src/lib.rs
@@ -10,7 +10,7 @@
 //! - **Config** — environment-based configuration
 //! - **Errors** — domain error types with snafu
 
-/// Domain types: `Issue`, `Status`, `Priority`, `ReadyState`, `BlockingEdge`, `BodySections`.
+/// Domain types: `Issue`, `IssueComment`, `Status`, `Priority`, `ReadyState`, `BlockingEdge`, `BodySections`.
 pub mod types;
 
 /// Dependency graph engine: build, ready set, cascade, cycle detection.

--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -1,8 +1,8 @@
 //! Domain types for the unblock system.
 //!
-//! Defines the core data structures: `Issue`, `IssueComment`, `IssueState`,
-//! `Status`, `Priority`, `ReadyState`, `IssueType`, `BlockingEdge`,
-//! `IssueSummary`, and `BodySections`.
+//! Defines the core data structures: `Issue`, `IssueComment`, `RelatedIssue`,
+//! `IssueState`, `Status`, `Priority`, `ReadyState`, `IssueType`,
+//! `BlockingEdge`, `IssueSummary`, and `BodySections`.
 //!
 //! All types are backend-agnostic — the GitHub client handles mapping from
 //! GitHub-specific field names. The graph engine works identically regardless
@@ -73,6 +73,14 @@ pub struct Issue {
     pub url: String,
     /// Comments on the issue (populated by `fetch_issue()`, empty for bulk fetches).
     pub comments: Vec<IssueComment>,
+    /// Issues that block this issue (populated by `fetch_issue()` only).
+    pub blocked_by: Vec<RelatedIssue>,
+    /// Issues that this issue blocks (populated by `fetch_issue()` only).
+    pub blocking: Vec<RelatedIssue>,
+    /// Parent issue if this is a sub-issue (populated by `fetch_issue()` only).
+    pub parent: Option<RelatedIssue>,
+    /// Sub-issues of this issue (populated by `fetch_issue()` only).
+    pub sub_issues: Vec<RelatedIssue>,
 }
 
 /// GitHub native issue state.
@@ -174,6 +182,21 @@ pub enum IssueType {
     Chore,
     /// A time-boxed investigation.
     Spike,
+}
+
+/// A lightweight reference to a related issue.
+///
+/// Used for dependency relationships (`blockedBy`, `blocking`),
+/// parent issues, and sub-issues returned by `fetch_issue()`.
+/// Contains only the fields available from nested GraphQL fragments.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RelatedIssue {
+    /// GitHub issue number.
+    pub number: u64,
+    /// Issue title.
+    pub title: String,
+    /// GitHub native issue state.
+    pub state: IssueState,
 }
 
 /// A blocking edge in the dependency graph.

--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -1,7 +1,7 @@
 //! Domain types for the unblock system.
 //!
-//! Defines the core data structures: `Issue`, `IssueState`, `Status`,
-//! `Priority`, `ReadyState`, `IssueType`, `BlockingEdge`,
+//! Defines the core data structures: `Issue`, `IssueComment`, `IssueState`,
+//! `Status`, `Priority`, `ReadyState`, `IssueType`, `BlockingEdge`,
 //! `IssueSummary`, and `BodySections`.
 //!
 //! All types are backend-agnostic — the GitHub client handles mapping from
@@ -10,6 +10,21 @@
 
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+
+/// A comment on a GitHub issue.
+///
+/// Parsed from the GraphQL `comments` connection on a single-issue fetch.
+/// Only included in [`Issue`] when fetched via `fetch_issue()` — the bulk
+/// `fetch_graph_data()` omits comments for performance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IssueComment {
+    /// GitHub login of the comment author.
+    pub author: String,
+    /// Full markdown body of the comment.
+    pub body: String,
+    /// Timestamp when the comment was created.
+    pub created_at: DateTime<Utc>,
+}
 
 /// An issue in the dependency graph.
 ///
@@ -56,6 +71,8 @@ pub struct Issue {
     pub updated_at: DateTime<Utc>,
     /// HTML URL for linking back to GitHub.
     pub url: String,
+    /// Comments on the issue (populated by `fetch_issue()`, empty for bulk fetches).
+    pub comments: Vec<IssueComment>,
 }
 
 /// GitHub native issue state.

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -3,3 +3,970 @@
 //! - `fetch_graph_data()` — paginated query returning all open issues, blocking edges,
 //!   and Projects V2 field values in a single request
 //! - `fetch_issue()` — single issue with comments, deps, parent, sub-issues, and all fields
+
+use chrono::{DateTime, Utc};
+use snafu::ResultExt as _;
+use tracing::{debug, instrument};
+use unblock_core::types::{
+    Issue, IssueComment, IssueState, IssueType, Priority, ReadyState, RelatedIssue, Status,
+};
+
+use crate::client::GitHubClient;
+use crate::errors::{self, Error};
+
+/// GraphQL query for fetching a single issue with full details.
+///
+/// Includes: all standard fields, comments (first 50), blockedBy, blocking,
+/// parent, subIssues, and Projects V2 field values.
+const FETCH_ISSUE_QUERY: &str = "
+query FetchIssue($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      id
+      number
+      title
+      body
+      state
+      url
+      createdAt
+      updatedAt
+      labels(first: 50) {
+        nodes {
+          name
+        }
+      }
+      milestone {
+        title
+      }
+      assignees(first: 20) {
+        nodes {
+          login
+        }
+      }
+      comments(first: 50) {
+        nodes {
+          author {
+            login
+          }
+          body
+          createdAt
+        }
+      }
+      trackedInIssues(first: 50) {
+        nodes {
+          number
+          title
+          state
+        }
+      }
+      trackedBy: trackedByIssues(first: 50) {
+        nodes {
+          number
+          title
+          state
+        }
+      }
+      parent {
+        number
+        title
+        state
+      }
+      subIssues(first: 50) {
+        nodes {
+          number
+          title
+          state
+        }
+      }
+      projectItems(first: 10) {
+        nodes {
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldTextValue {
+                field { ... on ProjectV2FieldCommon { name } }
+                text
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                field { ... on ProjectV2FieldCommon { name } }
+                number
+              }
+              ... on ProjectV2ItemFieldDateValue {
+                field { ... on ProjectV2FieldCommon { name } }
+                date
+              }
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                field { ... on ProjectV2FieldCommon { name } }
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+";
+
+impl GitHubClient {
+    /// Fetches a single issue with full details from GitHub.
+    ///
+    /// Returns the issue with all standard fields, comments (up to 50),
+    /// blocking relationships, parent/sub-issue links, and Projects V2
+    /// field values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if
+    /// the issue number does not exist. Returns network or GraphQL errors
+    /// for infrastructure failures.
+    ///
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    #[instrument(skip(self), fields(owner = %self.owner(), repo = %self.repo()))]
+    pub async fn fetch_issue(&self, number: u64) -> Result<Issue, Error> {
+        let variables = serde_json::json!({
+            "owner": self.owner(),
+            "repo": self.repo(),
+            "number": number.cast_signed(),
+        });
+
+        let response = self.graphql(FETCH_ISSUE_QUERY, variables).await?;
+
+        let issue_value = &response["data"]["repository"]["issue"];
+
+        if issue_value.is_null() {
+            return Err(unblock_core::errors::IssueNotFoundSnafu { number }
+                .build()
+                .into());
+        }
+
+        Ok(parse_issue(issue_value))
+    }
+
+    /// Sends a GraphQL query to the GitHub API.
+    ///
+    /// Posts the query and variables as JSON to the GraphQL endpoint.
+    /// Handles GraphQL-level errors (errors array in response) and
+    /// HTTP-level errors (non-2xx status codes, rate limiting).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::GitHubGraphQL`] if the response contains GraphQL errors.
+    /// Returns [`Error::GitHubApi`] for non-2xx HTTP responses.
+    /// Returns [`Error::RateLimited`] for HTTP 429 responses.
+    /// Returns [`Error::GitHubUnavailable`] for network failures.
+    #[instrument(skip(self, query, variables))]
+    pub(crate) async fn graphql(
+        &self,
+        query: &str,
+        variables: serde_json::Value,
+    ) -> Result<serde_json::Value, Error> {
+        let url = self.graphql_url();
+        let body = serde_json::json!({
+            "query": query,
+            "variables": variables,
+        });
+
+        debug!(url = %url, "Sending GraphQL request");
+
+        let response = self
+            .http()
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let status = response.status();
+
+        // Handle rate limiting.
+        if status.as_u16() == 429 {
+            let reset_at = parse_rate_limit_reset(&response);
+            return Err(errors::RateLimitedSnafu { reset_at }.build());
+        }
+
+        // Handle non-2xx status codes.
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_owned());
+            return Err(errors::GitHubApiSnafu {
+                status: status.as_u16(),
+                message,
+            }
+            .build());
+        }
+
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        // Check for GraphQL-level errors.
+        if let Some(arr) = json
+            .get("errors")
+            .and_then(serde_json::Value::as_array)
+            .filter(|a| !a.is_empty())
+        {
+            let messages: Vec<String> = arr
+                .iter()
+                .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                .map(String::from)
+                .collect();
+            return Err(errors::GitHubGraphQLSnafu {
+                errors: messages.join("; "),
+            }
+            .build());
+        }
+
+        Ok(json)
+    }
+}
+
+/// Parses the `X-RateLimit-Reset` header from a response into a `DateTime<Utc>`.
+///
+/// Falls back to `Utc::now()` if the header is missing or unparseable.
+fn parse_rate_limit_reset(response: &reqwest::Response) -> DateTime<Utc> {
+    response
+        .headers()
+        .get("x-ratelimit-reset")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+        .and_then(|ts| DateTime::from_timestamp(ts, 0))
+        .unwrap_or_else(Utc::now)
+}
+
+/// Parses a GraphQL issue JSON value into a domain [`Issue`].
+///
+/// Extracts all standard fields, comments, blocking relationships,
+/// parent/sub-issue links, and Projects V2 field values from the
+/// GraphQL response. Missing fields use sensible defaults.
+fn parse_issue(value: &serde_json::Value) -> Issue {
+    let number = json_u64(value, "number");
+    let node_id = json_string(value, "id");
+    let title = json_string(value, "title");
+    let body = value.get("body").and_then(|v| v.as_str()).map(String::from);
+    let state = parse_issue_state(value);
+    let url = json_string(value, "url");
+    let created_at = parse_datetime(value, "createdAt");
+    let updated_at = parse_datetime(value, "updatedAt");
+
+    let labels = parse_string_nodes(value, "labels", "name");
+    let milestone = value
+        .get("milestone")
+        .and_then(|m| m.get("title"))
+        .and_then(|t| t.as_str())
+        .map(String::from);
+    let assignees = parse_string_nodes(value, "assignees", "login");
+
+    let comments = parse_comments(value);
+    let blocked_by = parse_related_issues(value, "trackedInIssues");
+    let blocking = parse_related_issues(value, "trackedBy");
+    let parent = parse_parent_issue(value);
+    let sub_issues = parse_related_issues(value, "subIssues");
+
+    // Extract Projects V2 field values.
+    let field_values = extract_field_values(value);
+    let status = parse_status_field(&field_values);
+    let priority = parse_priority_field(&field_values);
+    let issue_type = parse_issue_type_field(&field_values);
+    let agent = field_values.get("Agent").cloned();
+    let story_points = field_values
+        .get("StoryPoints")
+        .and_then(|v| v.parse::<i32>().ok());
+    let defer_until = field_values
+        .get("DeferUntil")
+        .and_then(|v| chrono::NaiveDate::parse_from_str(v, "%Y-%m-%d").ok());
+    let ready_state = parse_ready_state_field(&field_values);
+    let claimed_at = field_values
+        .get("ClaimedAt")
+        .and_then(|v| v.parse::<DateTime<Utc>>().ok());
+
+    Issue {
+        number,
+        node_id,
+        title,
+        issue_type,
+        status,
+        priority,
+        agent,
+        claimed_at,
+        ready_state,
+        story_points,
+        defer_until,
+        labels,
+        milestone,
+        assignees,
+        state,
+        body,
+        created_at,
+        updated_at,
+        url,
+        comments,
+        blocked_by,
+        blocking,
+        parent,
+        sub_issues,
+    }
+}
+
+/// Extracts a `u64` from a JSON object by key.
+fn json_u64(value: &serde_json::Value, key: &str) -> u64 {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default()
+}
+
+/// Extracts a `String` from a JSON object by key.
+fn json_string(value: &serde_json::Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// Parses a datetime field from a JSON object.
+fn parse_datetime(value: &serde_json::Value, key: &str) -> DateTime<Utc> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok())
+        .unwrap_or_else(Utc::now)
+}
+
+/// Parses the `state` field into an [`IssueState`].
+fn parse_issue_state(value: &serde_json::Value) -> IssueState {
+    match value.get("state").and_then(|v| v.as_str()) {
+        Some("CLOSED") => IssueState::Closed,
+        _ => IssueState::Open,
+    }
+}
+
+/// Extracts string values from a connection's nodes by a nested field name.
+///
+/// Handles the pattern: `{ key: { nodes: [ { field: "value" }, ... ] } }`
+fn parse_string_nodes(value: &serde_json::Value, key: &str, field: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|v| v.get("nodes"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|node| node.get(field).and_then(|v| v.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parses the comments connection into [`IssueComment`] instances.
+fn parse_comments(value: &serde_json::Value) -> Vec<IssueComment> {
+    value
+        .get("comments")
+        .and_then(|v| v.get("nodes"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|node| {
+                    let author = node
+                        .get("author")
+                        .and_then(|a| a.get("login"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("ghost")
+                        .to_owned();
+                    let body = json_string(node, "body");
+                    let created_at = parse_datetime(node, "createdAt");
+                    IssueComment {
+                        author,
+                        body,
+                        created_at,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parses a related-issues connection (blockedBy, blocking, subIssues) into
+/// [`RelatedIssue`] instances.
+fn parse_related_issues(value: &serde_json::Value, key: &str) -> Vec<RelatedIssue> {
+    value
+        .get(key)
+        .and_then(|v| v.get("nodes"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|node| RelatedIssue {
+                    number: json_u64(node, "number"),
+                    title: json_string(node, "title"),
+                    state: parse_issue_state(node),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parses the parent issue field into an optional [`RelatedIssue`].
+fn parse_parent_issue(value: &serde_json::Value) -> Option<RelatedIssue> {
+    let parent = value.get("parent")?;
+    if parent.is_null() {
+        return None;
+    }
+    Some(RelatedIssue {
+        number: json_u64(parent, "number"),
+        title: json_string(parent, "title"),
+        state: parse_issue_state(parent),
+    })
+}
+
+/// Extracts all Projects V2 field values into a name-to-value map.
+///
+/// Iterates over all `projectItems` and their `fieldValues`, collecting
+/// field name/value pairs. For single-select fields, uses the option name.
+/// For text/number/date fields, uses the raw value.
+fn extract_field_values(value: &serde_json::Value) -> std::collections::HashMap<String, String> {
+    let mut fields = std::collections::HashMap::new();
+
+    let Some(project_items) = value
+        .get("projectItems")
+        .and_then(|v| v.get("nodes"))
+        .and_then(|v| v.as_array())
+    else {
+        return fields;
+    };
+
+    for item in project_items {
+        let Some(field_values) = item
+            .get("fieldValues")
+            .and_then(|v| v.get("nodes"))
+            .and_then(|v| v.as_array())
+        else {
+            continue;
+        };
+
+        for fv in field_values {
+            let Some(field_name) = fv
+                .get("field")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+            else {
+                continue;
+            };
+
+            // Single select: has a top-level "name" key (the option name).
+            if let Some(option_name) = fv.get("name").and_then(|v| v.as_str()) {
+                fields.insert(field_name.to_owned(), option_name.to_owned());
+                continue;
+            }
+
+            // Text field.
+            if let Some(text) = fv.get("text").and_then(|v| v.as_str()) {
+                fields.insert(field_name.to_owned(), text.to_owned());
+                continue;
+            }
+
+            // Number field.
+            if let Some(num) = fv.get("number").and_then(serde_json::Value::as_f64) {
+                fields.insert(field_name.to_owned(), num.to_string());
+                continue;
+            }
+
+            // Date field.
+            if let Some(date) = fv.get("date").and_then(|v| v.as_str()) {
+                fields.insert(field_name.to_owned(), date.to_owned());
+            }
+        }
+    }
+
+    fields
+}
+
+/// Maps the "Status" field value to a [`Status`] enum variant.
+fn parse_status_field(fields: &std::collections::HashMap<String, String>) -> Status {
+    match fields.get("Status").map(String::as_str) {
+        Some("In Progress") => Status::InProgress,
+        Some("Blocked") => Status::Blocked,
+        Some("Deferred") => Status::Deferred,
+        Some("Done" | "Closed") => Status::Closed,
+        _ => Status::Open,
+    }
+}
+
+/// Maps the "Priority" field value to a [`Priority`] enum variant.
+fn parse_priority_field(fields: &std::collections::HashMap<String, String>) -> Priority {
+    match fields.get("Priority").map(String::as_str) {
+        Some("P0") => Priority::P0,
+        Some("P1") => Priority::P1,
+        Some("P3") => Priority::P3,
+        Some("P4") => Priority::P4,
+        // Default to medium (P2) when missing or unrecognized.
+        _ => Priority::P2,
+    }
+}
+
+/// Maps the `IssueType` field value to an [`IssueType`] enum variant.
+fn parse_issue_type_field(fields: &std::collections::HashMap<String, String>) -> Option<IssueType> {
+    match fields.get("IssueType").map(String::as_str) {
+        Some("Task") => Some(IssueType::Task),
+        Some("Bug") => Some(IssueType::Bug),
+        Some("Feature") => Some(IssueType::Feature),
+        Some("Epic") => Some(IssueType::Epic),
+        Some("Chore") => Some(IssueType::Chore),
+        Some("Spike") => Some(IssueType::Spike),
+        _ => None,
+    }
+}
+
+/// Maps the `ReadyState` field value to a [`ReadyState`] enum variant.
+fn parse_ready_state_field(fields: &std::collections::HashMap<String, String>) -> ReadyState {
+    match fields.get("ReadyState").map(String::as_str) {
+        Some("Ready") => ReadyState::Ready,
+        Some("Blocked") => ReadyState::Blocked,
+        Some("Closed") => ReadyState::Closed,
+        // Default to NotReady when missing, "Not Ready", or unrecognized.
+        _ => ReadyState::NotReady,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_issue_state ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_state_open() {
+        let v = serde_json::json!({"state": "OPEN"});
+        assert_eq!(parse_issue_state(&v), IssueState::Open);
+    }
+
+    #[test]
+    fn parse_state_closed() {
+        let v = serde_json::json!({"state": "CLOSED"});
+        assert_eq!(parse_issue_state(&v), IssueState::Closed);
+    }
+
+    #[test]
+    fn parse_state_missing_defaults_open() {
+        let v = serde_json::json!({});
+        assert_eq!(parse_issue_state(&v), IssueState::Open);
+    }
+
+    // ── parse_string_nodes ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_labels_from_nodes() {
+        let v = serde_json::json!({
+            "labels": {
+                "nodes": [
+                    {"name": "bug"},
+                    {"name": "urgent"}
+                ]
+            }
+        });
+        assert_eq!(
+            parse_string_nodes(&v, "labels", "name"),
+            vec!["bug", "urgent"]
+        );
+    }
+
+    #[test]
+    fn parse_empty_nodes_returns_empty() {
+        let v = serde_json::json!({"labels": {"nodes": []}});
+        assert!(parse_string_nodes(&v, "labels", "name").is_empty());
+    }
+
+    #[test]
+    fn parse_missing_connection_returns_empty() {
+        let v = serde_json::json!({});
+        assert!(parse_string_nodes(&v, "labels", "name").is_empty());
+    }
+
+    // ── parse_comments ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_comments_with_data() {
+        let v = serde_json::json!({
+            "comments": {
+                "nodes": [
+                    {
+                        "author": {"login": "alice"},
+                        "body": "Hello",
+                        "createdAt": "2026-01-15T10:00:00Z"
+                    },
+                    {
+                        "author": {"login": "bob"},
+                        "body": "World",
+                        "createdAt": "2026-01-15T11:00:00Z"
+                    }
+                ]
+            }
+        });
+        let comments = parse_comments(&v);
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(comments[0].body, "Hello");
+        assert_eq!(comments[1].author, "bob");
+    }
+
+    #[test]
+    fn parse_comments_null_author_becomes_ghost() {
+        let v = serde_json::json!({
+            "comments": {
+                "nodes": [{
+                    "author": null,
+                    "body": "Deleted user comment",
+                    "createdAt": "2026-01-15T10:00:00Z"
+                }]
+            }
+        });
+        let comments = parse_comments(&v);
+        assert_eq!(comments[0].author, "ghost");
+    }
+
+    #[test]
+    fn parse_comments_empty() {
+        let v = serde_json::json!({"comments": {"nodes": []}});
+        assert!(parse_comments(&v).is_empty());
+    }
+
+    // ── parse_related_issues ────────────────────────────────────────────
+
+    #[test]
+    fn parse_blocked_by_issues() {
+        let v = serde_json::json!({
+            "trackedInIssues": {
+                "nodes": [
+                    {"number": 5, "title": "Blocker", "state": "OPEN"},
+                    {"number": 10, "title": "Other blocker", "state": "CLOSED"}
+                ]
+            }
+        });
+        let related = parse_related_issues(&v, "trackedInIssues");
+        assert_eq!(related.len(), 2);
+        assert_eq!(related[0].number, 5);
+        assert_eq!(related[0].state, IssueState::Open);
+        assert_eq!(related[1].number, 10);
+        assert_eq!(related[1].state, IssueState::Closed);
+    }
+
+    // ── parse_parent_issue ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_parent_present() {
+        let v = serde_json::json!({
+            "parent": {"number": 1, "title": "Epic", "state": "OPEN"}
+        });
+        let parent = parse_parent_issue(&v).expect("should parse parent");
+        assert_eq!(parent.number, 1);
+        assert_eq!(parent.title, "Epic");
+    }
+
+    #[test]
+    fn parse_parent_null() {
+        let v = serde_json::json!({"parent": null});
+        assert!(parse_parent_issue(&v).is_none());
+    }
+
+    #[test]
+    fn parse_parent_missing() {
+        let v = serde_json::json!({});
+        assert!(parse_parent_issue(&v).is_none());
+    }
+
+    // ── extract_field_values ────────────────────────────────────────────
+
+    #[test]
+    fn extract_single_select_field() {
+        let v = serde_json::json!({
+            "projectItems": {
+                "nodes": [{
+                    "fieldValues": {
+                        "nodes": [{
+                            "field": {"name": "Status"},
+                            "name": "In Progress"
+                        }]
+                    }
+                }]
+            }
+        });
+        let fields = extract_field_values(&v);
+        assert_eq!(
+            fields.get("Status").map(String::as_str),
+            Some("In Progress")
+        );
+    }
+
+    #[test]
+    fn extract_text_field() {
+        let v = serde_json::json!({
+            "projectItems": {
+                "nodes": [{
+                    "fieldValues": {
+                        "nodes": [{
+                            "field": {"name": "Agent"},
+                            "text": "claude-bot"
+                        }]
+                    }
+                }]
+            }
+        });
+        let fields = extract_field_values(&v);
+        assert_eq!(fields.get("Agent").map(String::as_str), Some("claude-bot"));
+    }
+
+    #[test]
+    fn extract_number_field() {
+        let v = serde_json::json!({
+            "projectItems": {
+                "nodes": [{
+                    "fieldValues": {
+                        "nodes": [{
+                            "field": {"name": "StoryPoints"},
+                            "number": 5.0
+                        }]
+                    }
+                }]
+            }
+        });
+        let fields = extract_field_values(&v);
+        assert_eq!(fields.get("StoryPoints").map(String::as_str), Some("5"));
+    }
+
+    #[test]
+    fn extract_date_field() {
+        let v = serde_json::json!({
+            "projectItems": {
+                "nodes": [{
+                    "fieldValues": {
+                        "nodes": [{
+                            "field": {"name": "DeferUntil"},
+                            "date": "2026-04-01"
+                        }]
+                    }
+                }]
+            }
+        });
+        let fields = extract_field_values(&v);
+        assert_eq!(
+            fields.get("DeferUntil").map(String::as_str),
+            Some("2026-04-01")
+        );
+    }
+
+    #[test]
+    fn extract_no_project_items_returns_empty() {
+        let v = serde_json::json!({});
+        assert!(extract_field_values(&v).is_empty());
+    }
+
+    // ── parse_status_field ──────────────────────────────────────────────
+
+    #[test]
+    fn status_field_mapping() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("Status".to_owned(), "In Progress".to_owned());
+        assert_eq!(parse_status_field(&fields), Status::InProgress);
+
+        fields.insert("Status".to_owned(), "Blocked".to_owned());
+        assert_eq!(parse_status_field(&fields), Status::Blocked);
+
+        fields.insert("Status".to_owned(), "Deferred".to_owned());
+        assert_eq!(parse_status_field(&fields), Status::Deferred);
+
+        fields.insert("Status".to_owned(), "Done".to_owned());
+        assert_eq!(parse_status_field(&fields), Status::Closed);
+
+        fields.insert("Status".to_owned(), "Closed".to_owned());
+        assert_eq!(parse_status_field(&fields), Status::Closed);
+    }
+
+    #[test]
+    fn status_field_missing_defaults_open() {
+        let fields = std::collections::HashMap::new();
+        assert_eq!(parse_status_field(&fields), Status::Open);
+    }
+
+    // ── parse_priority_field ────────────────────────────────────────────
+
+    #[test]
+    fn priority_field_mapping() {
+        let mut fields = std::collections::HashMap::new();
+        for (label, expected) in [
+            ("P0", Priority::P0),
+            ("P1", Priority::P1),
+            ("P2", Priority::P2),
+            ("P3", Priority::P3),
+            ("P4", Priority::P4),
+        ] {
+            fields.insert("Priority".to_owned(), label.to_owned());
+            assert_eq!(parse_priority_field(&fields), expected);
+        }
+    }
+
+    #[test]
+    fn priority_field_missing_defaults_p2() {
+        let fields = std::collections::HashMap::new();
+        assert_eq!(parse_priority_field(&fields), Priority::P2);
+    }
+
+    // ── parse_issue_type_field ──────────────────────────────────────────
+
+    #[test]
+    fn issue_type_field_mapping() {
+        let mut fields = std::collections::HashMap::new();
+        for (label, expected) in [
+            ("Task", IssueType::Task),
+            ("Bug", IssueType::Bug),
+            ("Feature", IssueType::Feature),
+            ("Epic", IssueType::Epic),
+            ("Chore", IssueType::Chore),
+            ("Spike", IssueType::Spike),
+        ] {
+            fields.insert("IssueType".to_owned(), label.to_owned());
+            assert_eq!(parse_issue_type_field(&fields), Some(expected));
+        }
+    }
+
+    #[test]
+    fn issue_type_field_missing_returns_none() {
+        let fields = std::collections::HashMap::new();
+        assert!(parse_issue_type_field(&fields).is_none());
+    }
+
+    // ── parse_ready_state_field ─────────────────────────────────────────
+
+    #[test]
+    fn ready_state_field_mapping() {
+        let mut fields = std::collections::HashMap::new();
+        for (label, expected) in [
+            ("Ready", ReadyState::Ready),
+            ("Blocked", ReadyState::Blocked),
+            ("Closed", ReadyState::Closed),
+            ("Not Ready", ReadyState::NotReady),
+        ] {
+            fields.insert("ReadyState".to_owned(), label.to_owned());
+            assert_eq!(parse_ready_state_field(&fields), expected);
+        }
+    }
+
+    #[test]
+    fn ready_state_field_missing_defaults_not_ready() {
+        let fields = std::collections::HashMap::new();
+        assert_eq!(parse_ready_state_field(&fields), ReadyState::NotReady);
+    }
+
+    // ── parse_issue (full roundtrip) ────────────────────────────────────
+
+    #[test]
+    fn parse_full_issue_from_json() {
+        let json = serde_json::json!({
+            "id": "MDU6SXNzdWUx",
+            "number": 42,
+            "title": "Fix the bug",
+            "body": "## Description\n\nSome bug.",
+            "state": "OPEN",
+            "url": "https://github.com/owner/repo/issues/42",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+            "labels": {"nodes": [{"name": "bug"}, {"name": "P0"}]},
+            "milestone": {"title": "v1.0"},
+            "assignees": {"nodes": [{"login": "alice"}]},
+            "comments": {
+                "nodes": [{
+                    "author": {"login": "bob"},
+                    "body": "Working on it",
+                    "createdAt": "2026-01-01T12:00:00Z"
+                }]
+            },
+            "trackedInIssues": {
+                "nodes": [
+                    {"number": 10, "title": "Dep A", "state": "OPEN"}
+                ]
+            },
+            "trackedBy": {
+                "nodes": [
+                    {"number": 20, "title": "Blocked by me", "state": "OPEN"}
+                ]
+            },
+            "parent": {"number": 1, "title": "Epic", "state": "OPEN"},
+            "subIssues": {"nodes": []},
+            "projectItems": {
+                "nodes": [{
+                    "fieldValues": {
+                        "nodes": [
+                            {"field": {"name": "Status"}, "name": "In Progress"},
+                            {"field": {"name": "Priority"}, "name": "P1"},
+                            {"field": {"name": "Agent"}, "text": "claude"},
+                            {"field": {"name": "StoryPoints"}, "number": 3.0}
+                        ]
+                    }
+                }]
+            }
+        });
+
+        let issue = parse_issue(&json);
+        assert_eq!(issue.number, 42);
+        assert_eq!(issue.node_id, "MDU6SXNzdWUx");
+        assert_eq!(issue.title, "Fix the bug");
+        assert_eq!(issue.body.as_deref(), Some("## Description\n\nSome bug."));
+        assert_eq!(issue.state, IssueState::Open);
+        assert_eq!(issue.url, "https://github.com/owner/repo/issues/42");
+        assert_eq!(issue.labels, vec!["bug", "P0"]);
+        assert_eq!(issue.milestone.as_deref(), Some("v1.0"));
+        assert_eq!(issue.assignees, vec!["alice"]);
+        assert_eq!(issue.status, Status::InProgress);
+        assert_eq!(issue.priority, Priority::P1);
+        assert_eq!(issue.agent.as_deref(), Some("claude"));
+        assert_eq!(issue.story_points, Some(3));
+
+        assert_eq!(issue.comments.len(), 1);
+        assert_eq!(issue.comments[0].author, "bob");
+        assert_eq!(issue.comments[0].body, "Working on it");
+
+        assert_eq!(issue.blocked_by.len(), 1);
+        assert_eq!(issue.blocked_by[0].number, 10);
+
+        assert_eq!(issue.blocking.len(), 1);
+        assert_eq!(issue.blocking[0].number, 20);
+
+        let parent = issue.parent.expect("should have parent");
+        assert_eq!(parent.number, 1);
+
+        assert!(issue.sub_issues.is_empty());
+    }
+
+    #[test]
+    fn parse_minimal_issue() {
+        let json = serde_json::json!({
+            "id": "node123",
+            "number": 1,
+            "title": "Minimal",
+            "body": null,
+            "state": "OPEN",
+            "url": "",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "labels": {"nodes": []},
+            "milestone": null,
+            "assignees": {"nodes": []},
+            "comments": {"nodes": []},
+            "trackedInIssues": {"nodes": []},
+            "trackedBy": {"nodes": []},
+            "parent": null,
+            "subIssues": {"nodes": []}
+        });
+
+        let issue = parse_issue(&json);
+        assert_eq!(issue.number, 1);
+        assert!(issue.body.is_none());
+        assert!(issue.comments.is_empty());
+        assert!(issue.blocked_by.is_empty());
+        assert!(issue.blocking.is_empty());
+        assert!(issue.parent.is_none());
+        assert!(issue.sub_issues.is_empty());
+        assert_eq!(issue.status, Status::Open);
+        assert_eq!(issue.priority, Priority::P2);
+    }
+}

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -260,8 +260,8 @@ fn parse_issue(value: &serde_json::Value) -> Issue {
     let assignees = parse_string_nodes(value, "assignees", "login");
 
     let comments = parse_comments(value);
-    let blocked_by = parse_related_issues(value, "trackedInIssues");
-    let blocking = parse_related_issues(value, "trackedBy");
+    let blocked_by = parse_related_issues(value, "trackedBy");
+    let blocking = parse_related_issues(value, "trackedInIssues");
     let parent = parse_parent_issue(value);
     let sub_issues = parse_related_issues(value, "subIssues");
 
@@ -882,12 +882,12 @@ mod tests {
             },
             "trackedInIssues": {
                 "nodes": [
-                    {"number": 10, "title": "Dep A", "state": "OPEN"}
+                    {"number": 20, "title": "Blocks me", "state": "OPEN"}
                 ]
             },
             "trackedBy": {
                 "nodes": [
-                    {"number": 20, "title": "Blocked by me", "state": "OPEN"}
+                    {"number": 10, "title": "Dep A", "state": "OPEN"}
                 ]
             },
             "parent": {"number": 1, "title": "Epic", "state": "OPEN"},

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -5,6 +5,7 @@
 //! set.
 
 use unblock_core::config::Config;
+use unblock_core::types::IssueState;
 use unblock_github::client::GitHubClient;
 
 /// Returns `true` if the `GITHUB_TOKEN` env var is set and non-empty.
@@ -62,5 +63,64 @@ async fn github_client_new_connects_to_real_repo() {
     assert!(
         graphql_url.ends_with("/graphql"),
         "graphql_url should end with /graphql, got: {graphql_url}"
+    );
+}
+
+// ── fetch_issue ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn fetch_issue_returns_full_details_for_existing_issue() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    // Issue #1 should exist in most repos. If the test repo has no issues,
+    // this test will fail gracefully with IssueNotFound.
+    let issue = client
+        .fetch_issue(1)
+        .await
+        .expect("fetch_issue(1) should succeed for an existing issue");
+
+    assert_eq!(issue.number, 1, "issue number should be 1");
+    assert!(!issue.title.is_empty(), "title should be non-empty");
+    assert!(!issue.node_id.is_empty(), "node_id should be non-empty");
+    assert!(!issue.url.is_empty(), "url should be non-empty");
+    assert!(
+        issue.state == IssueState::Open || issue.state == IssueState::Closed,
+        "state should be Open or Closed"
+    );
+}
+
+#[tokio::test]
+async fn fetch_issue_returns_issue_not_found_for_nonexistent_number() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    // Use a very large issue number that almost certainly does not exist.
+    let result = client.fetch_issue(999_999_999).await;
+    assert!(
+        result.is_err(),
+        "fetch_issue for non-existent issue should return an error"
+    );
+
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found") || msg.contains("Not Found") || err.status_code() == 404,
+        "error should indicate issue not found, got: {msg} (status: {})",
+        err.status_code()
     );
 }


### PR DESCRIPTION
Add IssueComment type (author, body, created_at) to unblock-core types.
Add comments: Vec<IssueComment> field to Issue struct, defaulting to
empty vec in all existing construction sites (graph.rs, cache.rs tests,
doc examples). This prepares for fetch_issue() which populates comments.