### PR TITLE
feat: implement claim MCP tool for atomic issue claiming

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use crate::tools::claim::{ClaimParams, ClaimResult};
 use crate::tools::create::{CreateParams, CreateResult};
 use crate::tools::execute_read_tool;
 use crate::tools::execute_write_tool;
@@ -694,6 +695,185 @@ impl UnblockServer {
             count,
             stale,
         }))
+    }
+
+    /// Claim an issue for an agent — marks it as in-progress.
+    ///
+    /// Validates the issue is open, unblocked, not deferred, and not already
+    /// claimed. Then updates Projects V2 fields (Status=In Progress, Agent=name,
+    /// ReadyState=Not Ready) and posts a claim comment.
+    ///
+    /// Validation order (cheapest first): closed, blocked, deferred, already claimed.
+    ///
+    /// This is a write tool — the cache is invalidated and rebuilt after all
+    /// mutations complete.
+    #[tool(
+        name = "claim",
+        description = "Claim an issue for an agent. Validates the issue is open, unblocked, not deferred, and not already claimed. Sets Status=In Progress, Agent=name, ReadyState=Not Ready, and posts a comment. Triggers graph rebuild."
+    )]
+    async fn claim(
+        &self,
+        Parameters(params): Parameters<ClaimParams>,
+    ) -> Result<Json<ClaimResult>, ErrorData> {
+        let state = self.state();
+        let client = Arc::clone(&state.client);
+        let config = Arc::clone(&state.config);
+
+        let issue_number = params.id;
+        let agent_name = params.agent.unwrap_or_else(|| config.agent.clone());
+
+        info!(
+            issue_number,
+            agent = %agent_name,
+            "Claim tool invoked"
+        );
+
+        let result = execute_write_tool(state, || {
+            let client = Arc::clone(&client);
+            let agent_name = agent_name.clone();
+
+            async move {
+                use chrono::Utc;
+                use unblock_core::errors::{
+                    AlreadyClaimedSnafu, IssueBlockedSnafu, IssueClosedSnafu, IssueDeferredSnafu,
+                };
+                use unblock_core::types::IssueState;
+
+                // Step 1: Fetch the issue.
+                let issue = client.fetch_issue(issue_number).await?;
+
+                // Step 2: Validate — closed (cheapest check).
+                if issue.state == IssueState::Closed {
+                    return Err(IssueClosedSnafu {
+                        number: issue_number,
+                    }
+                    .build()
+                    .into());
+                }
+
+                // Step 3: Validate — blocked (check open blockers).
+                let open_blockers: Vec<u64> = issue
+                    .blocked_by
+                    .iter()
+                    .filter(|r| r.state == IssueState::Open)
+                    .map(|r| r.number)
+                    .collect();
+
+                if !open_blockers.is_empty() {
+                    return Err(IssueBlockedSnafu {
+                        number: issue_number,
+                        blockers: open_blockers,
+                    }
+                    .build()
+                    .into());
+                }
+
+                // Step 4: Validate — deferred.
+                if let Some(defer_until) = issue.defer_until {
+                    let today = Utc::now().date_naive();
+                    if defer_until > today {
+                        return Err(IssueDeferredSnafu {
+                            number: issue_number,
+                            until: defer_until.to_string(),
+                        }
+                        .build()
+                        .into());
+                    }
+                }
+
+                // Step 5: Validate — already claimed.
+                if issue.status == unblock_core::types::Status::InProgress && issue.agent.is_some()
+                {
+                    return Err(AlreadyClaimedSnafu {
+                        number: issue_number,
+                        agent: issue.agent.unwrap_or_default(),
+                    }
+                    .build()
+                    .into());
+                }
+
+                // Step 6: Update Projects V2 fields.
+                if let Some(field_ids) = client.field_ids().await {
+                    if let Ok(project_info) = client.resolve_project_info().await {
+                        if let Ok(item_id) = client
+                            .get_project_item_id(&issue.node_id, &project_info.id)
+                            .await
+                        {
+                            use unblock_github::projects::FieldValue;
+
+                            // Status -> In Progress
+                            if let Some(option_id) = field_ids.status.options.get("In Progress")
+                                && let Err(e) = client
+                                    .update_field(
+                                        &project_info.id,
+                                        &item_id,
+                                        &field_ids.status.field_id,
+                                        &FieldValue::SingleSelectOption(option_id.clone()),
+                                    )
+                                    .await
+                            {
+                                tracing::warn!(error = %e, "Failed to set Status field");
+                            }
+
+                            // Agent -> agent_name
+                            if let Err(e) = client
+                                .update_field(
+                                    &project_info.id,
+                                    &item_id,
+                                    &field_ids.agent,
+                                    &FieldValue::Text(agent_name.clone()),
+                                )
+                                .await
+                            {
+                                tracing::warn!(error = %e, "Failed to set Agent field");
+                            }
+
+                            // ReadyState -> Not Ready
+                            if let Some(option_id) = field_ids.ready_state.options.get("Not Ready")
+                                && let Err(e) = client
+                                    .update_field(
+                                        &project_info.id,
+                                        &item_id,
+                                        &field_ids.ready_state.field_id,
+                                        &FieldValue::SingleSelectOption(option_id.clone()),
+                                    )
+                                    .await
+                            {
+                                tracing::warn!(error = %e, "Failed to set ReadyState field");
+                            }
+                        } else {
+                            tracing::warn!(
+                                "Failed to get project item ID — fields will not be set"
+                            );
+                        }
+                    } else {
+                        tracing::warn!("Failed to resolve project info — fields will not be set");
+                    }
+                } else {
+                    tracing::debug!(
+                        "No field IDs cached — run setup first to enable project field assignment"
+                    );
+                }
+
+                // Step 7: Post claim comment.
+                let now = Utc::now();
+                let comment_body =
+                    format!("\u{1F916} Claimed by {agent_name} at {}", now.to_rfc3339());
+                if let Err(e) = client.add_comment(issue_number, comment_body).await {
+                    tracing::warn!(error = %e, "Failed to post claim comment");
+                }
+
+                // Step 8: Return result (cache rebuild handled by execute_write_tool).
+                Ok(ClaimResult {
+                    issue_number,
+                    agent: agent_name,
+                    claimed_at: now,
+                })
+            }
+        })
+        .await?;
+
+        Ok(Json(result))
     }
 
     /// Create a new GitHub Issue with optional dependencies, project fields,

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -14,7 +14,9 @@
 
 use std::sync::Arc;
 
