### PR TITLE
fix: normalize empty-string filters to None in prime and ready tools

### DIFF
--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -53,6 +53,17 @@ use unblock_core::graph::DependencyGraph;
 use crate::errors::github_error_to_mcp;
 use crate::server::ServerState;
 
+/// Normalize an optional string filter: empty or whitespace-only values become `None`.
+///
+/// Serde deserializes `"agent": ""` as `Some("")`, not `None`. Without
+/// normalization, an empty string silently matches nothing and returns
+/// empty results. This helper collapses empty and whitespace-only strings
+/// to `None` so filters behave as if the parameter was omitted.
+#[must_use]
+pub(crate) fn normalize_filter(value: Option<String>) -> Option<String> {
+    value.filter(|s| !s.trim().is_empty())
+}
+
 /// Executes a read-only MCP tool operation.
 ///
 /// Calls `op` and maps any `unblock_github::errors::Error` to an
@@ -245,6 +256,42 @@ mod tests {
             agent_client: std::sync::OnceLock::new(),
             connected_at: std::sync::OnceLock::new(),
         }
+    }
+
+    // ── normalize_filter tests ──────────────────────────────────────────
+
+    #[test]
+    fn normalize_filter_none_stays_none() {
+        assert_eq!(normalize_filter(None), None);
+    }
+
+    #[test]
+    fn normalize_filter_non_empty_preserved() {
+        assert_eq!(
+            normalize_filter(Some("agent-x".to_owned())),
+            Some("agent-x".to_owned())
+        );
+    }
+
+    #[test]
+    fn normalize_filter_empty_string_becomes_none() {
+        assert_eq!(normalize_filter(Some(String::new())), None);
+    }
+
+    #[test]
+    fn normalize_filter_whitespace_only_becomes_none() {
+        assert_eq!(normalize_filter(Some("   ".to_owned())), None);
+        assert_eq!(normalize_filter(Some("\t\n".to_owned())), None);
+    }
+
+    #[test]
+    fn normalize_filter_preserves_whitespace_padded_value() {
+        // A value with surrounding whitespace is preserved (not trimmed) —
+        // only purely-whitespace strings are collapsed to None.
+        assert_eq!(
+            normalize_filter(Some(" agent-x ".to_owned())),
+            Some(" agent-x ".to_owned())
+        );
     }
 
     // ── execute_read_tool tests ────────────────────────────────────────

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -372,7 +372,10 @@ pub async fn handle_prime(
     let mut filtered_blocked = categories.blocked;
     let mut filtered_stale = categories.stale;
 
-    if let Some(ref agent_filter) = params.agent {
+    // Normalize empty/whitespace agent strings to None so they don't silently
+    // filter out all results (serde deserializes "" as Some("")).
+    let agent_filter = crate::tools::normalize_filter(params.agent.clone());
+    if let Some(ref agent_filter) = agent_filter {
         filtered_ip.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
         filtered_ready.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
         filtered_blocked.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
@@ -1735,6 +1738,49 @@ mod tests {
         let json = r"{}";
         let params: PrimeParams = serde_json::from_str(json).expect("should deserialize");
         assert!(params.agent.is_none());
+    }
+
+    #[test]
+    fn prime_params_empty_agent_deserializes_as_some_empty() {
+        // Demonstrates the serde behavior this fix addresses: `""` becomes
+        // `Some("")`, not `None`. The normalize_filter call in handle_prime
+        // collapses this to None before filtering.
+        let json = r#"{"agent": ""}"#;
+        let params: PrimeParams = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(
+            params.agent.as_deref(),
+            Some(""),
+            "serde should deserialize empty string as Some(\"\")"
+        );
+    }
+
+    #[test]
+    fn empty_agent_filter_returns_all_categories() {
+        // Regression test: empty string agent filter should behave as no filter.
+        let mut issue1 = test_issue(1, IssueState::Open, Status::InProgress);
+        issue1.agent = Some("agent-x".to_owned());
+        issue1.claimed_at = Some(Utc::now());
+        let mut issue2 = test_issue(2, IssueState::Open, Status::InProgress);
+        issue2.agent = Some("agent-y".to_owned());
+        issue2.claimed_at = Some(Utc::now());
+        let issues = vec![issue1, issue2];
+
+        let graph = DependencyGraph::build(&issues, &[]);
+        let ready = graph.compute_ready_set(&issues);
+        let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
+
+        // Simulate what handle_prime does: normalize then filter.
+        let agent_filter = crate::tools::normalize_filter(Some(String::new()));
+        assert!(
+            agent_filter.is_none(),
+            "empty string should normalize to None"
+        );
+
+        let (ip, _, _, _) = apply_agent_filter(&result, agent_filter.as_deref());
+        assert_eq!(
+            ip, 2,
+            "empty agent string should return all in_progress issues"
+        );
     }
 
     // ── summarise_drift tests ────────────────────────────────────────

--- a/crates/unblock-mcp/src/tools/ready.rs
+++ b/crates/unblock-mcp/src/tools/ready.rs
@@ -123,40 +123,45 @@ pub fn filter_ready_set(
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT);
     let today = Utc::now().date_naive();
 
+    // Normalize empty/whitespace string filters to None so they behave as
+    // "no filter" rather than silently matching nothing. Serde deserializes
+    // `"agent": ""` as `Some("")`, not `None`.
+    let issue_type = crate::tools::normalize_filter(params.issue_type.clone());
+    let priority = crate::tools::normalize_filter(params.priority.clone());
+    let milestone = crate::tools::normalize_filter(params.milestone.clone());
+    let agent = crate::tools::normalize_filter(params.agent.clone());
+    let label = crate::tools::normalize_filter(params.label.clone());
+
     ready_set
         .iter()
         // Filter by issue_type (case-insensitive Debug match).
         .filter(|s| {
-            params.issue_type.as_ref().is_none_or(|filter| {
+            issue_type.as_ref().is_none_or(|filter| {
                 s.issue_type
                     .is_some_and(|it| format!("{it:?}").eq_ignore_ascii_case(filter))
             })
         })
         // Filter by priority (case-insensitive Debug match).
         .filter(|s| {
-            params
-                .priority
+            priority
                 .as_ref()
                 .is_none_or(|filter| format!("{:?}", s.priority).eq_ignore_ascii_case(filter))
         })
         // Filter by milestone (exact match).
         .filter(|s| {
-            params
-                .milestone
+            milestone
                 .as_ref()
                 .is_none_or(|filter| s.milestone.as_deref() == Some(filter.as_str()))
         })
         // Filter by agent (exact match).
         .filter(|s| {
-            params
-                .agent
+            agent
                 .as_ref()
                 .is_none_or(|filter| s.agent.as_deref() == Some(filter.as_str()))
         })
         // Filter by label (case-insensitive, any match).
         .filter(|s| {
-            params
-                .label
+            label
                 .as_ref()
                 .is_none_or(|filter| s.labels.iter().any(|l| l.eq_ignore_ascii_case(filter)))
         })
@@ -372,6 +377,100 @@ mod tests {
         let result = filter_ready_set(&set, &params);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].number, 1);
+    }
+
+    // ── Empty string filter normalization ──────────────────────────────
+
+    #[test]
+    fn empty_agent_string_treated_as_no_filter() {
+        let set = vec![test_summary(1, Priority::P0), test_summary(2, Priority::P1)];
+        let params = ReadyParams {
+            agent: Some(String::new()),
+            ..default_params()
+        };
+        let result = filter_ready_set(&set, &params);
+        assert_eq!(
+            result.len(),
+            2,
+            "empty agent string should not filter out any issues"
+        );
+    }
+
+    #[test]
+    fn whitespace_agent_string_treated_as_no_filter() {
+        let set = vec![test_summary(1, Priority::P0)];
+        let params = ReadyParams {
+            agent: Some("   ".to_owned()),
+            ..default_params()
+        };
+        let result = filter_ready_set(&set, &params);
+        assert_eq!(
+            result.len(),
+            1,
+            "whitespace-only agent string should not filter out any issues"
+        );
+    }
+
+    #[test]
+    fn empty_issue_type_string_treated_as_no_filter() {
+        let set = vec![test_summary(1, Priority::P0)];
+        let params = ReadyParams {
+            issue_type: Some(String::new()),
+            ..default_params()
+        };
+        let result = filter_ready_set(&set, &params);
+        assert_eq!(
+            result.len(),
+            1,
+            "empty issue_type string should not filter out any issues"
+        );
+    }
+
+    #[test]
+    fn empty_priority_string_treated_as_no_filter() {
+        let set = vec![test_summary(1, Priority::P0)];
+        let params = ReadyParams {
+            priority: Some(String::new()),
+            ..default_params()
+        };
+        let result = filter_ready_set(&set, &params);
+        assert_eq!(
+            result.len(),
+            1,
+            "empty priority string should not filter out any issues"
+        );
+    }
+
+    #[test]
+    fn empty_milestone_string_treated_as_no_filter() {
+        let set = vec![test_summary(1, Priority::P0)];
+        let params = ReadyParams {
+            milestone: Some(String::new()),
+            ..default_params()
+        };
+        let result = filter_ready_set(&set, &params);
+        assert_eq!(
+            result.len(),
+            1,
+            "empty milestone string should not filter out any issues"
+        );
+    }
+
+    #[test]
+    fn empty_label_string_treated_as_no_filter() {
+        let mut s1 = test_summary(1, Priority::P0);
+        s1.labels = vec!["backend".to_owned()];
+        let set = vec![s1];
+        let params = ReadyParams {
+            label: Some(String::new()),
+            ..default_params()
+        };
+        let result = filter_ready_set(&set, &params);
+        assert_eq!(
+            result.len(),
+            1,
+            "empty label string should not filter out any issues"
+        );
     }
 
     // ── Deferred exclusion ───────────────────────────────────────────


### PR DESCRIPTION
Empty or whitespace-only string filters (e.g. agent="") were silently matching nothing due to serde deserializing "" as Some("") rather than None. Add normalize_filter() helper that collapses these to None so they behave as "no filter". Applied to all string filters in ready.rs (agent, issue_type, priority, milestone, label) and agent in prime.rs.

Closes: unblock-b6b.130