### PR TITLE
feat: implement MCP server bootstrap with ServerState and UnblockServer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ reqwest = { version = "0.12", features = ["json"] }
 petgraph = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
 snafu = "0.8"
-anyhow = "1"
 rmcp = { version = "1.0", features = ["server", "transport-io"] }
 schemars = "1"
 rand = "0.9"

--- a/crates/unblock-mcp/Cargo.toml
+++ b/crates/unblock-mcp/Cargo.toml
@@ -24,3 +24,4 @@ tracing-subscriber = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 snafu = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/unblock-mcp/Cargo.toml
+++ b/crates/unblock-mcp/Cargo.toml
@@ -24,4 +24,3 @@ tracing-subscriber = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 snafu = { workspace = true }
-anyhow = { workspace = true }

--- a/crates/unblock-mcp/src/errors.rs
+++ b/crates/unblock-mcp/src/errors.rs
@@ -2,3 +2,47 @@
 //!
 //! Maps domain errors (`unblock-core`) and infrastructure errors (`unblock-github`)
 //! to MCP error responses with appropriate error codes.
+
+use snafu::Snafu;
+
+/// Errors that can occur during MCP server bootstrap.
+///
+/// Each variant wraps the underlying source error and carries a human-readable
+/// message describing what went wrong, so that the operator can diagnose
+/// startup failures without reading source code.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum BootstrapError {
+    /// Failed to load configuration from environment variables.
+    #[snafu(display(
+        "Failed to load configuration. Ensure GITHUB_TOKEN is set in the environment."
+    ))]
+    ConfigLoad {
+        /// The underlying domain error from `Config::load`.
+        source: unblock_core::errors::DomainError,
+    },
+
+    /// Failed to initialize the GitHub API client.
+    #[snafu(display(
+        "Failed to initialize GitHub client. Check GITHUB_TOKEN and repository settings."
+    ))]
+    ClientInit {
+        /// The underlying GitHub client error.
+        source: unblock_github::errors::Error,
+    },
+
+    /// Failed to start the MCP stdio transport.
+    #[snafu(display("Failed to start MCP stdio transport"))]
+    Transport {
+        /// The underlying rmcp initialization error.
+        #[snafu(source(from(rmcp::service::ServerInitializeError, Box::new)))]
+        source: Box<rmcp::service::ServerInitializeError>,
+    },
+
+    /// The MCP runtime task panicked or was cancelled.
+    #[snafu(display("MCP runtime task failed"))]
+    Runtime {
+        /// The underlying tokio `JoinError`.
+        source: tokio::task::JoinError,
+    },
+}

--- a/crates/unblock-mcp/src/main.rs
+++ b/crates/unblock-mcp/src/main.rs
@@ -17,21 +17,21 @@ mod tools;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context as _;
 use rmcp::ServiceExt as _;
+use snafu::ResultExt as _;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 use unblock_core::cache::GraphCache;
 use unblock_core::config::Config;
 use unblock_github::client::GitHubClient;
 
