### PR TITLE
feat: implement REST mutations — create_issue, close_issue, add_comment

### DIFF
--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -390,7 +390,7 @@ impl GitHubClient {
 /// Parses the `X-RateLimit-Reset` header from a response into a `DateTime<Utc>`.
 ///
 /// Falls back to `Utc::now()` if the header is missing or unparseable.
-fn parse_rate_limit_reset(response: &reqwest::Response) -> DateTime<Utc> {
+pub(crate) fn parse_rate_limit_reset(response: &reqwest::Response) -> DateTime<Utc> {
     response
         .headers()
         .get("x-ratelimit-reset")

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -2,8 +2,397 @@
 //!
 //! - `create_issue()` — REST POST
 //! - `close_issue()` — REST PATCH
-//! - `reopen_issue()` — REST PATCH
 //! - `add_comment()` — REST POST
-//! - `add_blocked_by()` — GraphQL mutation
-//! - `remove_blocked_by()` — GraphQL mutation
-//! - `add_sub_issue()` — GraphQL mutation
+//!
+//! All mutations use the GitHub REST API for simplicity. Error handling follows
+//! the same pattern as GraphQL: 429 → `RateLimited`, 404 → `IssueNotFound`,
+//! other non-2xx → `GitHubApi`.
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt as _;
+use tracing::{instrument, warn};
+use unblock_core::types::Issue;
+
+use crate::client::GitHubClient;
+use crate::errors::{self, Error};
+use crate::graphql::parse_rate_limit_reset;
+
+/// Parameters for creating a new GitHub issue.
+///
+/// Only `title` is required; all other fields are optional and default to
+/// empty/None when omitted.
+#[derive(Debug, Clone)]
+pub struct CreateIssueParams {
+    /// Issue title (required).
+    pub title: String,
+    /// Issue body in markdown.
+    pub body: Option<String>,
+    /// Labels to attach to the issue.
+    pub labels: Vec<String>,
+    /// Milestone number to assign (the numeric ID, not the title).
+    pub milestone: Option<u64>,
+    /// GitHub usernames to assign.
+    pub assignees: Vec<String>,
+}
+
+/// Minimal response shape from the REST POST /issues endpoint.
+///
+/// Only the `number` field is needed — the full issue is re-fetched via
+/// `fetch_issue()` to get Projects V2 fields and computed data.
+#[derive(Debug, Deserialize)]
+struct CreateIssueResponse {
+    number: u64,
+}
+
+/// Minimal response shape from the REST POST /issues/{n}/comments endpoint.
+#[derive(Debug, Deserialize)]
+struct CreateCommentResponse {
+    html_url: String,
+}
+
+/// Request body for creating a GitHub issue via REST API.
+#[derive(Debug, Serialize)]
+struct CreateIssueBody {
+    title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    milestone: Option<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    assignees: Vec<String>,
+}
+
+/// Request body for closing a GitHub issue via REST API.
+#[derive(Debug, Serialize)]
+struct CloseIssueBody {
+    state: &'static str,
+    state_reason: &'static str,
+}
+
+/// Request body for adding a comment to a GitHub issue via REST API.
+#[derive(Debug, Serialize)]
+struct AddCommentBody {
+    body: String,
+}
+
+impl GitHubClient {
+    /// Creates a new GitHub issue.
+    ///
+    /// Sends a REST POST to `/repos/{owner}/{repo}/issues` with the given
+    /// parameters. After creation, re-fetches the issue via [`fetch_issue()`]
+    /// to return the full field set including Projects V2 fields.
+    ///
+    /// If a project is configured, the newly created issue is added to the
+    /// project on a best-effort basis (failure is logged as a warning, not
+    /// propagated).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::GitHubApi`] for non-2xx responses.
+    /// Returns [`Error::RateLimited`] for HTTP 429 responses.
+    /// Returns [`Error::GitHubUnavailable`] for network failures.
+    ///
+    /// [`fetch_issue()`]: crate::graphql
+    #[instrument(skip(self, params), fields(owner = %self.owner(), repo = %self.repo(), title = %params.title))]
+    pub async fn create_issue(&self, params: CreateIssueParams) -> Result<Issue, Error> {
+        let url = self.rest_url(&format!("/repos/{}/{}/issues", self.owner(), self.repo()));
+
+        let request_body = CreateIssueBody {
+            title: params.title,
+            body: params.body,
+            labels: params.labels,
+            milestone: params.milestone,
+            assignees: params.assignees,
+        };
+
+        let response = self
+            .http()
+            .post(&url)
+            .json(&request_body)
+            .send()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let status = response.status();
+
+        if status.as_u16() == 429 {
+            let reset_at = parse_rate_limit_reset(&response);
+            return Err(errors::RateLimitedSnafu { reset_at }.build());
+        }
+
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_owned());
+            return Err(errors::GitHubApiSnafu {
+                status: status.as_u16(),
+                message,
+            }
+            .build());
+        }
+
+        let created: CreateIssueResponse = response
+            .json()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let number = created.number;
+
+        // Best-effort: add to project if configured.
+        if let Some(project_number) = self.project_number()
+            && let Err(e) = self.add_issue_to_project(number, project_number).await
+        {
+            warn!(
+                number,
+                project_number,
+                error = %e,
+                "Failed to add issue to project (best-effort)"
+            );
+        }
+
+        // Re-fetch via GraphQL for full field set.
+        self.fetch_issue(number).await
+    }
+
+    /// Closes a GitHub issue.
+    ///
+    /// If `reason` is provided, adds a comment with the reason text before
+    /// closing the issue. Sends a REST PATCH to
+    /// `/repos/{owner}/{repo}/issues/{number}` with `state: "closed"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if the
+    /// issue does not exist (HTTP 404).
+    /// Returns [`Error::RateLimited`] for HTTP 429 responses.
+    /// Returns [`Error::GitHubApi`] for other non-2xx responses.
+    ///
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    #[instrument(skip(self), fields(owner = %self.owner(), repo = %self.repo()))]
+    pub async fn close_issue(&self, number: u64, reason: Option<String>) -> Result<(), Error> {
+        // If reason is provided, add a comment first.
+        if let Some(reason_text) = reason {
+            self.add_comment(number, reason_text).await?;
+        }
+
+        let url = self.rest_url(&format!(
+            "/repos/{}/{}/issues/{number}",
+            self.owner(),
+            self.repo()
+        ));
+
+        let request_body = CloseIssueBody {
+            state: "closed",
+            state_reason: "completed",
+        };
+
+        let response = self
+            .http()
+            .patch(&url)
+            .json(&request_body)
+            .send()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let status = response.status();
+
+        if status.as_u16() == 429 {
+            let reset_at = parse_rate_limit_reset(&response);
+            return Err(errors::RateLimitedSnafu { reset_at }.build());
+        }
+
+        if status.as_u16() == 404 {
+            return Err(unblock_core::errors::IssueNotFoundSnafu { number }
+                .build()
+                .into());
+        }
+
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_owned());
+            return Err(errors::GitHubApiSnafu {
+                status: status.as_u16(),
+                message,
+            }
+            .build());
+        }
+
+        Ok(())
+    }
+
+    /// Adds a comment to a GitHub issue.
+    ///
+    /// Sends a REST POST to `/repos/{owner}/{repo}/issues/{number}/comments`.
+    /// Returns the HTML URL of the created comment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if the
+    /// issue does not exist (HTTP 404).
+    /// Returns [`Error::RateLimited`] for HTTP 429 responses.
+    /// Returns [`Error::GitHubApi`] for other non-2xx responses.
+    ///
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    #[instrument(skip(self, body), fields(owner = %self.owner(), repo = %self.repo()))]
+    pub async fn add_comment(&self, number: u64, body: String) -> Result<String, Error> {
+        let url = self.rest_url(&format!(
+            "/repos/{}/{}/issues/{number}/comments",
+            self.owner(),
+            self.repo()
+        ));
+
+        let request_body = AddCommentBody { body };
+
+        let response = self
+            .http()
+            .post(&url)
+            .json(&request_body)
+            .send()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let status = response.status();
+
+        if status.as_u16() == 429 {
+            let reset_at = parse_rate_limit_reset(&response);
+            return Err(errors::RateLimitedSnafu { reset_at }.build());
+        }
+
+        if status.as_u16() == 404 {
+            return Err(unblock_core::errors::IssueNotFoundSnafu { number }
+                .build()
+                .into());
+        }
+
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_owned());
+            return Err(errors::GitHubApiSnafu {
+                status: status.as_u16(),
+                message,
+            }
+            .build());
+        }
+
+        let comment: CreateCommentResponse = response
+            .json()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        Ok(comment.html_url)
+    }
+
+    /// Adds an issue to a GitHub Projects V2 project.
+    ///
+    /// Uses the GraphQL `addProjectV2ItemById` mutation. Requires the issue's
+    /// node ID, which is fetched via a lightweight REST call first.
+    ///
+    /// This is an internal helper — callers use `create_issue()` which calls
+    /// this automatically when a project is configured.
+    async fn add_issue_to_project(
+        &self,
+        issue_number: u64,
+        project_number: u64,
+    ) -> Result<(), Error> {
+        // Fetch the issue's node_id via REST (lightweight, avoids full GraphQL fetch).
+        let url = self.rest_url(&format!(
+            "/repos/{}/{}/issues/{issue_number}",
+            self.owner(),
+            self.repo()
+        ));
+
+        let response = self
+            .http()
+            .get(&url)
+            .send()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let status = response.status();
+
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_owned());
+            return Err(errors::GitHubApiSnafu {
+                status: status.as_u16(),
+                message,
+            }
+            .build());
+        }
+
+        let issue_json: serde_json::Value = response
+            .json()
+            .await
+            .context(errors::GitHubUnavailableSnafu)?;
+
+        let node_id = issue_json["node_id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned();
+
+        if node_id.is_empty() {
+            warn!(issue_number, "Issue has no node_id — cannot add to project");
+            return Ok(());
+        }
+
+        // Fetch the project's node ID via GraphQL.
+        let project_query = "
+            query FindProject($owner: String!, $repo: String!, $projectNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                    projectV2(number: $projectNumber) {
+                        id
+                    }
+                }
+            }
+        ";
+
+        let project_vars = serde_json::json!({
+            "owner": self.owner(),
+            "repo": self.repo(),
+            "projectNumber": project_number,
+        });
+
+        let project_response = self.graphql(project_query, project_vars).await?;
+        let project_id = project_response["data"]["repository"]["projectV2"]["id"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned();
+
+        if project_id.is_empty() {
+            warn!(
+                project_number,
+                "Project not found — cannot add issue to project"
+            );
+            return Ok(());
+        }
+
+        // Add the issue to the project.
+        let mutation = "
+            mutation AddToProject($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                    item {
+                        id
+                    }
+                }
+            }
+        ";
+
+        let mutation_vars = serde_json::json!({
+            "projectId": project_id,
+            "contentId": node_id,
+        });
+
+        self.graphql(mutation, mutation_vars).await?;
+
+        Ok(())
+    }
+}

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -7,6 +7,7 @@
 use unblock_core::config::Config;
 use unblock_core::types::{IssueState, Status};
 use unblock_github::client::GitHubClient;
