### PR TITLE
feat: implement comment MCP tool

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1486,7 +1486,7 @@ impl UnblockServer {
 
         // Step 3: Post the comment.
         let comment_url =
-            execute_read_tool(state, || client.add_comment(issue_number, body.clone())).await?;
+            execute_read_tool(state, || client.add_comment(issue_number, body)).await?;
 
         Ok(Json(CommentResult {
             issue_number,

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -18,6 +18,7 @@ use chrono::Utc;
 
 use crate::tools::claim::{ClaimCandidate, ClaimParams, ClaimResult, validate_claimable};
 use crate::tools::close::{CloseParams, CloseResult};
+use crate::tools::comment::{CommentParams, CommentResult};
 use crate::tools::create::{CreateParams, CreateResult};
 use crate::tools::depends::{DependsParams, DependsResult};
 use crate::tools::execute_read_tool;
@@ -84,8 +85,8 @@ unblock turns GitHub Issues into a dependency graph. Ask `ready` to get unblocke
 - Always call `ready` first to find unblocked work.
 - Use `claim` before starting work to prevent conflicts.
 - After `close`, dependents are automatically re-evaluated.
-- Write tools (create, close, update, comment, claim) trigger a graph rebuild.
-- Read tools (ready, show, depends) use the cache for fast responses.
+- Write tools (create, close, update, claim) trigger a graph rebuild.
+- Read tools (ready, show, depends, comment) use the cache for fast responses.
 - Bootstrap tools (init, setup) manage the project itself and do not affect the dependency graph.
 ";
 
@@ -1448,6 +1449,49 @@ impl UnblockServer {
         .await?;
 
         Ok(Json(result))
+    }
+
+    /// Post a comment on an issue.
+    ///
+    /// Validates that the body is non-empty and that the issue exists before
+    /// calling the GitHub API. This is a read tool from the graph perspective —
+    /// comments do not affect the dependency graph or ready set, so no cache
+    /// invalidation is needed.
+    #[tool(
+        name = "comment",
+        description = "Post a comment on an issue. Does not affect the dependency graph or ready set — no graph rebuild is triggered. Returns the URL of the new comment."
+    )]
+    async fn comment(
+        &self,
+        Parameters(params): Parameters<CommentParams>,
+    ) -> Result<Json<CommentResult>, ErrorData> {
+        let state = self.state();
+        let client = &state.client;
+        let issue_number = params.id;
+        let body = params.body;
+
+        info!(issue_number, "Comment tool invoked");
+
+        // Step 1: Validate body is non-empty (before any API call).
+        if body.trim().is_empty() {
+            return Err(ErrorData {
+                code: rmcp::model::ErrorCode::INVALID_PARAMS,
+                message: "Comment body must not be empty or whitespace-only".into(),
+                data: None,
+            });
+        }
+
+        // Step 2: Validate issue exists.
+        let _issue = execute_read_tool(state, || client.fetch_issue(issue_number)).await?;
+
+        // Step 3: Post the comment.
+        let comment_url =
+            execute_read_tool(state, || client.add_comment(issue_number, body.clone())).await?;
+
+        Ok(Json(CommentResult {
+            issue_number,
+            comment_url,
+        }))
     }
 }
 

--- a/crates/unblock-mcp/src/tools/comment.rs
+++ b/crates/unblock-mcp/src/tools/comment.rs
@@ -1,0 +1,33 @@
+//! Comment tool — posts a comment on an issue.
+//!
+//! This is a read tool from the graph perspective: comments do not affect
+//! the dependency graph or ready set, so no cache invalidation is needed.
+//! Uses `execute_read_tool()` despite being a write to GitHub.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Input parameters for the `comment` MCP tool.
+///
+/// Requires both an issue number and a non-empty comment body.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CommentParams {
+    /// Issue number to comment on (required).
+    pub id: u64,
+    /// Comment body text (required, must not be empty or whitespace-only).
+    pub body: String,
+}
+
+/// Result returned by the `comment` MCP tool.
+///
+/// Contains the issue number and a URL pointing to the newly created comment.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CommentResult {
+    /// The issue number the comment was posted on.
+    pub issue_number: u64,
+    /// URL of the newly created comment on GitHub.
+    pub comment_url: String,
+}
+
+// TODO(unblock-45a.12): Add integration tests for comment tool (existing issue,
+// non-existent issue, empty body) as part of the E2E workflow integration test.

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -33,6 +33,7 @@
 
 pub mod claim;
 pub mod close;
+pub mod comment;
 pub mod create;
 pub mod depends;
 pub mod init;


### PR DESCRIPTION
Add the comment tool that posts a comment on an issue via the GitHub API. Uses execute_read_tool() pattern since comments do not affect the dependency graph or ready set — no cache invalidation is triggered.

Validates body is non-empty before any API call, then validates issue exists via fetch_issue, and finally calls add_comment to post the comment.

Also fixes INSTRUCTIONS_STR to correctly classify comment as a read tool (does not trigger graph rebuild).