### PR TITLE
fix: make parse_github_url configurable for GitHub Enterprise hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ QA:             spec conformity, test/build/lint, verdict
 |---|---|---|---|
 | `GITHUB_TOKEN` | yes | — | pat or github app token |
 | `GITHUB_API_URL` | no | `https://api.github.com` | ghe: `https://<host>/api/v3` |
+| `GITHUB_URL` | no | `https://github.com` | ghe: `https://<ghe-host>` (web url, not api) |
 | `UNBLOCK_REPO` | no | auto-detect | `owner/repo` format |
 | `UNBLOCK_PROJECT` | no | auto-detect | project number |
 | `UNBLOCK_AGENT` | no | `agent` | default agent name |

--- a/crates/unblock-core/src/config.rs
+++ b/crates/unblock-core/src/config.rs
@@ -3,6 +3,7 @@
 //! Reads configuration from environment variables:
 //! - `GITHUB_TOKEN` (required)
 //! - `GITHUB_API_URL` (optional, default: `https://api.github.com`)
+//! - `GITHUB_URL` (optional, default: `https://github.com`)
 //! - `UNBLOCK_REPO` (optional, auto-detect from git remote)
 //! - `UNBLOCK_PROJECT` (optional, auto-detect from linked Projects V2)
 //! - `UNBLOCK_AGENT` (optional, default: `agent`)
@@ -31,6 +32,7 @@ use crate::errors::ValidationSnafu;
 /// | Env var | Field | Default |
 /// |---------|-------|---------|
 /// | `GITHUB_API_URL` | [`api_base_url`](Self::api_base_url) | `https://api.github.com` |
+/// | `GITHUB_URL` | [`github_url`](Self::github_url) | `https://github.com` |
 /// | `UNBLOCK_REPO` | [`repo`](Self::repo) | `None` (auto-detect) |
 /// | `UNBLOCK_PROJECT` | [`project_number`](Self::project_number) | `None` (auto-detect) |
 /// | `UNBLOCK_AGENT` | [`agent`](Self::agent) | `"agent"` |
