### PR TITLE
chore: wire parent and sub_issues into ShowResult and ShowIssue

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -598,6 +598,23 @@ impl UnblockServer {
             })
             .collect();
 
+        // Step 3b: Extract parent and sub-issues from the issue.
+        let parent: Option<ShowRelatedIssue> = issue.parent.as_ref().map(|r| ShowRelatedIssue {
+            number: r.number,
+            title: r.title.clone(),
+            state: format!("{:?}", r.state),
+        });
+
+        let sub_issues: Vec<ShowRelatedIssue> = issue
+            .sub_issues
+            .iter()
+            .map(|r| ShowRelatedIssue {
+                number: r.number,
+                title: r.title.clone(),
+                state: format!("{:?}", r.state),
+            })
+            .collect();
+
         // Step 4: If include_deps, get dependency tree from cached graph.
         let dependency_tree = if include_deps {
             state.cache.get_graph().await.map(|graph| {
@@ -656,6 +673,8 @@ impl UnblockServer {
             created_at: issue.created_at.to_rfc3339(),
             updated_at: issue.updated_at.to_rfc3339(),
             url: issue.url.clone(),
+            parent: parent.clone(),
+            sub_issues: sub_issues.clone(),
         };
 
         Ok(Json(ShowResult {
@@ -667,6 +686,8 @@ impl UnblockServer {
             },
             blocking,
             blocked_by,
+            parent,
+            sub_issues,
             dependency_tree,
             comments,
         }))

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -578,6 +578,7 @@ impl UnblockServer {
         );
 
         // Step 3: Extract blocking/blocked_by from the issue.
+        // TODO(unblock-b6b.62): Extract shared helper fn for RelatedIssue-to-ShowRelatedIssue mapping
         let blocking: Vec<ShowRelatedIssue> = issue
             .blocking
             .iter()
@@ -673,8 +674,6 @@ impl UnblockServer {
             created_at: issue.created_at.to_rfc3339(),
             updated_at: issue.updated_at.to_rfc3339(),
             url: issue.url.clone(),
-            parent: parent.clone(),
-            sub_issues: sub_issues.clone(),
         };
 
         Ok(Json(ShowResult {

--- a/crates/unblock-mcp/src/tools/show.rs
+++ b/crates/unblock-mcp/src/tools/show.rs
@@ -92,10 +92,6 @@ pub struct ShowIssue {
     pub updated_at: String,
     /// HTML URL for linking back to GitHub.
     pub url: String,
-    /// Parent issue if this is a sub-issue.
-    pub parent: Option<ShowRelatedIssue>,
-    /// Sub-issues of this issue.
-    pub sub_issues: Vec<ShowRelatedIssue>,
 }
 
 /// Parsed body sections for the show result.

--- a/crates/unblock-mcp/src/tools/show.rs
+++ b/crates/unblock-mcp/src/tools/show.rs
@@ -36,6 +36,10 @@ pub struct ShowResult {
     pub blocking: Vec<ShowRelatedIssue>,
     /// Issues that block this issue (upstream blockers).
     pub blocked_by: Vec<ShowRelatedIssue>,
+    /// Parent issue if this is a sub-issue.
+    pub parent: Option<ShowRelatedIssue>,
+    /// Sub-issues of this issue.
+    pub sub_issues: Vec<ShowRelatedIssue>,
     /// Dependency tree from the cached graph, up to depth 3.
     /// Each entry is `(issue_number, depth)`. `None` if `include_deps`
     /// is `false` or the graph cache is empty.
@@ -88,6 +92,10 @@ pub struct ShowIssue {
     pub updated_at: String,
     /// HTML URL for linking back to GitHub.
     pub url: String,
+    /// Parent issue if this is a sub-issue.
+    pub parent: Option<ShowRelatedIssue>,
+    /// Sub-issues of this issue.
+    pub sub_issues: Vec<ShowRelatedIssue>,
 }
 
 /// Parsed body sections for the show result.


### PR DESCRIPTION
PRD §6.3 and ARCH §10.6 specify that the show tool must include parent and subIssues fields. The domain Issue type already models these, but ShowIssue and ShowResult omitted them. Added both fields to ShowIssue (issue-level) and ShowResult (top-level, matching blocking/blocked_by pattern), and wired the mapping in the server handler.