### PR TITLE
docs: add pub API change tracking convention to commit strategy

### DIFF
--- a/.claude/agents/rust-supervisor.md
+++ b/.claude/agents/rust-supervisor.md
@@ -164,6 +164,7 @@ Cargo.toml           # Workspace root
   ```
 - Atomic commits — each commit must compile and pass tests
 - Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`
+- **Pub API change tracking** — when a `pub fn`, `pub struct`, `pub enum`, or `pub trait` signature changes in a library crate (`unblock-core`, `unblock-github`), the commit body must include an `API:` line (additive changes) or `BREAKING CHANGE:` footer (incompatible changes) noting the signature change. This enables changelog generation and semver decisions. Binary crate (`unblock-mcp`) is excluded.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,15 @@ Get more info from reference: https://github.com/steveyegge/beads/raw/refs/heads
 - ❌ Do NOT use external issue trackers
 - ❌ Do NOT duplicate tracking systems
 
+## Commit Conventions: Pub API Changes
+
+When a commit changes the signature of a `pub fn`, `pub struct`, `pub enum`, or `pub trait` in a **library crate** (`unblock-core`, `unblock-github`), the commit message body **must** note the change:
+
+- **Additive/non-breaking:** Add an `API:` line describing the change
+- **Incompatible:** Add a `BREAKING CHANGE:` footer per the Conventional Commits spec
+
+This enables automated changelog generation and semver tracking. The binary crate (`unblock-mcp`) is excluded since it has no downstream consumers.
+
 ## Landing the Plane (Session Completion)
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,28 @@ GITHUB_TOKEN=ghp_... cargo run -p unblock-mcp   # run locally
 - Never commit breaking changes. Run tests before every commit.
 - No reconstructed history — commits must represent actual development order
 
+### Pub API Change Tracking
+
+When a `pub fn`, `pub struct`, `pub enum`, or `pub trait` signature changes in a **library crate** (`unblock-core`, `unblock-github`), the commit message **must** note the change for changelog/semver awareness. This applies to additions, removals, renames, and parameter changes.
+
+Use one of:
+- A `BREAKING CHANGE:` footer (per Conventional Commits spec) for incompatible changes
+- An `API:` line in the commit body for additive or non-breaking changes
+
+Examples:
+```
+feat: make GitHub URL configurable for GHE support
+
+API: parse_github_url() signature changed — added `github_url` parameter
+```
+```
+refactor: simplify graph builder interface
+
+BREAKING CHANGE: GraphBuilder::new() now requires a Config parameter
+```
+
+**Scope:** Library crates only. The binary crate (`unblock-mcp`) has no downstream consumers and is excluded from this requirement.
+
 ## Documentation
 
 - `docs/unblock-prd-github.md` — what to build (MCP)


### PR DESCRIPTION
Add a rule requiring commit messages to note pub API signature changes (pub fn/struct/enum/trait) in library crates for changelog and semver awareness. Uses API: lines for additive changes and BREAKING CHANGE: footers for incompatible changes. Binary crate (unblock-mcp) excluded.

Updated in: CLAUDE.md, AGENTS.md, .claude/agents/rust-supervisor.md