### PR TITLE
chore: add exit-code assertion before stdout check in subprocess tests

### DIFF
--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -1219,6 +1219,10 @@ mod tests {
             .output()
             .expect("failed to spawn subprocess");
 
+        assert!(
+            output.status.success(),
+            "subprocess exited with non-zero status: {output:?}"
+        );
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             stdout.contains("AGENT_FIELD=test-supervisor"),
@@ -1244,6 +1248,10 @@ mod tests {
             .output()
             .expect("failed to spawn subprocess");
 
+        assert!(
+            output.status.success(),
+            "subprocess exited with non-zero status: {output:?}"
+        );
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             stdout.contains("AGENT_FIELD=NONE"),


### PR DESCRIPTION
The two subprocess tests (session_meta_agent_field_set_via_subprocess and session_meta_agent_field_unset_via_subprocess) now assert output.status.success() before inspecting stdout. This surfaces the real failure cause immediately when the subprocess exits non-zero, instead of producing a misleading "expected X in output" message on empty stdout.