### PR TITLE
chore: align GitHubGraphQL error variant to Vec<String>

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -41,10 +41,10 @@ pub enum Error {
     },
 
     /// One or more errors in a GitHub GraphQL response.
-    #[snafu(display("GitHub GraphQL error: {errors}"))]
+    #[snafu(display("GitHub GraphQL error: {}", errors.join("; ")))]
     GitHubGraphQL {
-        /// Concatenated error messages from the GraphQL response.
-        errors: String,
+        /// Individual error messages from the GraphQL response.
+        errors: Vec<String>,
     },
 
     /// Network or connection failure when reaching GitHub.
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn github_graphql_display() {
         let err = GitHubGraphQLSnafu {
-            errors: "Field 'x' not found".to_owned(),
+            errors: vec!["Field 'x' not found".to_owned()],
         }
         .build();
         assert_eq!(err.to_string(), "GitHub GraphQL error: Field 'x' not found");
@@ -210,7 +210,7 @@ mod tests {
             }
             .build(),
             GitHubGraphQLSnafu {
-                errors: "err".to_owned(),
+                errors: vec!["err".to_owned()],
             }
             .build(),
             RateLimitedSnafu {
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn status_code_github_graphql() {
         let err = GitHubGraphQLSnafu {
-            errors: "bad field".to_owned(),
+            errors: vec!["bad field".to_owned()],
         }
         .build();
         assert_eq!(err.status_code(), 422);

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -213,10 +213,7 @@ impl GitHubClient {
                 .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
                 .map(String::from)
                 .collect();
-            return Err(errors::GitHubGraphQLSnafu {
-                errors: messages.join("; "),
-            }
-            .build());
+            return Err(errors::GitHubGraphQLSnafu { errors: messages }.build());
         }
 
         Ok(json)

--- a/docs/unblock-architecture-github.md
+++ b/docs/unblock-architecture-github.md
@@ -1375,8 +1375,8 @@ pub enum Error {
     #[snafu(display("GitHub API error: {message}"))]
     GitHubApi { message: String },
 
-    #[snafu(display("GitHub GraphQL error: {errors}"))]
-    GitHubGraphQL { errors: String },
+    #[snafu(display("GitHub GraphQL error: {}", errors.join("; ")))]
+    GitHubGraphQL { errors: Vec<String> },
 
     #[snafu(display("Cannot connect to GitHub: {source}"))]
     GitHubUnavailable { source: reqwest::Error },


### PR DESCRIPTION
The task spec (unblock-467.7) defines GitHubGraphQL { errors: Vec<String> } but the implementation used a plain String. Change the field type to Vec<String>, update the snafu display to join with "; ", remove the pre-join in graphql.rs, fix all test call sites, and update the architecture doc for consistency.