### PR TITLE
test: add wiremock-based unit tests for fetch_graph_data pagination loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +326,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "displaydoc"
@@ -640,6 +668,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +687,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1030,6 +1065,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2101,6 +2146,7 @@ dependencies = [
  "tokio",
  "tracing",
  "unblock-core",
+ "wiremock",
 ]
 
 [[package]]
@@ -2482,6 +2528,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ schemars = "1"
 rand = "0.9"
 proptest = "1"
 criterion = { version = "0.5", features = ["async_tokio"] }
+wiremock = "0.6"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/unblock-github/Cargo.toml
+++ b/crates/unblock-github/Cargo.toml
@@ -18,3 +18,7 @@ reqwest = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 snafu = { workspace = true }
+
+[dev-dependencies]
+wiremock = { workspace = true }
+tokio = { workspace = true }

--- a/crates/unblock-github/src/client.rs
+++ b/crates/unblock-github/src/client.rs
@@ -216,6 +216,22 @@ impl GitHubClient {
     fn resolve_project(config: &Config) -> Option<u64> {
         config.project_number
     }
+
+    /// Creates a `GitHubClient` for unit testing with a custom API base URL.
+    ///
+    /// Constructs a bare client with no auth headers, pointing at the given
+    /// `api_base_url` (typically a wiremock server URI). Available only in
+    /// `#[cfg(test)]` builds and accessible from other crate modules.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(api_base_url: &str) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_base_url: api_base_url.to_owned(),
+            owner: "test-owner".to_owned(),
+            repo: "test-repo".to_owned(),
+            project_number: None,
+        }
+    }
 }
 
 /// Parses a GitHub URL into `(owner, repo)`.

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -1428,4 +1428,206 @@ mod tests {
         let edges = extract_blocking_edges(&node);
         assert!(edges.is_empty());
     }