@@ -47,6 +49,14 @@ pub struct Config {
     /// Defaults to `https://api.github.com`. For GitHub Enterprise Server,
     /// set to `https://<host>/api/v3`. Trailing slashes are stripped.
     pub api_base_url: String,
+
+    /// GitHub web URL (from `GITHUB_URL`).
+    ///
+    /// Defaults to `https://github.com`. For GitHub Enterprise Server,
+    /// set to `https://<ghe-host>`. Used by the git remote parser to match
+    /// remote origin URLs. This is the **web** URL, not the API URL.
+    /// Trailing slashes are stripped.
+    pub github_url: String,
 
     /// Repository in `owner/repo` format (from `UNBLOCK_REPO`).
     ///
@@ -90,6 +100,9 @@ const DEFAULT_AGENT: &str = "agent";
 
 /// Default GitHub API base URL.
 const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
+
+/// Default GitHub web URL.
+const DEFAULT_GITHUB_URL: &str = "https://github.com";
 
 /// The set of valid tracing log-level strings.
 ///
@@ -185,6 +198,12 @@ impl Config {
             .trim_end_matches('/')
             .to_owned();
 
+        // GITHUB_URL with trailing-slash normalisation.
+        let github_url = env("GITHUB_URL")
+            .unwrap_or_else(|_| DEFAULT_GITHUB_URL.to_owned())
+            .trim_end_matches('/')
+            .to_owned();
+
         let repo = match env("UNBLOCK_REPO") {
             Ok(val) => {
                 validate_repo_format(&val)?;
@@ -224,6 +243,7 @@ impl Config {
         Ok(Self {
             token,
             api_base_url,
+            github_url,
             repo,
             project_number,
             agent,
@@ -271,6 +291,7 @@ mod tests {
 
         assert_eq!(config.token, "ghp_test123");
         assert_eq!(config.api_base_url, "https://api.github.com");
+        assert_eq!(config.github_url, "https://github.com");
         assert_eq!(config.repo, None);
         assert_eq!(config.project_number, None);
         assert_eq!(config.agent, "agent");
@@ -284,6 +305,7 @@ mod tests {
         let env = make_env(&[
             ("GITHUB_TOKEN", "ghp_override"),
             ("GITHUB_API_URL", "https://ghe.example.com/api/v3/"),
+            ("GITHUB_URL", "https://ghe.example.com/"),
             ("UNBLOCK_REPO", "acme/widgets"),
             ("UNBLOCK_PROJECT", "42"),
             ("UNBLOCK_AGENT", "my-bot"),
@@ -296,6 +318,7 @@ mod tests {
         assert_eq!(config.token, "ghp_override");
         // Trailing slash stripped:
         assert_eq!(config.api_base_url, "https://ghe.example.com/api/v3");
+        assert_eq!(config.github_url, "https://ghe.example.com");
         assert_eq!(config.repo.as_deref(), Some("acme/widgets"));
         assert_eq!(config.project_number, Some(42));
         assert_eq!(config.agent, "my-bot");
@@ -455,5 +478,34 @@ mod tests {
                 "log_level should be normalized to lowercase for '{level}'"
             );
         }
+    }
+
+    // ── GITHUB_URL tests ──────────────────────────────────────────────
+
+    #[test]
+    fn github_url_defaults_to_github_com() {
+        let env = make_env(&[("GITHUB_TOKEN", "ghp_test")]);
+        let config = Config::load_from(env).expect("should load");
+        assert_eq!(config.github_url, "https://github.com");
+    }
+
+    #[test]
+    fn github_url_override_applied() {
+        let env = make_env(&[
+            ("GITHUB_TOKEN", "ghp_test"),
+            ("GITHUB_URL", "https://ghe.corp.com"),
+        ]);
+        let config = Config::load_from(env).expect("should load");
+        assert_eq!(config.github_url, "https://ghe.corp.com");
+    }
+
+    #[test]
+    fn github_url_trailing_slashes_stripped() {
+        let env = make_env(&[
+            ("GITHUB_TOKEN", "ghp_test"),
+            ("GITHUB_URL", "https://ghe.corp.com///"),
+        ]);
+        let config = Config::load_from(env).expect("should load");
+        assert_eq!(config.github_url, "https://ghe.corp.com");
     }
 }

--- a/crates/unblock-github/src/client.rs
+++ b/crates/unblock-github/src/client.rs
@@ -205,7 +205,7 @@ impl GitHubClient {
             .build()
         })?;
 
-        parse_github_url(&url)
+        parse_github_url(&url, &config.github_url)
     }
 
     /// Resolves the project number from configuration.
@@ -220,28 +220,46 @@ impl GitHubClient {
 
 /// Parses a GitHub URL into `(owner, repo)`.
 ///
-/// Supported formats:
-/// - `https://github.com/owner/repo.git`
-/// - `https://github.com/owner/repo`
-/// - `git@github.com:owner/repo.git`
-/// - `git@github.com:owner/repo`
+/// The `github_url` parameter specifies the expected GitHub host as a web URL
+/// (e.g. `https://github.com` or `https://ghe.corp.com`). The hostname is
+/// extracted and used to match HTTPS and SSH remote URL formats.
+///
+/// Supported formats (where `<host>` is derived from `github_url`):
+/// - `https://<host>/owner/repo.git`
+/// - `https://<host>/owner/repo`
+/// - `http://<host>/owner/repo[.git]`
+/// - `git@<host>:owner/repo.git`
+/// - `git@<host>:owner/repo`
 ///
 /// # Errors
 ///
-/// Returns [`Error::GitRemote`] if the URL is not a recognized GitHub format.
-pub fn parse_github_url(url: &str) -> Result<(String, String), Error> {
+/// Returns [`Error::GitRemote`] if the URL is not a recognized GitHub format
+/// or if the `github_url` cannot be parsed to extract a hostname.
+pub fn parse_github_url(url: &str, github_url: &str) -> Result<(String, String), Error> {
     let url = url.trim();
 
-    // Try HTTPS format: https://github.com/owner/repo[.git]
+    // Extract the hostname from github_url.
+    // github_url is expected to be like "https://github.com" or "https://ghe.corp.com".
+    let host = extract_host(github_url).ok_or_else(|| {
+        GitRemoteSnafu {
+            message: format!("cannot extract hostname from GITHUB_URL: {github_url}"),
+        }
+        .build()
+    })?;
+
+    // Try HTTPS format: https://<host>/owner/repo[.git]
+    let secure_prefix = format!("https://{host}/");
+    let plain_prefix = format!("http://{host}/");
     if let Some(path) = url
-        .strip_prefix("https://github.com/")
-        .or_else(|| url.strip_prefix("http://github.com/"))
+        .strip_prefix(&secure_prefix)
+        .or_else(|| url.strip_prefix(&plain_prefix))
     {
         return parse_owner_repo_from_path(path, url);
     }
 
-    // Try SSH format: git@github.com:owner/repo[.git]
-    if let Some(path) = url.strip_prefix("git@github.com:") {
+    // Try SSH format: git@<host>:owner/repo[.git]
+    let ssh_prefix = format!("git@{host}:");
+    if let Some(path) = url.strip_prefix(&ssh_prefix) {
         return parse_owner_repo_from_path(path, url);
     }
 
@@ -249,6 +267,26 @@ pub fn parse_github_url(url: &str) -> Result<(String, String), Error> {
         message: format!("not a GitHub URL: {url}"),
     }
     .build())
+}
+
+/// Extracts the hostname from a URL string.
+///
+/// Handles URLs with or without a scheme. For example:
+/// - `https://github.com` -> `github.com`
+/// - `https://ghe.corp.com/` -> `ghe.corp.com`
+/// - `https://ghe.corp.com:8443` -> `ghe.corp.com:8443`
+fn extract_host(url: &str) -> Option<String> {
+    // Strip the scheme (e.g. "https://").
+    let after_scheme = url.find("://").map_or(url, |i| &url[i + 3..]);
+
+    // Take everything up to the first '/' (the host, possibly with port).
+    let host = after_scheme.split('/').next()?;
+
+    if host.is_empty() {
+        return None;
+    }
+
+    Some(host.to_owned())
 }
 
 /// Extracts `(owner, repo)` from a `owner/repo[.git]` path segment.
@@ -318,44 +356,51 @@ mod tests {
 
     // ── parse_github_url ─────────────────────────────────────────────
 
+    const DEFAULT_GH_URL: &str = "https://github.com";
+
     #[test]
     fn parse_https_with_git_suffix() {
-        let (owner, repo) = parse_github_url("https://github.com/websublime/unblock.git").unwrap();
+        let (owner, repo) =
+            parse_github_url("https://github.com/websublime/unblock.git", DEFAULT_GH_URL).unwrap();
         assert_eq!(owner, "websublime");
         assert_eq!(repo, "unblock");
     }
 
     #[test]
     fn parse_https_without_git_suffix() {
-        let (owner, repo) = parse_github_url("https://github.com/websublime/unblock").unwrap();
+        let (owner, repo) =
+            parse_github_url("https://github.com/websublime/unblock", DEFAULT_GH_URL).unwrap();
         assert_eq!(owner, "websublime");
         assert_eq!(repo, "unblock");
     }
 
     #[test]
     fn parse_ssh_with_git_suffix() {
-        let (owner, repo) = parse_github_url("git@github.com:websublime/unblock.git").unwrap();
+        let (owner, repo) =
+            parse_github_url("git@github.com:websublime/unblock.git", DEFAULT_GH_URL).unwrap();
         assert_eq!(owner, "websublime");
         assert_eq!(repo, "unblock");
     }
 
     #[test]
     fn parse_ssh_without_git_suffix() {
-        let (owner, repo) = parse_github_url("git@github.com:websublime/unblock").unwrap();
+        let (owner, repo) =
+            parse_github_url("git@github.com:websublime/unblock", DEFAULT_GH_URL).unwrap();
         assert_eq!(owner, "websublime");
         assert_eq!(repo, "unblock");
     }
 
     #[test]
     fn parse_https_with_trailing_slash() {
-        let (owner, repo) = parse_github_url("https://github.com/acme/widgets/").unwrap();
+        let (owner, repo) =
+            parse_github_url("https://github.com/acme/widgets/", DEFAULT_GH_URL).unwrap();
         assert_eq!(owner, "acme");
         assert_eq!(repo, "widgets");
     }
 
     #[test]
     fn parse_non_github_url_returns_error() {
-        let err = parse_github_url("https://gitlab.com/owner/repo").unwrap_err();
+        let err = parse_github_url("https://gitlab.com/owner/repo", DEFAULT_GH_URL).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("not a GitHub URL"),
@@ -365,17 +410,116 @@ mod tests {
 
     #[test]
     fn parse_empty_string_returns_error() {
-        assert!(parse_github_url("").is_err());
+        assert!(parse_github_url("", DEFAULT_GH_URL).is_err());
     }
 
     #[test]
     fn parse_garbage_returns_error() {
-        assert!(parse_github_url("not-a-url").is_err());
+        assert!(parse_github_url("not-a-url", DEFAULT_GH_URL).is_err());
     }
 
     #[test]
     fn parse_github_url_with_extra_segments_returns_error() {
-        assert!(parse_github_url("https://github.com/owner/repo/pulls").is_err());
+        assert!(parse_github_url("https://github.com/owner/repo/pulls", DEFAULT_GH_URL).is_err());
+    }
+
+    // ── parse_github_url with GHE host ────────────────────────────────
+
+    #[test]
+    fn parse_ghe_https_with_git_suffix() {
+        let (owner, repo) = parse_github_url(
+            "https://ghe.corp.com/acme/widgets.git",
+            "https://ghe.corp.com",
+        )
+        .unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "widgets");
+    }
+
+    #[test]
+    fn parse_ghe_https_without_git_suffix() {
+        let (owner, repo) =
+            parse_github_url("https://ghe.corp.com/acme/widgets", "https://ghe.corp.com").unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "widgets");
+    }
+
+    #[test]
+    fn parse_ghe_ssh() {
+        let (owner, repo) =
+            parse_github_url("git@ghe.corp.com:acme/widgets.git", "https://ghe.corp.com").unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "widgets");
+    }
+
+    #[test]
+    fn parse_ghe_http() {
+        let (owner, repo) =
+            parse_github_url("http://ghe.corp.com/acme/widgets", "https://ghe.corp.com").unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "widgets");
+    }
+
+    #[test]
+    fn parse_ghe_url_mismatch_returns_error() {
+        // Remote points to github.com but GITHUB_URL is set to a GHE host.
+        let err = parse_github_url("https://github.com/acme/widgets", "https://ghe.corp.com")
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not a GitHub URL"),
+            "expected 'not a GitHub URL' in: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_ghe_with_port() {
+        let (owner, repo) = parse_github_url(
+            "https://ghe.corp.com:8443/acme/widgets",
+            "https://ghe.corp.com:8443",
+        )
+        .unwrap();
+        assert_eq!(owner, "acme");
+        assert_eq!(repo, "widgets");
+    }
+
+    // ── extract_host ──────────────────────────────────────────────────
+
+    #[test]
+    fn extract_host_from_https_url() {
+        assert_eq!(
+            extract_host("https://github.com").as_deref(),
+            Some("github.com")
+        );
+    }
+
+    #[test]
+    fn extract_host_from_ghe_url() {
+        assert_eq!(
+            extract_host("https://ghe.corp.com").as_deref(),
+            Some("ghe.corp.com")
+        );
+    }
+
+    #[test]
+    fn extract_host_with_trailing_slash() {
+        assert_eq!(
+            extract_host("https://ghe.corp.com/").as_deref(),
+            Some("ghe.corp.com")
+        );
+    }
+
+    #[test]
+    fn extract_host_with_port() {
+        assert_eq!(
+            extract_host("https://ghe.corp.com:8443").as_deref(),
+            Some("ghe.corp.com:8443")
+        );
+    }
+
+    #[test]
+    fn extract_host_empty_returns_none() {
+        assert_eq!(extract_host("https://"), None);
     }
 
     // ── parse_remote_origin_url ──────────────────────────────────────
@@ -435,6 +579,7 @@ mod tests {
         let config = Config {
             token: "ghp_test".to_owned(),
             api_base_url: "https://api.github.com".to_owned(),
+            github_url: "https://github.com".to_owned(),
             repo: Some("acme/widgets".to_owned()),
             project_number: None,
             agent: "agent".to_owned(),
@@ -454,6 +599,7 @@ mod tests {
         let config = Config {
             token: "ghp_test".to_owned(),
             api_base_url: "https://api.github.com".to_owned(),
+            github_url: "https://github.com".to_owned(),
             repo: None,
             project_number: Some(42),
             agent: "agent".to_owned(),
@@ -469,6 +615,7 @@ mod tests {
         let config = Config {
             token: "ghp_test".to_owned(),
             api_base_url: "https://api.github.com".to_owned(),
+            github_url: "https://github.com".to_owned(),
             repo: None,
             project_number: None,
             agent: "agent".to_owned(),

--- a/docs/unblock-architecture-github.md
+++ b/docs/unblock-architecture-github.md
@@ -1243,6 +1243,7 @@ Backend: GitHub Issues + Projects V2
 pub struct Config {
     pub token: String,              // GITHUB_TOKEN (required)
     pub api_base_url: String,       // GITHUB_API_URL (default: "https://api.github.com")
+    pub github_url: String,         // GITHUB_URL (default: "https://github.com")
     pub repo: Option<String>,       // UNBLOCK_REPO (auto-detect from git remote)
     pub project_number: Option<u64>,// UNBLOCK_PROJECT (auto-detect from linked projects)
     pub agent: String,              // UNBLOCK_AGENT (default: "agent")

--- a/docs/unblock-prd-github.md
+++ b/docs/unblock-prd-github.md
@@ -718,6 +718,7 @@ The agent doesn't wait for the full rebuild — it gets results in milliseconds 
 |---|---|---|---|
 | `GITHUB_TOKEN` | Yes | — | PAT or GitHub App token |
 | `GITHUB_API_URL` | No | `https://api.github.com` | API base URL. GHE Server: `https://<host>/api/v3` |
+| `GITHUB_URL` | No | `https://github.com` | Web URL for git remote matching. GHE: `https://<ghe-host>` (not the API URL) |
 | `UNBLOCK_REPO` | No | Auto-detect from git remote | `owner/repo` format |
 | `UNBLOCK_PROJECT` | No | Auto-detect first linked project | Project number |
 | `UNBLOCK_AGENT` | No | `agent` | Default agent name |


### PR DESCRIPTION
parse_github_url() was hardcoded to github.com, breaking git remote auto-detection for GHE users. Add GITHUB_URL env var (default https://github.com) and pass it to parse_github_url() which now dynamically builds HTTPS/SSH prefixes from the configured host.