### PR TITLE
refactor: return &str from agent_kind_str() instead of String

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -155,10 +155,8 @@ impl ServerState {
     /// when the lock has not been set (e.g., in tests or when `initialize` is not
     /// called).
     #[must_use]
-    pub fn agent_kind_str(&self) -> String {
-        self.agent_kind
-            .get()
-            .map_or_else(|| "unknown".into(), |k| k.as_str().to_owned())
+    pub fn agent_kind_str(&self) -> &str {
+        self.agent_kind.get().map_or("unknown", AgentKind::as_str)
     }
 }
 
@@ -2202,7 +2200,7 @@ mod tests {
 
         // Exercise the extraction pattern inside the subscriber scope.
         tracing::subscriber::with_default(subscriber, || {
-            let kind: String = state.agent_kind_str();
+            let kind: &str = state.agent_kind_str();
             info!(agent.kind = %kind, "Ready tool invoked");
         });
 
@@ -2256,7 +2254,7 @@ mod tests {
         // Do NOT set agent_kind — test the fallback.
 
         tracing::subscriber::with_default(subscriber, || {
-            let kind: String = state.agent_kind_str();
+            let kind: &str = state.agent_kind_str();
             info!(agent.kind = %kind, "Claim tool invoked");
         });
 

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -250,7 +250,7 @@ impl SessionMeta {
             .get()
             .map_or_else(|| "unknown".to_owned(), |c| c.name.clone());
 
-        let agent_kind = state.agent_kind_str();
+        let agent_kind = state.agent_kind_str().to_owned();
 
         let agent_field = std::env::var("UNBLOCK_AGENT").ok();
 


### PR DESCRIPTION
Avoid a heap allocation on every tool call by returning a borrowed reference. The OnceLock lifetime is tied to &self, so the borrow is valid for the lifetime of the ServerState. The fallback "unknown" is a &'static str.

The only call site that needs an owned String (SessionMeta in prime.rs) now calls .to_owned() explicitly.