### PR TITLE
feat: expand setup tool with view creation and field discovery 

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -19,7 +19,7 @@ use crate::tools::execute_read_tool;
 use crate::tools::execute_write_tool;
 use crate::tools::init::{InitParams, InitResult};
 use crate::tools::ready::{ReadyParams, ReadyResult};
-use crate::tools::setup::{SetupParams, SetupResult};
+use crate::tools::setup::{REQUIRED_VIEWS, SetupParams, SetupResult};
 use crate::tools::show::{
     DependencyTreeEntry, ShowBodySections, ShowComment, ShowIssue, ShowParams, ShowRelatedIssue,
     ShowResult,
@@ -32,6 +32,7 @@ use tracing::info;
 use unblock_core::cache::GraphCache;
 use unblock_core::config::Config;
 use unblock_github::client::GitHubClient;
+use unblock_github::projects::{CreateViewParams, ViewLayout};
 
 /// Instructions string injected into the agent context window.
 ///
@@ -376,9 +377,6 @@ impl UnblockServer {
         &self,
         Parameters(params): Parameters<SetupParams>,
     ) -> Result<Json<SetupResult>, ErrorData> {
-        use crate::tools::setup::REQUIRED_VIEWS;
-        use unblock_github::projects::{CreateViewParams, ViewLayout};
-
         let state = self.state();
         let dry_run = params.dry_run.unwrap_or(false);
 
@@ -412,10 +410,9 @@ impl UnblockServer {
 
         if dry_run {
             // Dry-run: query which fields and views exist without creating anything.
-            let field_status = client
-                .query_setup_status(&project_info.id)
-                .await
-                .map_err(crate::errors::github_error_to_mcp)?;
+            let project_id = project_info.id.clone();
+            let field_status =
+                execute_read_tool(state, || client.query_setup_status(&project_id)).await?;
 
             // Step 5: Query existing views.
             let existing_views = execute_read_tool(state, || client.list_views(owner_type)).await?;
@@ -493,6 +490,10 @@ impl UnblockServer {
                 visible_fields,
             };
 
+            // NOTE: execute_read_tool is intentional here despite create_view being a
+            // mutating POST. Views do not affect the dependency graph, so no cache
+            // rebuild is needed. execute_read_tool provides consistent error mapping
+            // without the unnecessary cache invalidation of execute_write_tool.
             execute_read_tool(state, || client.create_view(owner_type, &view_params)).await?;
 
             views_created.push(spec.name.to_owned());

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -363,19 +363,22 @@ impl UnblockServer {
         }))
     }
 
-    /// Create required Projects V2 fields on the configured project (idempotent).
+    /// Configure required Projects V2 fields and views (idempotent).
     ///
-    /// This is typically the first tool an agent calls on a fresh repository.
-    /// With `dry_run: true`, reports which fields exist and which are missing
-    /// without creating anything.
+    /// Ensures the 7 required custom fields and 5 pre-configured views exist
+    /// on the project. With `dry_run: true`, reports what would be created
+    /// without mutating anything.
     #[tool(
         name = "setup",
-        description = "Create required Projects V2 custom fields (Status, Priority, IssueType, Agent, StoryPoints, DeferUntil, ReadyState). Safe to call repeatedly — existing fields are skipped. Use dry_run=true to check without mutating."
+        description = "Configure Projects V2 fields (Status, Priority, IssueType, Agent, StoryPoints, DeferUntil, ReadyState) and views (://ready, ://team, ://pipeline, ://roadmap, ://timeline). Safe to call repeatedly — existing fields/views are skipped. Use dry_run=true to check without mutating."
     )]
     async fn setup(
         &self,
         Parameters(params): Parameters<SetupParams>,
     ) -> Result<Json<SetupResult>, ErrorData> {
+        use crate::tools::setup::REQUIRED_VIEWS;
+        use unblock_github::projects::{CreateViewParams, ViewLayout};
+
         let state = self.state();
         let dry_run = params.dry_run.unwrap_or(false);
 
@@ -404,22 +407,46 @@ impl UnblockServer {
             "Setup tool invoked"
         );
 
+        // Step 4: Detect owner type (read-only GET, safe for dry-run too).
+        let owner_type = execute_read_tool(state, || client.detect_owner_type()).await?;
+
         if dry_run {
-            // Dry-run: query which fields exist without creating anything.
-            let status = client
+            // Dry-run: query which fields and views exist without creating anything.
+            let field_status = client
                 .query_setup_status(&project_info.id)
                 .await
                 .map_err(crate::errors::github_error_to_mcp)?;
 
+            // Step 5: Query existing views.
+            let existing_views = execute_read_tool(state, || client.list_views(owner_type)).await?;
+
+            let existing_view_names: std::collections::HashSet<&str> =
+                existing_views.iter().map(|v| v.name.as_str()).collect();
+
+            let mut views_existing = Vec::new();
+            let mut views_would_create = Vec::new();
+            for spec in REQUIRED_VIEWS {
+                if existing_view_names.contains(spec.name) {
+                    views_existing.push(spec.name.to_owned());
+                } else {
+                    views_would_create.push(spec.name.to_owned());
+                }
+            }
+
             return Ok(Json(SetupResult {
                 fields_created: Vec::new(),
-                fields_skipped: status.existing,
-                fields_missing: status.missing,
-                project_id: project_info.id,
+                fields_existing: field_status.existing,
+                fields_missing: field_status.missing,
+                views_created: views_would_create,
+                views_existing,
+                project_number: u64::from(project_info.number),
+                dry_run: true,
             }));
         }
 
-        // Write path: create fields, invalidate cache, rebuild.
+        // ── Write path ──────────────────────────────────────────────────
+
+        // Step 1–3: Create fields (with cache rebuild).
         let project_id = project_info.id.clone();
         let client_clone = Arc::clone(client);
 
@@ -431,11 +458,54 @@ impl UnblockServer {
         // Cache the resolved field IDs on the client for subsequent update_field calls.
         client.set_field_ids(report.field_ids).await;
 
+        // Step 5: Query existing views.
+        let existing_views = execute_read_tool(state, || client.list_views(owner_type)).await?;
+
+        let existing_view_names: std::collections::HashSet<&str> =
+            existing_views.iter().map(|v| v.name.as_str()).collect();
+
+        // Step 6: Discover all field IDs via REST (needed for visible_fields).
+        let rest_fields = execute_read_tool(state, || client.list_rest_fields(owner_type)).await?;
+
+        let all_field_ids: Vec<u64> = rest_fields.iter().map(|f| f.id).collect();
+
+        // Step 7: Create missing views.
+        let mut views_created = Vec::new();
+        let mut views_existing = Vec::new();
+
+        for spec in REQUIRED_VIEWS {
+            if existing_view_names.contains(spec.name) {
+                views_existing.push(spec.name.to_owned());
+                continue;
+            }
+
+            // Roadmap views do not support visible_fields (ARCH §8.5).
+            let visible_fields = if spec.layout == ViewLayout::Roadmap {
+                None
+            } else {
+                Some(all_field_ids.clone())
+            };
+
+            let view_params = CreateViewParams {
+                name: spec.name.to_owned(),
+                layout: spec.layout,
+                filter: spec.filter.map(String::from),
+                visible_fields,
+            };
+
+            execute_read_tool(state, || client.create_view(owner_type, &view_params)).await?;
+
+            views_created.push(spec.name.to_owned());
+        }
+
         Ok(Json(SetupResult {
             fields_created: report.created,
-            fields_skipped: report.skipped,
+            fields_existing: report.skipped,
             fields_missing: Vec::new(),
-            project_id: project_info.id,
+            views_created,
+            views_existing,
+            project_number: u64::from(project_info.number),
+            dry_run: false,
         }))
     }
 

--- a/crates/unblock-mcp/src/tools/setup.rs
+++ b/crates/unblock-mcp/src/tools/setup.rs
@@ -1,18 +1,21 @@
-//! Setup tool — creates required Projects V2 custom fields (idempotent).
+//! Setup tool — configures Projects V2 fields and views (idempotent).
 //!
-//! This is typically the first tool an agent calls on a fresh repository.
-//! It ensures the 7 required Projects V2 fields exist on the configured project,
-//! and reports which fields were created vs. skipped.
+//! This is typically the first tool an agent calls on a fresh repository
+//! (after `init`). It ensures the 7 required Projects V2 fields and 5
+//! pre-configured views exist on the configured project, and reports which
+//! were created vs. already present.
 //!
-//! Supports a `dry_run` mode that queries field presence without mutating.
+//! Supports a `dry_run` mode that queries field/view presence without mutating.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use unblock_github::projects::ViewLayout;
 
 /// Input parameters for the `setup` MCP tool.
 ///
 /// Both fields are optional: `project` overrides the configured project number,
-/// and `dry_run` controls whether fields are actually created or just inspected.
+/// and `dry_run` controls whether fields/views are actually created or just
+/// inspected.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SetupParams {
     /// Optional project number override. If omitted, uses the configured
@@ -20,26 +23,77 @@ pub struct SetupParams {
     ///
     /// **Note:** This parameter is accepted but not yet wired — the configured
     /// project number is always used. If provided, a warning is logged.
-    pub project: Option<u32>,
-    /// If `true`, report which fields exist and which are missing without
+    pub project: Option<u64>,
+    /// If `true`, report which fields/views exist and which are missing without
     /// creating anything. Defaults to `false`.
     pub dry_run: Option<bool>,
 }
 
 /// Result returned by the `setup` MCP tool.
 ///
-/// Contains the canonical names of fields that were created, skipped, and
-/// (in dry-run mode) missing, plus the project's GraphQL node ID for reference.
+/// Contains the canonical names of fields and views that were created,
+/// already existed, or (in dry-run mode) are missing, plus the project number.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct SetupResult {
     /// Canonical names of fields that were newly created (e.g. `["Agent", "DeferUntil"]`).
     pub fields_created: Vec<String>,
     /// Canonical names of fields that already existed and were skipped.
-    pub fields_skipped: Vec<String>,
+    pub fields_existing: Vec<String>,
     /// Canonical names of fields that are missing and would be created by a
     /// non-dry-run call. Always empty when `dry_run` is `false` (the fields
     /// were already created).
     pub fields_missing: Vec<String>,
-    /// The GraphQL node ID of the project.
-    pub project_id: String,
+    /// Names of views that were newly created (e.g. `["://ready", "://team"]`).
+    pub views_created: Vec<String>,
+    /// Names of views that already existed and were skipped.
+    pub views_existing: Vec<String>,
+    /// The project number.
+    pub project_number: u64,
+    /// Whether this was a dry-run (no mutations were performed).
+    pub dry_run: bool,
 }
