### PR TITLE
chore: surface JoinError in concurrent benchmark task handle

### DIFF
--- a/crates/unblock-core/benches/cache_bench.rs
+++ b/crates/unblock-core/benches/cache_bench.rs
@@ -166,7 +166,7 @@ fn bench_concurrent_readers(c: &mut Criterion) {
                     handles.push(tokio::spawn(async move { c.get_ready_set().await }));
                 }
                 for handle in handles {
-                    let _ = handle.await;
+                    handle.await.expect("benchmark task panicked");
                 }
             });
         });


### PR DESCRIPTION
Replace `let _ = handle.await` with `.expect("benchmark task panicked")` so that task panics in the concurrent readers benchmark are surfaced immediately instead of being silently discarded.