### PR TITLE
chore: extract repo slug into local variable before tracing info! macro

### DIFF
--- a/crates/unblock-mcp/src/main.rs
+++ b/crates/unblock-mcp/src/main.rs
@@ -53,10 +53,11 @@ async fn main() -> Result<(), crate::errors::BootstrapError> {
         cache: Arc::new(cache),
     };
 
+    let repo_slug = format!("{}/{}", state.client.owner(), state.client.repo());
     info!(
         server_name = "unblock",
         version = env!("CARGO_PKG_VERSION"),
-        repo = %state.client.owner().to_owned() + "/" + state.client.repo(),
+        repo = %repo_slug,
         project = ?state.client.project_number(),
         "Starting unblock MCP server"
     );


### PR DESCRIPTION
Moves the runtime string concatenation (`owner().to_owned() + "/" + repo()`) out of the `info!` macro call into a `format!`-based local variable. This improves readability and avoids an unnecessary heap allocation inside the macro expansion.