-use crate::tools::claim::{ClaimParams, ClaimResult};
+use chrono::Utc;
+
+use crate::tools::claim::{ClaimCandidate, ClaimParams, ClaimResult, validate_claimable};
 use crate::tools::create::{CreateParams, CreateResult};
 use crate::tools::execute_read_tool;
 use crate::tools::execute_write_tool;
@@ -733,9 +735,6 @@ impl UnblockServer {
             let agent_name = agent_name.clone();
 
             async move {
-                use crate::tools::claim::{ClaimCandidate, validate_claimable};
-                use chrono::Utc;
-
                 // Step 1: Fetch the issue.
                 let issue = client.fetch_issue(issue_number).await?;
 

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -733,64 +733,22 @@ impl UnblockServer {
             let agent_name = agent_name.clone();
 
             async move {
+                use crate::tools::claim::{ClaimCandidate, validate_claimable};
                 use chrono::Utc;
-                use unblock_core::errors::{
-                    AlreadyClaimedSnafu, IssueBlockedSnafu, IssueClosedSnafu, IssueDeferredSnafu,
-                };
-                use unblock_core::types::IssueState;
 
                 // Step 1: Fetch the issue.
                 let issue = client.fetch_issue(issue_number).await?;
 
-                // Step 2: Validate — closed (cheapest check).
-                if issue.state == IssueState::Closed {
-                    return Err(IssueClosedSnafu {
-                        number: issue_number,
-                    }
-                    .build()
-                    .into());
-                }
-
-                // Step 3: Validate — blocked (check open blockers).
-                let open_blockers: Vec<u64> = issue
-                    .blocked_by
-                    .iter()
-                    .filter(|r| r.state == IssueState::Open)
-                    .map(|r| r.number)
-                    .collect();
-
-                if !open_blockers.is_empty() {
-                    return Err(IssueBlockedSnafu {
-                        number: issue_number,
-                        blockers: open_blockers,
-                    }
-                    .build()
-                    .into());
-                }
-
-                // Step 4: Validate — deferred.
-                if let Some(defer_until) = issue.defer_until {
-                    let today = Utc::now().date_naive();
-                    if defer_until > today {
-                        return Err(IssueDeferredSnafu {
-                            number: issue_number,
-                            until: defer_until.to_string(),
-                        }
-                        .build()
-                        .into());
-                    }
-                }
-
-                // Step 5: Validate — already claimed.
-                if issue.status == unblock_core::types::Status::InProgress && issue.agent.is_some()
-                {
-                    return Err(AlreadyClaimedSnafu {
-                        number: issue_number,
-                        agent: issue.agent.unwrap_or_default(),
-                    }
-                    .build()
-                    .into());
-                }
+                // Steps 2–5: Validate claimability (closed, blocked, deferred, already claimed).
+                let candidate = ClaimCandidate {
+                    number: issue.number,
+                    state: issue.state,
+                    status: issue.status,
+                    agent: issue.agent.clone(),
+                    blocked_by: issue.blocked_by.clone(),
+                    defer_until: issue.defer_until,
+                };
+                validate_claimable(&candidate, Utc::now().date_naive())?;
 
                 // Step 6: Update Projects V2 fields.
                 if let Some(field_ids) = client.field_ids().await {

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -1,0 +1,36 @@
+//! Claim tool — atomically claims an issue for an agent.
+//!
+//! Validates the issue is open, unblocked, not deferred, and not already claimed,
+//! then updates Projects V2 fields (Status=In Progress, Agent=name,
+//! ReadyState=Not Ready) and posts a claim comment. Uses `execute_write_tool()`
+//! to rebuild the cache after all mutations complete.
+
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Input parameters for the `claim` MCP tool.
+///
+/// Only `id` is required. If `agent` is not provided, falls back to
+/// `Config.agent` (from `UNBLOCK_AGENT`), then `"unknown"`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ClaimParams {
+    /// Issue number to claim (required).
+    pub id: u64,
+    /// Agent name claiming the issue. Defaults to the configured agent name.
+    pub agent: Option<String>,
+}
+
+/// Result returned by the `claim` MCP tool.
+///
+/// Contains the claimed issue number, the resolved agent name, and the
+/// timestamp when the claim was recorded.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ClaimResult {
+    /// The claimed issue number.
+    pub issue_number: u64,
+    /// The agent name that claimed the issue.
+    pub agent: String,
+    /// Timestamp when the claim was recorded (ISO 8601).
+    pub claimed_at: DateTime<Utc>,
+}

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -116,10 +116,12 @@ pub(crate) fn validate_claimable(
     }
 
     // Check 4: already claimed.
-    if candidate.status == Status::InProgress && candidate.agent.is_some() {
+    if let Some(ref agent) = candidate.agent
+        && candidate.status == Status::InProgress
+    {
         return Err(AlreadyClaimedSnafu {
             number: candidate.number,
-            agent: candidate.agent.clone().unwrap_or_default(),
+            agent: agent.clone(),
         }
         .build()
         .into());

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -130,6 +130,9 @@ pub(crate) fn validate_claimable(
     Ok(())
 }
 
+// TODO(unblock-45a.12): Add integration tests for claim tool (ready, blocked, closed, deferred,
+// already-claimed paths) as part of the E2E workflow integration test.
+
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -4,10 +4,17 @@
 //! then updates Projects V2 fields (Status=In Progress, Agent=name,
 //! ReadyState=Not Ready) and posts a claim comment. Uses `execute_write_tool()`
 //! to rebuild the cache after all mutations complete.
+//!
+//! The validation logic is extracted into `validate_claimable` so it can be
+//! unit tested without a GitHub client.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use unblock_core::errors::{
+    AlreadyClaimedSnafu, IssueBlockedSnafu, IssueClosedSnafu, IssueDeferredSnafu,
+};
+use unblock_core::types::{IssueState, RelatedIssue, Status};
 
 /// Input parameters for the `claim` MCP tool.
 ///
@@ -33,4 +40,280 @@ pub struct ClaimResult {
     pub agent: String,
     /// Timestamp when the claim was recorded (ISO 8601).
     pub claimed_at: DateTime<Utc>,
+}
+
+/// Snapshot of the fields needed to validate whether an issue can be claimed.
+///
+/// Extracted from [`Issue`](unblock_core::types::Issue) to decouple validation
+/// from the full issue type and the GitHub client.
+pub(crate) struct ClaimCandidate {
+    /// Issue number.
+    pub number: u64,
+    /// GitHub native issue state (Open/Closed).
+    pub state: IssueState,
+    /// Workflow status from Projects V2.
+    pub status: Status,
+    /// Agent name if already claimed.
+    pub agent: Option<String>,
+    /// Issues blocking this issue.
+    pub blocked_by: Vec<RelatedIssue>,
+    /// Date until which the issue is deferred.
+    pub defer_until: Option<NaiveDate>,
+}
+
+/// Validates that an issue can be claimed.
+///
+/// Checks are performed in order of cost (cheapest first):
+/// 1. Issue must be open (not closed).
+/// 2. Issue must have no open blockers.
+/// 3. Issue must not be deferred beyond today.
+/// 4. Issue must not already be claimed (In Progress with an agent).
+///
+/// # Errors
+///
+/// Returns an `unblock_github::errors::Error` (wrapping a domain error) if
+/// any validation check fails.
+pub(crate) fn validate_claimable(
+    candidate: &ClaimCandidate,
+    today: NaiveDate,
+) -> Result<(), unblock_github::errors::Error> {
+    // Check 1: closed (cheapest).
+    if candidate.state == IssueState::Closed {
+        return Err(IssueClosedSnafu {
+            number: candidate.number,
+        }
+        .build()
+        .into());
+    }
+
+    // Check 2: blocked (filter to open blockers).
+    let open_blockers: Vec<u64> = candidate
+        .blocked_by
+        .iter()
+        .filter(|r| r.state == IssueState::Open)
+        .map(|r| r.number)
+        .collect();
+
+    if !open_blockers.is_empty() {
+        return Err(IssueBlockedSnafu {
+            number: candidate.number,
+            blockers: open_blockers,
+        }
+        .build()
+        .into());
+    }
+
+    // Check 3: deferred.
+    if let Some(defer_until) = candidate.defer_until
+        && defer_until > today
+    {
+        return Err(IssueDeferredSnafu {
+            number: candidate.number,
+            until: defer_until.to_string(),
+        }
+        .build()
+        .into());
+    }
+
+    // Check 4: already claimed.
+    if candidate.status == Status::InProgress && candidate.agent.is_some() {
+        return Err(AlreadyClaimedSnafu {
+            number: candidate.number,
+            agent: candidate.agent.clone().unwrap_or_default(),
+        }
+        .build()
+        .into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+    use unblock_core::types::{IssueState, RelatedIssue, Status};
+
+    use super::*;
+
+    /// Build a minimal `ClaimCandidate` for a ready (claimable) issue.
+    fn ready_candidate(number: u64) -> ClaimCandidate {
+        ClaimCandidate {
+            number,
+            state: IssueState::Open,
+            status: Status::Open,
+            agent: None,
+            blocked_by: vec![],
+            defer_until: None,
+        }
+    }
+
+    /// Build a `RelatedIssue` for testing blockers.
+    fn blocker(number: u64, state: IssueState) -> RelatedIssue {
+        RelatedIssue {
+            number,
+            title: format!("Blocker #{number}"),
+            state,
+        }
+    }
+
+    fn today() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 3, 30).expect("valid date")
+    }
+
+    // ── Happy path ──────────────────────────────────────────────────
+
+    #[test]
+    fn open_unblocked_issue_is_claimable() {
+        let candidate = ready_candidate(1);
+        assert!(validate_claimable(&candidate, today()).is_ok());
+    }
+
+    #[test]
+    fn issue_with_only_closed_blockers_is_claimable() {
+        let mut candidate = ready_candidate(1);
+        candidate.blocked_by = vec![blocker(2, IssueState::Closed)];
+        assert!(validate_claimable(&candidate, today()).is_ok());
+    }
+
+    #[test]
+    fn issue_with_past_defer_until_is_claimable() {
+        let mut candidate = ready_candidate(1);
+        candidate.defer_until = Some(NaiveDate::from_ymd_opt(2026, 3, 29).expect("valid date"));
+        assert!(validate_claimable(&candidate, today()).is_ok());
+    }
+
+    #[test]
+    fn issue_with_today_defer_until_is_claimable() {
+        let mut candidate = ready_candidate(1);
+        candidate.defer_until = Some(today());
+        assert!(validate_claimable(&candidate, today()).is_ok());
+    }
+
+    #[test]
+    fn in_progress_issue_without_agent_is_claimable() {
+        let mut candidate = ready_candidate(1);
+        candidate.status = Status::InProgress;
+        candidate.agent = None;
+        assert!(validate_claimable(&candidate, today()).is_ok());
+    }
+
+    // ── Closed issue ────────────────────────────────────────────────
+
+    #[test]
+    fn closed_issue_returns_issue_closed_error() {
+        let mut candidate = ready_candidate(1);
+        candidate.state = IssueState::Closed;
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already closed"),
+            "expected IssueClosed error, got: {msg}"
+        );
+        assert!(msg.contains('1'));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    // ── Blocked issue ───────────────────────────────────────────────
+
+    #[test]
+    fn blocked_issue_returns_issue_blocked_error() {
+        let mut candidate = ready_candidate(5);
+        candidate.blocked_by = vec![blocker(2, IssueState::Open), blocker(3, IssueState::Open)];
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("blocked by"),
+            "expected IssueBlocked error, got: {msg}"
+        );
+        assert!(msg.contains('5'));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn blocked_by_mix_of_open_and_closed_returns_only_open_blockers() {
+        let mut candidate = ready_candidate(5);
+        candidate.blocked_by = vec![blocker(2, IssueState::Open), blocker(3, IssueState::Closed)];
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("blocked by"), "got: {msg}");
+        // The error should mention issue 2 (open) but we cannot easily parse the vec from Display.
+        // Just ensure it is an IssueBlocked error.
+        assert_eq!(err.status_code(), 409);
+    }
+
+    // ── Deferred issue ──────────────────────────────────────────────
+
+    #[test]
+    fn deferred_issue_returns_issue_deferred_error() {
+        let mut candidate = ready_candidate(7);
+        candidate.defer_until = Some(NaiveDate::from_ymd_opt(2026, 4, 15).expect("valid date"));
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("deferred"),
+            "expected IssueDeferred error, got: {msg}"
+        );
+        assert!(msg.contains("2026-04-15"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    // ── Already claimed issue ───────────────────────────────────────
+
+    #[test]
+    fn already_claimed_issue_returns_already_claimed_error() {
+        let mut candidate = ready_candidate(10);
+        candidate.status = Status::InProgress;
+        candidate.agent = Some("other-agent".to_owned());
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already claimed"),
+            "expected AlreadyClaimed error, got: {msg}"
+        );
+        assert!(msg.contains("other-agent"));
+        assert!(msg.contains("10"));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    // ── Validation order ────────────────────────────────────────────
+
+    #[test]
+    fn closed_takes_precedence_over_blocked() {
+        let mut candidate = ready_candidate(1);
+        candidate.state = IssueState::Closed;
+        candidate.blocked_by = vec![blocker(2, IssueState::Open)];
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already closed"),
+            "closed should take precedence over blocked, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn blocked_takes_precedence_over_deferred() {
+        let mut candidate = ready_candidate(1);
+        candidate.blocked_by = vec![blocker(2, IssueState::Open)];
+        candidate.defer_until = Some(NaiveDate::from_ymd_opt(2026, 4, 15).expect("valid date"));
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("blocked by"),
+            "blocked should take precedence over deferred, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn deferred_takes_precedence_over_already_claimed() {
+        let mut candidate = ready_candidate(1);
+        candidate.defer_until = Some(NaiveDate::from_ymd_opt(2026, 4, 15).expect("valid date"));
+        candidate.status = Status::InProgress;
+        candidate.agent = Some("bot".to_owned());
+        let err = validate_claimable(&candidate, today()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("deferred"),
+            "deferred should take precedence over already-claimed, got: {msg}"
+        );
+    }
 }

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -31,6 +31,7 @@
 //! ### Setup & Diagnostics (4)
 //! `init`, `setup`, `doctor`, `prime`
 
+pub mod claim;
 pub mod create;
 pub mod init;
 pub mod ready;


### PR DESCRIPTION
dd the claim tool that validates an issue is open, unblocked, not
deferred, and not already claimed before marking it as in-progress.

Validation order (cheapest first): closed, blocked, deferred, claimed.
On success: sets Status=In Progress, Agent=name, ReadyState=Not Ready
on the Projects V2 item and posts a claim comment with agent name and
timestamp. Cache is rebuilt via execute_write_tool after mutations.

ClaimedAt field write is skipped — it is not in ProjectFieldIds and
adding it is a cross-crate change tracked separately.

Files:
- crates/unblock-mcp/src/tools/claim.rs (NEW)
- crates/unblock-mcp/src/tools/mod.rs
- crates/unblock-mcp/src/server.rs