+use unblock_github::mutations::CreateIssueParams;
 
 /// Returns `true` if the `GITHUB_TOKEN` env var is set and non-empty.
 fn has_github_token() -> bool {
@@ -247,4 +248,300 @@ async fn fetch_graph_data_issues_have_valid_status_and_priority() {
             issue.number, issue.status
         );
     }
+}
+
+// ── mutations: create_issue ─────────────────────────────────────────
+
+#[tokio::test]
+async fn create_issue_returns_issue_with_correct_fields() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    let params = CreateIssueParams {
+        title: "[test] create_issue integration test".to_owned(),
+        body: Some("Automated integration test — safe to close.".to_owned()),
+        labels: vec!["test".to_owned()],
+        milestone: None,
+        assignees: vec![],
+    };
+
+    let issue = client
+        .create_issue(params)
+        .await
+        .expect("create_issue() should succeed");
+
+    // Verify the returned issue has the correct fields.
+    assert!(issue.number > 0, "issue number should be positive");
+    assert_eq!(
+        issue.title, "[test] create_issue integration test",
+        "title should match what was provided"
+    );
+    assert!(!issue.node_id.is_empty(), "node_id should be non-empty");
+    assert!(!issue.url.is_empty(), "url should be non-empty");
+    assert_eq!(
+        issue.state,
+        IssueState::Open,
+        "newly created issue should be Open"
+    );
+
+    // Cleanup: close the created issue.
+    client
+        .close_issue(issue.number, Some("Automated test cleanup".to_owned()))
+        .await
+        .expect("close_issue() cleanup should succeed");
+
+    eprintln!(
+        "create_issue test: created and closed issue #{}",
+        issue.number
+    );
+}
+
+// ── mutations: close_issue ──────────────────────────────────────────
+
+#[tokio::test]
+async fn close_issue_closes_issue_and_refetch_confirms() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    // Create an issue to close.
+    let params = CreateIssueParams {
+        title: "[test] close_issue integration test".to_owned(),
+        body: Some("Automated integration test — will be closed.".to_owned()),
+        labels: vec!["test".to_owned()],
+        milestone: None,
+        assignees: vec![],
+    };
+
+    let issue = client
+        .create_issue(params)
+        .await
+        .expect("create_issue() should succeed");
+
+    // Close it without a reason.
+    client
+        .close_issue(issue.number, None)
+        .await
+        .expect("close_issue() should succeed");
+
+    // Re-fetch and verify it is closed.
+    let refetched = client
+        .fetch_issue(issue.number)
+        .await
+        .expect("fetch_issue() after close should succeed");
+
+    assert_eq!(
+        refetched.state,
+        IssueState::Closed,
+        "issue should be Closed after close_issue()"
+    );
+
+    eprintln!("close_issue test: closed issue #{}", issue.number);
+}
+
+#[tokio::test]
+async fn close_issue_with_reason_adds_comment_before_closing() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    // Create an issue to close with a reason.
+    let params = CreateIssueParams {
+        title: "[test] close_issue_with_reason integration test".to_owned(),
+        body: Some("Automated integration test — will be closed with reason.".to_owned()),
+        labels: vec!["test".to_owned()],
+        milestone: None,
+        assignees: vec![],
+    };
+
+    let issue = client
+        .create_issue(params)
+        .await
+        .expect("create_issue() should succeed");
+
+    let reason_text = "Closing because the test is complete.";
+
+    // Close with a reason (adds comment first).
+    client
+        .close_issue(issue.number, Some(reason_text.to_owned()))
+        .await
+        .expect("close_issue() with reason should succeed");
+
+    // Re-fetch and verify the comment appears.
+    let refetched = client
+        .fetch_issue(issue.number)
+        .await
+        .expect("fetch_issue() after close should succeed");
+
+    assert_eq!(
+        refetched.state,
+        IssueState::Closed,
+        "issue should be Closed after close_issue()"
+    );
+
+    // The reason comment should appear in the comments list.
+    let has_reason_comment = refetched
+        .comments
+        .iter()
+        .any(|c| c.body.contains(reason_text));
+    assert!(
+        has_reason_comment,
+        "reason comment should appear in the issue comments, got: {:?}",
+        refetched
+            .comments
+            .iter()
+            .map(|c| &c.body)
+            .collect::<Vec<_>>()
+    );
+
+    eprintln!(
+        "close_issue_with_reason test: closed issue #{} with reason",
+        issue.number
+    );
+}
+
+#[tokio::test]
+async fn close_issue_returns_issue_not_found_for_nonexistent_number() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    let result = client.close_issue(999_999_999, None).await;
+    assert!(
+        result.is_err(),
+        "close_issue for non-existent issue should return an error"
+    );
+
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.status_code(),
+        404,
+        "error should be 404 IssueNotFound, got: {} ({})",
+        err.status_code(),
+        err
+    );
+}
+
+// ── mutations: add_comment ──────────────────────────────────────────
+
+#[tokio::test]
+async fn add_comment_posts_comment_and_returns_url() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    // Create an issue to comment on.
+    let params = CreateIssueParams {
+        title: "[test] add_comment integration test".to_owned(),
+        body: Some("Automated integration test — will receive a comment.".to_owned()),
+        labels: vec!["test".to_owned()],
+        milestone: None,
+        assignees: vec![],
+    };
+
+    let issue = client
+        .create_issue(params)
+        .await
+        .expect("create_issue() should succeed");
+
+    let comment_body = "Integration test comment — hello from add_comment!";
+
+    let comment_url = client
+        .add_comment(issue.number, comment_body.to_owned())
+        .await
+        .expect("add_comment() should succeed");
+
+    // Verify the URL is non-empty and looks like a GitHub URL.
+    assert!(!comment_url.is_empty(), "comment URL should be non-empty");
+    assert!(
+        comment_url.contains("github"),
+        "comment URL should contain 'github', got: {comment_url}"
+    );
+
+    // Re-fetch and verify the comment appears.
+    let refetched = client
+        .fetch_issue(issue.number)
+        .await
+        .expect("fetch_issue() after comment should succeed");
+
+    let has_comment = refetched
+        .comments
+        .iter()
+        .any(|c| c.body.contains(comment_body));
+    assert!(
+        has_comment,
+        "comment should appear in issue comments after add_comment()"
+    );
+
+    // Cleanup: close the issue.
+    client
+        .close_issue(issue.number, Some("Test cleanup".to_owned()))
+        .await
+        .expect("close_issue() cleanup should succeed");
+
+    eprintln!(
+        "add_comment test: commented on issue #{}, URL: {comment_url}",
+        issue.number
+    );
+}
+
+#[tokio::test]
+async fn add_comment_returns_issue_not_found_for_nonexistent_number() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let config = test_config();
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new() should succeed");
+
+    let result = client
+        .add_comment(999_999_999, "should fail".to_owned())
+        .await;
+    assert!(
+        result.is_err(),
+        "add_comment for non-existent issue should return an error"
+    );
+
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.status_code(),
+        404,
+        "error should be 404 IssueNotFound, got: {} ({})",
+        err.status_code(),
+        err
+    );
 }


### PR DESCRIPTION
Implement three write mutation methods on GitHubClient using the GitHub REST API as specified in bead unblock-467.4:

- create_issue(CreateIssueParams) — POST /repos/{o}/{r}/issues, re-fetches via fetch_issue for full field set, best-effort project addition via addProjectV2ItemById GraphQL mutation
- close_issue(number, reason) — PATCH /repos/{o}/{r}/issues/{n} with state:closed, optionally adds reason comment first via add_comment
- add_comment(number, body) — POST /repos/{o}/{r}/issues/{n}/comments, returns the HTML URL of the created comment

All methods handle 429 (RateLimited), 404 (IssueNotFound), and generic non-2xx (GitHubApi) error responses. Made parse_rate_limit_reset pub(crate) in graphql.rs for reuse.

Integration tests cover: create with correct fields, close with refetch confirmation, close with reason comment, add_comment with URL return, and IssueNotFound for nonexistent issue numbers on close and comment.