### PR TITLE
refactor: change normalize_filter to accept Option<&str> instead of O…

### DIFF
--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -60,7 +60,7 @@ use crate::server::ServerState;
 /// empty results. This helper collapses empty and whitespace-only strings
 /// to `None` so filters behave as if the parameter was omitted.
 #[must_use]
-pub(crate) fn normalize_filter(value: Option<String>) -> Option<String> {
+pub(crate) fn normalize_filter(value: Option<&str>) -> Option<&str> {
     value.filter(|s| !s.trim().is_empty())
 }
 
@@ -267,31 +267,25 @@ mod tests {
 
     #[test]
     fn normalize_filter_non_empty_preserved() {
-        assert_eq!(
-            normalize_filter(Some("agent-x".to_owned())),
-            Some("agent-x".to_owned())
-        );
+        assert_eq!(normalize_filter(Some("agent-x")), Some("agent-x"));
     }
 
     #[test]
     fn normalize_filter_empty_string_becomes_none() {
-        assert_eq!(normalize_filter(Some(String::new())), None);
+        assert_eq!(normalize_filter(Some("")), None);
     }
 
     #[test]
     fn normalize_filter_whitespace_only_becomes_none() {
-        assert_eq!(normalize_filter(Some("   ".to_owned())), None);
-        assert_eq!(normalize_filter(Some("\t\n".to_owned())), None);
+        assert_eq!(normalize_filter(Some("   ")), None);
+        assert_eq!(normalize_filter(Some("\t\n")), None);
     }
 
     #[test]
     fn normalize_filter_preserves_whitespace_padded_value() {
         // A value with surrounding whitespace is preserved (not trimmed) —
         // only purely-whitespace strings are collapsed to None.
-        assert_eq!(
-            normalize_filter(Some(" agent-x ".to_owned())),
-            Some(" agent-x ".to_owned())
-        );
+        assert_eq!(normalize_filter(Some(" agent-x ")), Some(" agent-x "));
     }
 
     // ── execute_read_tool tests ────────────────────────────────────────

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -374,12 +374,12 @@ pub async fn handle_prime(
 
     // Normalize empty/whitespace agent strings to None so they don't silently
     // filter out all results (serde deserializes "" as Some("")).
-    let agent_filter = crate::tools::normalize_filter(params.agent.clone());
-    if let Some(ref agent_filter) = agent_filter {
-        filtered_ip.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
-        filtered_ready.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
-        filtered_blocked.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
-        filtered_stale.retain(|s| s.agent.as_deref() == Some(agent_filter.as_str()));
+    let agent_filter = crate::tools::normalize_filter(params.agent.as_deref());
+    if let Some(agent_filter) = agent_filter {
+        filtered_ip.retain(|s| s.agent.as_deref() == Some(agent_filter));
+        filtered_ready.retain(|s| s.agent.as_deref() == Some(agent_filter));
+        filtered_blocked.retain(|s| s.agent.as_deref() == Some(agent_filter));
+        filtered_stale.retain(|s| s.agent.as_deref() == Some(agent_filter));
     }
 
     // 6. Build result with counts computed AFTER filtering.
@@ -1770,13 +1770,13 @@ mod tests {
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // Simulate what handle_prime does: normalize then filter.
-        let agent_filter = crate::tools::normalize_filter(Some(String::new()));
+        let agent_filter = crate::tools::normalize_filter(Some(""));
         assert!(
             agent_filter.is_none(),
             "empty string should normalize to None"
         );
 
-        let (ip, _, _, _) = apply_agent_filter(&result, agent_filter.as_deref());
+        let (ip, _, _, _) = apply_agent_filter(&result, agent_filter);
         assert_eq!(
             ip, 2,
             "empty agent string should return all in_progress issues"

--- a/crates/unblock-mcp/src/tools/ready.rs
+++ b/crates/unblock-mcp/src/tools/ready.rs
@@ -126,44 +126,32 @@ pub fn filter_ready_set(
     // Normalize empty/whitespace string filters to None so they behave as
     // "no filter" rather than silently matching nothing. Serde deserializes
     // `"agent": ""` as `Some("")`, not `None`.
-    let issue_type = crate::tools::normalize_filter(params.issue_type.clone());
-    let priority = crate::tools::normalize_filter(params.priority.clone());
-    let milestone = crate::tools::normalize_filter(params.milestone.clone());
-    let agent = crate::tools::normalize_filter(params.agent.clone());
-    let label = crate::tools::normalize_filter(params.label.clone());
+    let issue_type = crate::tools::normalize_filter(params.issue_type.as_deref());
+    let priority = crate::tools::normalize_filter(params.priority.as_deref());
+    let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
+    let agent = crate::tools::normalize_filter(params.agent.as_deref());
+    let label = crate::tools::normalize_filter(params.label.as_deref());
 
     ready_set
         .iter()
         // Filter by issue_type (case-insensitive Debug match).
         .filter(|s| {
-            issue_type.as_ref().is_none_or(|filter| {
+            issue_type.is_none_or(|filter| {
                 s.issue_type
                     .is_some_and(|it| format!("{it:?}").eq_ignore_ascii_case(filter))
             })
         })
         // Filter by priority (case-insensitive Debug match).
         .filter(|s| {
-            priority
-                .as_ref()
-                .is_none_or(|filter| format!("{:?}", s.priority).eq_ignore_ascii_case(filter))
+            priority.is_none_or(|filter| format!("{:?}", s.priority).eq_ignore_ascii_case(filter))
         })
         // Filter by milestone (exact match).
-        .filter(|s| {
-            milestone
-                .as_ref()
-                .is_none_or(|filter| s.milestone.as_deref() == Some(filter.as_str()))
-        })
+        .filter(|s| milestone.is_none_or(|filter| s.milestone.as_deref() == Some(filter)))
         // Filter by agent (exact match).
-        .filter(|s| {
-            agent
-                .as_ref()
-                .is_none_or(|filter| s.agent.as_deref() == Some(filter.as_str()))
-        })
+        .filter(|s| agent.is_none_or(|filter| s.agent.as_deref() == Some(filter)))
         // Filter by label (case-insensitive, any match).
         .filter(|s| {
-            label
-                .as_ref()
-                .is_none_or(|filter| s.labels.iter().any(|l| l.eq_ignore_ascii_case(filter)))
+            label.is_none_or(|filter| s.labels.iter().any(|l| l.eq_ignore_ascii_case(filter)))
         })
         // Exclude deferred issues (defer_until > today).
         .filter(|s| s.defer_until.is_none_or(|d| d <= today))


### PR DESCRIPTION
…ption<String>

Eliminates .clone() at all call sites by accepting a borrowed string slice. Call sites now pass .as_deref() and downstream filter closures drop .as_ref() / .as_str() since the value is already &str.

Cosmetic/idiomatic improvement on a non-hot path — no behavioral change.