+
+    // ── fetch_graph_data pagination (wiremock) ─────────────────────────
+
+    /// Creates a `GitHubClient` pointing at a custom base URL for mock testing.
+    ///
+    /// Delegates to `GitHubClient::new_for_test` which constructs a bare client
+    /// with no auth headers. The `api_base_url` should be a wiremock server URI
+    /// so that `graphql_url()` routes requests to the mock.
+    fn make_mock_client(api_base_url: &str) -> GitHubClient {
+        GitHubClient::new_for_test(api_base_url)
+    }
+
+    /// Builds a mock GraphQL response page for `fetch_graph_data`.
+    ///
+    /// Each issue node has the minimal fields required by `parse_graph_issue`:
+    /// number, id, title, body, state, url, createdAt, updatedAt, labels,
+    /// milestone, assignees, and optionally trackedBy edges.
+    fn make_page_response(
+        issues: &[(u64, &str, Vec<u64>)],
+        has_next_page: bool,
+        end_cursor: Option<&str>,
+    ) -> serde_json::Value {
+        let nodes: Vec<serde_json::Value> = issues
+            .iter()
+            .map(|(number, title, blockers)| {
+                let tracked_by_nodes: Vec<serde_json::Value> = blockers
+                    .iter()
+                    .map(|n| serde_json::json!({"number": n}))
+                    .collect();
+                serde_json::json!({
+                    "id": format!("node-{number}"),
+                    "number": number,
+                    "title": title,
+                    "body": null,
+                    "state": "OPEN",
+                    "url": format!("https://github.com/test-owner/test-repo/issues/{number}"),
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "labels": {"nodes": []},
+                    "milestone": null,
+                    "assignees": {"nodes": []},
+                    "trackedBy": {"nodes": tracked_by_nodes}
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "data": {
+                "repository": {
+                    "issues": {
+                        "pageInfo": {
+                            "hasNextPage": has_next_page,
+                            "endCursor": end_cursor,
+                        },
+                        "nodes": nodes,
+                    }
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn fetch_graph_data_multi_page_pagination() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = make_mock_client(&server.uri());
+
+        // Page 1: cursor is null → returns 2 issues, hasNextPage: true.
+        // The JSON body will contain `"cursor":null` for the first request.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("\"cursor\":null"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_page_response(
+                &[(1, "Issue one", vec![]), (2, "Issue two", vec![1])],
+                true,
+                Some("cursor-page1"),
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Page 2: cursor is "cursor-page1" → returns 1 issue, hasNextPage: false.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("\"cursor\":\"cursor-page1\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_page_response(
+                &[(3, "Issue three", vec![2])],
+                false,
+                None,
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (issues, edges) = client.fetch_graph_data().await.expect("should succeed");
+
+        // All 3 issues from both pages.
+        assert_eq!(issues.len(), 3);
+        assert_eq!(issues[0].number, 1);
+        assert_eq!(issues[0].title, "Issue one");
+        assert_eq!(issues[1].number, 2);
+        assert_eq!(issues[1].title, "Issue two");
+        assert_eq!(issues[2].number, 3);
+        assert_eq!(issues[2].title, "Issue three");
+
+        // Edges: issue 2 blocked by 1, issue 3 blocked by 2.
+        assert_eq!(edges.len(), 2);
+        assert_eq!(edges[0].source, 2);
+        assert_eq!(edges[0].target, 1);
+        assert_eq!(edges[1].source, 3);
+        assert_eq!(edges[1].target, 2);
+    }
+
+    #[tokio::test]
+    async fn fetch_graph_data_single_page_no_extra_requests() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = make_mock_client(&server.uri());
+
+        // Single page: hasNextPage: false on the first (and only) request.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_page_response(
+                &[(10, "Only issue", vec![])],
+                false,
+                None,
+            )))
+            .expect(1) // Exactly 1 request — no extra page fetches.
+            .mount(&server)
+            .await;
+
+        let (issues, edges) = client.fetch_graph_data().await.expect("should succeed");
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].number, 10);
+        assert!(edges.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_graph_data_null_end_cursor_breaks_pagination() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = make_mock_client(&server.uri());
+
+        // Pathological response: hasNextPage: true but endCursor: null.
+        // The infinite-loop guard (graphql.rs:289-298) should break out
+        // and return the partial results from this single page.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_page_response(
+                &[(5, "Partial one", vec![]), (6, "Partial two", vec![5])],
+                true, // hasNextPage: true (would loop forever without guard)
+                None, // endCursor: null (triggers the guard)
+            )))
+            .expect(1) // Only 1 request — guard prevents re-fetch.
+            .mount(&server)
+            .await;
+
+        let (issues, edges) = client.fetch_graph_data().await.expect("should succeed");
+
+        // Returns partial results from the single page.
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].number, 5);
+        assert_eq!(issues[1].number, 6);
+
+        // Edge: issue 6 blocked by issue 5.
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].source, 6);
+        assert_eq!(edges[0].target, 5);
+    }
+
+    #[tokio::test]
+    async fn fetch_graph_data_empty_repo_returns_empty_vecs() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = make_mock_client(&server.uri());
+
+        // Empty repo: no issue nodes, hasNextPage: false.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_page_response(
+                &[],
+                false,
+                None,
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (issues, edges) = client.fetch_graph_data().await.expect("should succeed");
+
+        assert!(issues.is_empty());
+        assert!(edges.is_empty());
+    }
 }


### PR DESCRIPTION
Add 4 new unit tests exercising the pagination loop in fetch_graph_data() without requiring a live GITHUB_TOKEN:

- multi_page_pagination: 2-page fetch returns all issues and edges
- single_page_no_extra_requests: verifies exactly 1 HTTP request
- null_end_cursor_breaks_pagination: infinite-loop guard test
- empty_repo_returns_empty_vecs: no issues returns empty vectors

Uses wiremock (new dev-dependency) to mock the GitHub GraphQL endpoint. Adds GitHubClient::new_for_test() pub(crate) constructor for pointing the client at a wiremock server URI during tests.