+
+/// Specification for a required project view.
+///
+/// Used internally by the setup handler to define the 5 pre-configured views.
+#[derive(Debug, Clone)]
+pub(crate) struct ViewSpec {
+    /// View display name (e.g. `"://ready"`).
+    pub name: &'static str,
+    /// View layout type.
+    pub layout: ViewLayout,
+    /// Optional filter query string.
+    pub filter: Option<&'static str>,
+}
+
+/// The 5 pre-configured views required by the setup tool.
+///
+/// Each view follows the naming convention `://name` to distinguish
+/// unblock-managed views from user-created ones.
+pub(crate) const REQUIRED_VIEWS: &[ViewSpec] = &[
+    ViewSpec {
+        name: "://ready",
+        layout: ViewLayout::Board,
+        filter: Some("\"Ready State\":\"ready\""),
+    },
+    ViewSpec {
+        name: "://team",
+        layout: ViewLayout::Board,
+        filter: None,
+    },
+    ViewSpec {
+        name: "://pipeline",
+        layout: ViewLayout::Table,
+        filter: None,
+    },
+    ViewSpec {
+        name: "://roadmap",
+        layout: ViewLayout::Roadmap,
+        filter: None,
+    },
+    ViewSpec {
+        name: "://timeline",
+        layout: ViewLayout::Roadmap,
+        filter: None,
+    },
+];

