### PR TITLE
docs: update TraversalDirection doc to mention bidirectional traversal

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -245,7 +245,8 @@ pub struct IssueSummary {
 ///
 /// Controls which edges are followed during BFS traversal of the
 /// dependency graph. Used by [`DependencyGraph::dependency_tree()`]
-/// to walk either upstream (blockers) or downstream (blocked issues).
+/// to walk upstream (blockers), downstream (blocked issues), or both
+/// directions simultaneously.
 ///
 /// [`DependencyGraph::dependency_tree()`]: crate::graph::DependencyGraph::dependency_tree
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
The module-level doc comment only mentioned upstream and downstream traversal but omitted the Both variant added in unblock-b6b.21.