### PR TITLE
fix: wire milestone param to REST API in create tool

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1340,20 +1340,40 @@ impl UnblockServer {
                     client.ensure_labels(&labels).await?;
                 }
 
-                // Step 2: Log milestone if provided (not yet resolved to ID).
-                if let Some(ref ms) = milestone_title {
-                    tracing::warn!(
-                        milestone = %ms,
-                        "Milestone resolution from title to ID is not yet implemented — milestone will not be set on the issue"
-                    );
-                }
+                // Step 2: Resolve milestone title to milestone number.
+                let milestone_number = if let Some(ref ms_title) = milestone_title {
+                    match client.list_milestones().await {
+                        Ok(milestones) => {
+                            if let Some(ms) = milestones.iter().find(|m| m.title == *ms_title) {
+                                Some(ms.number)
+                            } else {
+                                tracing::warn!(
+                                    milestone = %ms_title,
+                                    "Milestone not found — milestone will not be set on the issue"
+                                );
+                                None
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                milestone = %ms_title,
+                                "Failed to list milestones (best-effort) — milestone will not be set on the issue"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                let milestone_set = milestone_number.is_some();
 
                 // Step 3: Create the issue.
                 let create_params = unblock_github::mutations::CreateIssueParams {
                     title,
                     body,
                     labels,
-                    milestone: None, // Milestone ID resolution not yet implemented.
+                    milestone: milestone_number,
                     assignees: Vec::new(),
                 };
 
@@ -1463,6 +1483,7 @@ impl UnblockServer {
                     fields_attempted,
                     blockers_added,
                     parent_set,
+                    milestone_set,
                     hint: format!(
                         "Issue #{issue_number} created. Use `show` to verify or `ready` to check if it appears in the ready set."
                     ),

--- a/crates/unblock-mcp/src/tools/create.rs
+++ b/crates/unblock-mcp/src/tools/create.rs
@@ -24,8 +24,9 @@ pub struct CreateParams {
     pub body: Option<String>,
     /// Labels to attach. Labels that do not exist on the repo are created.
     pub labels: Option<Vec<String>>,
-    /// Milestone title. Currently accepted but not resolved to a milestone ID
-    /// (milestone resolution requires a separate API call not yet implemented).
+    /// Milestone title. Resolved to a milestone number via `list_milestones()`.
+    /// If the title is not found among open milestones, a warning is logged and
+    /// the issue is created without a milestone.
     pub milestone: Option<String>,
     /// Issues that block this new issue. Accepts local numbers (`42`) or
     /// cross-repo references (`owner/repo#42`).
@@ -41,6 +42,7 @@ pub struct CreateParams {
 /// Result returned by the `create` MCP tool.
 ///
 /// Contains the created issue number, URL, and a summary of what was set.
+#[allow(clippy::struct_excessive_bools)] // Result struct — bools report discrete outcomes.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct CreateResult {
     /// The created issue number.
@@ -62,6 +64,8 @@ pub struct CreateResult {
     pub blockers_added: u32,
     /// Whether a parent relationship was created.
     pub parent_set: bool,
+    /// Whether a milestone was successfully resolved and set on the issue.
+    pub milestone_set: bool,
     /// Hint message for next steps.
     pub hint: String,
 }


### PR DESCRIPTION
Resolve milestone title to milestone number via list_milestones() before passing it to CreateIssueParams, matching the pattern already used by the update tool handler. Milestone resolution is best-effort: if the title is not found or list_milestones() fails, a warning is logged and the issue is created without a milestone.

- Replace warning-only stub with actual milestone resolution logic
- Add milestone_set: bool field to CreateResult for reporting
- Update stale doc comment on CreateParams.milestone
- Allow clippy::struct_excessive_bools on CreateResult (report struct)