--- a/crates/unblock-mcp/src/tools/setup.rs
+++ b/crates/unblock-mcp/src/tools/setup.rs
@@ -55,9 +55,11 @@ pub struct SetupResult {
 
 /// Specification for a required project view.
 ///
-/// Used internally by the setup handler to define the 5 pre-configured views.
+/// Defines the name, layout, and optional filter for each view that the
+/// setup tool creates on a project. The 5 required views are defined in
+/// [`REQUIRED_VIEWS`].
 #[derive(Debug, Clone)]
-pub(crate) struct ViewSpec {
+pub struct ViewSpec {
     /// View display name (e.g. `"://ready"`).
     pub name: &'static str,
     /// View layout type.
@@ -70,7 +72,7 @@ pub(crate) struct ViewSpec {
 ///
 /// Each view follows the naming convention `://name` to distinguish
 /// unblock-managed views from user-created ones.
-pub(crate) const REQUIRED_VIEWS: &[ViewSpec] = &[
+pub const REQUIRED_VIEWS: &[ViewSpec] = &[
     ViewSpec {
         name: "://ready",
         layout: ViewLayout::Board,

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -14,6 +14,7 @@ use unblock_core::types::{
     BlockingEdge, IssueRef, IssueState, IssueType, Priority, ReadyState, Status,
 };
 use unblock_github::client::GitHubClient;
+use unblock_github::projects::OwnerType;
 use unblock_mcp::server::ServerState;
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -1041,4 +1042,387 @@ async fn create_issue_appears_in_ready_set_after_rebuild() {
     let _ = client
         .close_issue(issue.number, Some("test cleanup".to_owned()))
         .await;
+}
+
+// ── Setup tool: integration tests ────────────────────────────────────
+
+/// Returns `true` if the `UNBLOCK_PROJECT` env var is set and non-empty.
+fn has_project_number() -> bool {
+    std::env::var("UNBLOCK_PROJECT")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+/// Setup creates all 7 required fields on first run.
+///
+/// Verifies that `setup_fields()` returns `created` entries for any fields
+/// that did not already exist, and that the total resolved field count is 7.
+#[tokio::test]
+async fn setup_creates_fields_on_first_run() {
+    if !has_github_token() || !has_project_number() {
+        eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
+        return;
+    }
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let project_info = client
+        .resolve_project_info()
+        .await
+        .expect("resolve_project_info should succeed");
+
+    let report = client
+        .setup_fields(&project_info.id)
+        .await
+        .expect("setup_fields should succeed");
+
+    // Total fields (created + skipped) should be 7.
+    let total = report.created.len() + report.skipped.len();
+    assert_eq!(
+        total, 7,
+        "setup should resolve exactly 7 fields, got {total}"
+    );
+
+    eprintln!(
+        "setup_creates_fields: created={:?}, skipped={:?}",
+        report.created, report.skipped
+    );
+}
+
+/// Setup is idempotent — rerun creates no duplicate fields.
+///
+/// Calls `setup_fields()` twice. The second call should report all fields
+/// as skipped (already existing) with zero created.
+#[tokio::test]
+async fn setup_fields_idempotent_no_duplicates() {
+    if !has_github_token() || !has_project_number() {
+        eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
+        return;
+    }
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let project_info = client
+        .resolve_project_info()
+        .await
+        .expect("resolve_project_info should succeed");
+
+    // First run — ensure all fields exist.
+    let _ = client
+        .setup_fields(&project_info.id)
+        .await
+        .expect("setup_fields (first run) should succeed");
+
+    // Second run — all should be skipped.
+    let report2 = client
+        .setup_fields(&project_info.id)
+        .await
+        .expect("setup_fields (second run) should succeed");
+
+    assert!(
+        report2.created.is_empty(),
+        "second setup_fields should create zero fields, got: {:?}",
+        report2.created
+    );
+    assert_eq!(
+        report2.skipped.len(),
+        7,
+        "second setup_fields should skip all 7 fields"
+    );
+
+    eprintln!("setup_fields_idempotent: skipped={:?}", report2.skipped);
+}
+
+/// Setup creates 5 views with correct layout and filter values.
+///
+/// Calls `create_view()` for each required view spec and verifies the
+/// returned view has the expected layout.
+#[tokio::test]
+async fn setup_creates_views_with_correct_layout() {
+    if !has_github_token() || !has_project_number() {
+        eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
+        return;
+    }
+
+    use unblock_github::projects::{CreateViewParams, ViewLayout};
+    use unblock_mcp::tools::setup::REQUIRED_VIEWS;
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let owner_type = client
+        .detect_owner_type()
+        .await
+        .expect("detect_owner_type should succeed");
+
+    // Get existing views to determine what would be created.
+    let existing_views = client
+        .list_views(owner_type)
+        .await
+        .expect("list_views should succeed");
+
+    let existing_names: std::collections::HashSet<String> =
+        existing_views.iter().map(|v| v.name.clone()).collect();
+
+    // Get REST fields for visible_fields.
+    let rest_fields = client
+        .list_rest_fields(owner_type)
+        .await
+        .expect("list_rest_fields should succeed");
+    let all_field_ids: Vec<u64> = rest_fields.iter().map(|f| f.id).collect();
+
+    let mut created_count = 0;
+    let mut skipped_count = 0;
+
+    for spec in REQUIRED_VIEWS {
+        if existing_names.contains(spec.name) {
+            skipped_count += 1;
+            continue;
+        }
+
+        let visible_fields = if spec.layout == ViewLayout::Roadmap {
+            None
+        } else {
+            Some(all_field_ids.clone())
+        };
+
+        let params = CreateViewParams {
+            name: spec.name.to_owned(),
+            layout: spec.layout,
+            filter: spec.filter.map(String::from),
+            visible_fields,
+        };
+
+        let view = client
+            .create_view(owner_type, &params)
+            .await
+            .unwrap_or_else(|e| panic!("create_view({}) should succeed: {e}", spec.name));
+
+        assert_eq!(
+            view.layout, spec.layout,
+            "layout mismatch for {}",
+            spec.name
+        );
+        created_count += 1;
+    }
+
+    eprintln!("setup_creates_views: created={created_count}, skipped={skipped_count}");
+}
+
+/// Views are idempotent — rerun creates no duplicate views.
+///
+/// After the views exist, calling list_views should show all 5 required
+/// view names present.
+#[tokio::test]
+async fn setup_views_idempotent_no_duplicates() {
+    if !has_github_token() || !has_project_number() {
+        eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
+        return;
+    }
+
+    use unblock_mcp::tools::setup::REQUIRED_VIEWS;
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let owner_type = client
+        .detect_owner_type()
+        .await
+        .expect("detect_owner_type should succeed");
+
+    let existing_views = client
+        .list_views(owner_type)
+        .await
+        .expect("list_views should succeed");
+
+    let existing_names: std::collections::HashSet<String> =
+        existing_views.iter().map(|v| v.name.clone()).collect();
+
+    let mut found = 0;
+    for spec in REQUIRED_VIEWS {
+        if existing_names.contains(spec.name) {
+            found += 1;
+        }
+    }
+
+    eprintln!(
+        "setup_views_idempotent: {found}/{} required views found in existing views",
+        REQUIRED_VIEWS.len()
+    );
+}
+
+/// Dry-run returns fields/views report without making mutations.
+///
+/// Calls `query_setup_status()` and `list_views()` (the dry-run path)
+/// and verifies the report is well-formed without creating anything.
+#[tokio::test]
+async fn setup_dry_run_reports_without_mutations() {
+    if !has_github_token() || !has_project_number() {
+        eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
+        return;
+    }
+
+    use unblock_mcp::tools::setup::REQUIRED_VIEWS;
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let project_info = client
+        .resolve_project_info()
+        .await
+        .expect("resolve_project_info should succeed");
+
+    // Query field status (dry-run path).
+    let field_status = client
+        .query_setup_status(&project_info.id)
+        .await
+        .expect("query_setup_status should succeed");
+
+    let total_fields = field_status.existing.len() + field_status.missing.len();
+    assert_eq!(
+        total_fields, 7,
+        "dry-run field status should account for all 7 fields"
+    );
+
+    // Query view status (dry-run path).
+    let owner_type = client
+        .detect_owner_type()
+        .await
+        .expect("detect_owner_type should succeed");
+
+    let existing_views = client
+        .list_views(owner_type)
+        .await
+        .expect("list_views should succeed");
+
+    let existing_view_names: std::collections::HashSet<String> =
+        existing_views.iter().map(|v| v.name.clone()).collect();
+
+    let mut would_create = 0;
+    let mut already_exist = 0;
+    for spec in REQUIRED_VIEWS {
+        if existing_view_names.contains(spec.name) {
+            already_exist += 1;
+        } else {
+            would_create += 1;
+        }
+    }
+
+    eprintln!(
+        "setup_dry_run: fields existing={}, missing={}; views existing={already_exist}, would_create={would_create}",
+        field_status.existing.len(),
+        field_status.missing.len(),
+    );
+}
+
+/// No project configured returns `ProjectNotConfigured` error.
+///
+/// Uses a client without `UNBLOCK_PROJECT` set and verifies that
+/// `resolve_project_info()` fails with the expected error.
+#[tokio::test]
+async fn setup_no_project_returns_project_not_configured() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    // Build a config without UNBLOCK_PROJECT.
+    let config = Config::load_from(|key| match key {
+        "UNBLOCK_PROJECT" => Err(std::env::VarError::NotPresent),
+        other => std::env::var(other),
+    })
+    .expect("Config should load without UNBLOCK_PROJECT");
+
+    let client = GitHubClient::new(&config)
+        .await
+        .expect("GitHubClient::new should succeed");
+
+    // resolve_project_info should fail with ProjectNotConfigured.
+    let result = client.resolve_project_info().await;
+    assert!(
+        result.is_err(),
+        "resolve_project_info should fail without project number"
+    );
+
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("setup") || msg.contains("project") || msg.contains("configured"),
+        "error should reference project configuration: {msg}",
+    );
+
+    eprintln!("setup_no_project: error = {msg}");
+}
+
+/// Owner type detection correctly identifies org vs user accounts.
+///
+/// This test verifies that `detect_owner_type()` returns a valid
+/// `OwnerType` for the configured repository owner.
+#[tokio::test]
+async fn setup_owner_type_detection_works() {
+    if !has_github_token() {
+        eprintln!("GITHUB_TOKEN not set — skipping integration test");
+        return;
+    }
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let owner_type = client
+        .detect_owner_type()
+        .await
+        .expect("detect_owner_type should succeed");
+
+    // Just verify it returns a valid value — the actual type depends on the
+    // test repo's owner.
+    match owner_type {
+        OwnerType::Org => eprintln!("Owner '{}' is an organization", client.owner()),
+        OwnerType::User => eprintln!("Owner '{}' is a personal account", client.owner()),
+    }
+}
+
+/// Views use correct visible_fields integer IDs from list_rest_fields.
+///
+/// Verifies that `list_rest_fields()` returns fields with positive integer
+/// IDs that are suitable for use as `visible_fields` in view creation.
+#[tokio::test]
+async fn setup_visible_fields_use_integer_ids() {
+    if !has_github_token() || !has_project_number() {
+        eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
+        return;
+    }
+
+    let state = test_server_state().await;
+    let client = &state.client;
+
+    let owner_type = client
+        .detect_owner_type()
+        .await
+        .expect("detect_owner_type should succeed");
+
+    let fields = client
+        .list_rest_fields(owner_type)
+        .await
+        .expect("list_rest_fields should succeed");
+
+    assert!(
+        !fields.is_empty(),
+        "list_rest_fields should return at least one field"
+    );
+
+    for field in &fields {
+        assert!(
+            field.id > 0,
+            "field ID should be a positive integer, got {}",
+            field.id
+        );
+    }
+
+    eprintln!(
+        "setup_visible_fields: {} fields with IDs {:?}",
+        fields.len(),
+        fields.iter().map(|f| f.id).collect::<Vec<_>>()
+    );
 }

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -1243,8 +1243,11 @@ async fn setup_views_idempotent_no_duplicates() {
         }
     }
 
-    eprintln!(
-        "setup_views_idempotent: {found}/{} required views found in existing views",
+    assert_eq!(
+        found,
+        REQUIRED_VIEWS.len(),
+        "Expected all {} required views to exist after setup, but only {found} found. \
+         Missing views indicate setup did not create them or idempotency check failed.",
         REQUIRED_VIEWS.len()
     );
 }

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -14,8 +14,9 @@ use unblock_core::types::{
     BlockingEdge, IssueRef, IssueState, IssueType, Priority, ReadyState, Status,
 };
 use unblock_github::client::GitHubClient;
-use unblock_github::projects::OwnerType;
+use unblock_github::projects::{CreateViewParams, OwnerType, ViewLayout};
 use unblock_mcp::server::ServerState;
+use unblock_mcp::tools::setup::REQUIRED_VIEWS;
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -1146,9 +1147,6 @@ async fn setup_creates_views_with_correct_layout() {
         return;
     }
 
-    use unblock_github::projects::{CreateViewParams, ViewLayout};
-    use unblock_mcp::tools::setup::REQUIRED_VIEWS;
-
     let state = test_server_state().await;
     let client = &state.client;
 
@@ -1213,7 +1211,7 @@ async fn setup_creates_views_with_correct_layout() {
 
 /// Views are idempotent — rerun creates no duplicate views.
 ///
-/// After the views exist, calling list_views should show all 5 required
+/// After the views exist, calling `list_views` should show all 5 required
 /// view names present.
 #[tokio::test]
 async fn setup_views_idempotent_no_duplicates() {
@@ -1221,8 +1219,6 @@ async fn setup_views_idempotent_no_duplicates() {
         eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
         return;
     }
-
-    use unblock_mcp::tools::setup::REQUIRED_VIEWS;
 
     let state = test_server_state().await;
     let client = &state.client;
@@ -1263,8 +1259,6 @@ async fn setup_dry_run_reports_without_mutations() {
         eprintln!("GITHUB_TOKEN or UNBLOCK_PROJECT not set — skipping integration test");
         return;
     }
-
-    use unblock_mcp::tools::setup::REQUIRED_VIEWS;
 
     let state = test_server_state().await;
     let client = &state.client;
@@ -1383,7 +1377,7 @@ async fn setup_owner_type_detection_works() {
     }
 }
 
-/// Views use correct visible_fields integer IDs from list_rest_fields.
+/// Views use correct `visible_fields` integer IDs from `list_rest_fields`.
 ///
 /// Verifies that `list_rest_fields()` returns fields with positive integer
 /// IDs that are suitable for use as `visible_fields` in view creation.


### PR DESCRIPTION
Expand the setup MCP tool to create 5 pre-configured project views
(://ready, ://team, ://pipeline, ://roadmap, ://timeline) in addition
to the existing 7 field setup. Add owner type detection, REST field
discovery for visible_fields, and dry-run support for views.

Key changes:
- SetupParams.project type changed from Option<u32> to Option<u64>
- SetupResult: renamed fields_skipped to fields_existing, added
  views_created, views_existing, project_number, dry_run fields;
  removed project_id
- Added ViewSpec struct and REQUIRED_VIEWS const for view definitions
- Roadmap views skip visible_fields (not supported per ARCH §8.5)
- Dry-run queries both fields and views without mutations