+use crate::errors::{ClientInitSnafu, ConfigLoadSnafu, RuntimeSnafu, TransportSnafu};
 use crate::server::{ServerState, UnblockServer};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), crate::errors::BootstrapError> {
     // 1. Load configuration from environment variables.
-    let config = Config::load()
-        .context("Failed to load configuration. Ensure GITHUB_TOKEN is set in the environment.")?;
+    let config = Config::load().context(ConfigLoadSnafu)?;
 
     // 2. Initialize tracing subscriber: JSON format, output to stderr, level from config.
     tracing_subscriber::fmt()
@@ -41,9 +41,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     // 3. Create GitHub client — resolves repo and project, exits on failure.
-    let client = GitHubClient::new(&config).await.context(
-        "Failed to initialize GitHub client. Check GITHUB_TOKEN and repository settings.",
-    )?;
+    let client = GitHubClient::new(&config).await.context(ClientInitSnafu)?;
 
     // 4. Create graph cache with TTL from configuration.
     let cache = GraphCache::new(Duration::from_secs(config.cache_ttl));
@@ -68,10 +66,10 @@ async fn main() -> anyhow::Result<()> {
     let running = server
         .serve(rmcp::transport::io::stdio())
         .await
-        .context("Failed to start MCP stdio transport")?;
+        .context(TransportSnafu)?;
 
     // 7. Block until the client disconnects.
-    running.waiting().await?;
+    running.waiting().await.context(RuntimeSnafu)?;
 
     Ok(())
 }

--- a/crates/unblock-mcp/src/main.rs
+++ b/crates/unblock-mcp/src/main.rs
@@ -3,7 +3,7 @@
 //! MCP server binary for dependency-aware task tracking powered by GitHub.
 //!
 //! Connects to GitHub via `unblock-github`, builds a dependency graph via `unblock-core`,
-//! and exposes 17 MCP tools over stdio transport.
+//! and exposes MCP tools over stdio transport.
 
 /// MCP server bootstrap, state, and tool registration.
 mod server;
@@ -14,7 +14,64 @@ mod errors;
 /// MCP tool handlers.
 mod tools;
 
-fn main() {
-    // Server bootstrap will be implemented in Phase 1.
-    // Config → tracing → GitHubClient → GraphCache → ServerState → rmcp stdio.
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use rmcp::ServiceExt as _;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+use unblock_core::cache::GraphCache;
+use unblock_core::config::Config;
+use unblock_github::client::GitHubClient;
+
+use crate::server::{ServerState, UnblockServer};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // 1. Load configuration from environment variables.
+    let config = Config::load()
+        .context("Failed to load configuration. Ensure GITHUB_TOKEN is set in the environment.")?;
+
+    // 2. Initialize tracing subscriber: JSON format, output to stderr, level from config.
+    tracing_subscriber::fmt()
+        .json()
+        .with_env_filter(EnvFilter::new(&config.log_level))
+        .with_writer(std::io::stderr)
+        .init();
+
+    // 3. Create GitHub client — resolves repo and project, exits on failure.
+    let client = GitHubClient::new(&config).await.context(
+        "Failed to initialize GitHub client. Check GITHUB_TOKEN and repository settings.",
+    )?;
+
+    // 4. Create graph cache with TTL from configuration.
+    let cache = GraphCache::new(Duration::from_secs(config.cache_ttl));
+
+    // 5. Build server state.
+    let state = ServerState {
+        config: Arc::new(config),
+        client: Arc::new(client),
+        cache: Arc::new(cache),
+    };
+
+    info!(
+        server_name = "unblock",
+        version = env!("CARGO_PKG_VERSION"),
+        repo = %state.client.owner().to_owned() + "/" + state.client.repo(),
+        project = ?state.client.project_number(),
+        "Starting unblock MCP server"
+    );
+
+    // 6. Build and serve the MCP server on stdio.
+    let server = UnblockServer::new(state);
+    let running = server
+        .serve(rmcp::transport::io::stdio())
+        .await
+        .context("Failed to start MCP stdio transport")?;
+
+    // 7. Block until the client disconnects.
+    running.waiting().await?;
+
+    Ok(())
 }

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1,4 +1,143 @@
 //! MCP server bootstrap and state management.
 //!
-//! `ServerState` holds `GitHubClient`, `GraphCache`, and `Config`.
-//! Uses rmcp stdio transport with `ServerInfo` metadata.
+//! [`ServerState`] holds [`GitHubClient`](unblock_github::client::GitHubClient),
+//! [`GraphCache`](unblock_core::cache::GraphCache), and
+//! [`Config`](unblock_core::config::Config). [`UnblockServer`] implements the rmcp
+//! [`ServerHandler`](rmcp::ServerHandler) trait, exposing MCP tools over stdio transport.
+//!
+//! The server is constructed via [`UnblockServer::new`], which takes ownership of a
+//! [`ServerState`] and wraps it in an [`Arc`] for shared access across tool handlers.
+
+use std::sync::Arc;
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::model::{Implementation, ServerInfo};
+use rmcp::{ServerHandler, tool_handler, tool_router};
+use unblock_core::cache::GraphCache;
+use unblock_core::config::Config;
+use unblock_github::client::GitHubClient;
+
+/// Instructions string injected into the agent context window.
+///
+/// Provides a concise reference card for agents describing each tool, its purpose,
+/// key parameters, and when to use it. This is sent as part of the MCP `ServerInfo`
+/// during initialization.
+pub const INSTRUCTIONS_STR: &str = "\
+# unblock — Dependency-Aware Task Tracking
+
+unblock turns GitHub Issues into a dependency graph. Ask `ready` to get unblocked work.
+
+## Workflow
+1. `setup` — Configure the target repository (run once per session)
+2. `ready` — Get issues with no active blockers (the main entry point)
+3. `claim` — Assign yourself to an issue before starting work
+4. `close` — Close a completed issue (auto-unblocks dependents)
+
+## Tools
+
+### Core Workflow
+| Tool    | Purpose                                              | Key Params                          |
+|---------|------------------------------------------------------|-------------------------------------|
+| setup   | Set target repo and project                          | owner, repo, project_number?        |
+| ready   | Find issues that can be worked on right now           | limit?, type?, priority?, agent?    |
+| claim   | Assign yourself to an issue                          | issue_number, agent?                |
+| close   | Close an issue and cascade-unblock dependents        | issue_number                        |
+| create  | Create a new issue with optional dependencies        | title, body?, blocked_by?           |
+
+### Query & Dependencies
+| Tool    | Purpose                                              | Key Params                          |
+|---------|------------------------------------------------------|-------------------------------------|
+| show    | Get full details for a single issue                  | issue_number                        |
+| depends | Show the dependency tree for an issue                | issue_number, direction?            |
+| comment | Add a comment to an issue                            | issue_number, body                  |
+| update  | Update issue fields (priority, labels, body, etc.)   | issue_number, fields...             |
+
+## Tips
+- Always call `ready` first to find unblocked work.
+- Use `claim` before starting work to prevent conflicts.
+- After `close`, dependents are automatically re-evaluated.
+- Write tools (create, close, update, comment, claim) trigger a graph rebuild.
+- Read tools (ready, show, depends) use the cache for fast responses.
+";
+
+/// Shared state for all MCP tool handlers.
+///
+/// Holds the GitHub API client, the in-memory graph cache, and the application
+/// configuration. All fields are wrapped in [`Arc`] so that `ServerState` itself
+/// can be shared across tool handlers via `Arc<ServerState>`.
+///
+/// # Thread Safety
+///
+/// `ServerState` is `Send + Sync` because all inner types are `Send + Sync`:
+/// - [`Config`] is `Clone + Send + Sync` (plain data).
+/// - [`GitHubClient`] wraps `reqwest::Client` which is `Send + Sync`.
+/// - [`GraphCache`] uses `tokio::sync::RwLock` which is `Send + Sync`.
+#[derive(Debug)]
+#[allow(dead_code)] // Fields used by tool handlers added in beads 45a.3–45a.11.
+pub struct ServerState {
+    /// Application configuration loaded from environment variables.
+    pub config: Arc<Config>,
+    /// GitHub API client for GraphQL and REST operations.
+    pub client: Arc<GitHubClient>,
+    /// In-memory cache for the dependency graph and ready set.
+    pub cache: Arc<GraphCache>,
+}
+
+/// MCP server implementation for unblock.
+///
+/// Wraps [`ServerState`] in an [`Arc`] and provides tool routing via rmcp macros.
+/// Implements [`ServerHandler`] to serve MCP requests over stdio transport.
+///
+/// Constructed via [`UnblockServer::new`].
+pub struct UnblockServer {
+    /// Shared server state accessible by all tool handlers.
+    #[allow(dead_code)] // Used by tool handlers added in beads 45a.3–45a.11.
+    state: Arc<ServerState>,
+    /// Tool router generated by the `#[tool_router]` macro.
+    #[allow(dead_code)]
+    tool_router: ToolRouter<Self>,
+}
+
+impl UnblockServer {
+    /// Creates a new `UnblockServer` from the given state.
+    ///
+    /// Wraps the state in an `Arc` for shared access across tool handlers
+    /// and initializes the tool router.
+    #[must_use]
+    pub fn new(state: ServerState) -> Self {
+        Self {
+            state: Arc::new(state),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Returns a reference to the shared server state.
+    #[must_use]
+    #[allow(dead_code)] // Used by tool handlers added in beads 45a.3–45a.11.
+    pub fn state(&self) -> &Arc<ServerState> {
+        &self.state
+    }
+}
+
+/// Tool router implementation — tools will be added in subsequent beads (45a.3–45a.11).
+#[tool_router]
+impl UnblockServer {}
+
+#[tool_handler]
+impl ServerHandler for UnblockServer {
+    fn get_info(&self) -> ServerInfo {
+        let capabilities = rmcp::model::ServerCapabilities::builder()
+            .enable_tools()
+            .build();
+        ServerInfo::new(capabilities)
+            .with_server_info(Implementation::new("unblock", env!("CARGO_PKG_VERSION")))
+            .with_instructions(INSTRUCTIONS_STR)
+    }
+}
+
+// Static assertions: ServerState must be Send + Sync.
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ServerState>();
+    assert_send_sync::<Arc<ServerState>>();
+};


### PR DESCRIPTION
Implement full server initialization in main.rs and server.rs per ARCH §9.1/§9.2:

- main.rs: #[tokio::main] async entry point with Config::load(), tracing subscriber (JSON to stderr with configurable log level), GitHubClient::new(), GraphCache::new(), ServerState construction, and rmcp stdio transport serve loop
- server.rs: ServerState struct (Arc<Config>, Arc<GitHubClient>, Arc<GraphCache>), UnblockServer with tool_router and ServerHandler impl, ServerInfo with name='unblock' and version from Cargo.toml, INSTRUCTIONS_STR reference card describing all Phase 1 tools
- Cargo.toml: add anyhow dependency for main error handling
- Static compile-time assertion that ServerState is Send + Sync