### PR TITLE
chore: re-export std::sync::Arc from unblock-core public API

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,0 +1,2 @@
+{"id":"int-e0f624c2","kind":"field_change","created_at":"2026-03-25T15:06:23.473344Z","actor":"Miguel Ramos","issue_id":"unblock-b6b.29","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-6e0f47de","kind":"field_change","created_at":"2026-03-25T15:08:06.374413Z","actor":"Miguel Ramos","issue_id":"unblock-b6b.29","extra":{"field":"status","new_value":"in-review","old_value":"in_progress"}}

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,2 +1,0 @@
-{"id":"int-e0f624c2","kind":"field_change","created_at":"2026-03-25T15:06:23.473344Z","actor":"Miguel Ramos","issue_id":"unblock-b6b.29","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
-{"id":"int-6e0f47de","kind":"field_change","created_at":"2026-03-25T15:08:06.374413Z","actor":"Miguel Ramos","issue_id":"unblock-b6b.29","extra":{"field":"status","new_value":"in-review","old_value":"in_progress"}}

--- a/crates/unblock-core/src/lib.rs
+++ b/crates/unblock-core/src/lib.rs
@@ -9,6 +9,21 @@
 //! - **Cache** — in-memory graph cache with TTL and invalidation
 //! - **Config** — environment-based configuration
 //! - **Errors** — domain error types with snafu
+//!
+//! # Re-exports
+//!
+//! [`Arc`] is re-exported for convenience because [`cache::GraphCache`] accessor
+//! methods (`get_ready_set`, `get_graph`) return `Arc`-wrapped values. Callers
+//! can import it directly from this crate instead of pulling in `std::sync::Arc`
+//! separately.
+
+/// [`std::sync::Arc`] re-exported for convenience.
+///
+/// Cache accessor methods such as [`cache::GraphCache::get_ready_set`] and
+/// [`cache::GraphCache::get_graph`] return `Arc`-wrapped values. This re-export
+/// allows downstream crates to use `unblock_core::Arc` without an additional
+/// `std::sync` import.
+pub use std::sync::Arc;
 
 /// Domain types: `Issue`, `IssueComment`, `RelatedIssue`, `Status`, `Priority`, `ReadyState`, `BlockingEdge`, `BodySections`.
 pub mod types;


### PR DESCRIPTION
Cache accessor methods (get_ready_set, get_graph) return Arc-wrapped values. Re-exporting Arc from the crate root lets downstream consumers import it as unblock_core::Arc instead of adding a separate std::sync::Arc import.