### PR TITLE
chore: use Display instead of Debug for IssueType filter in ready.rs

### DIFF
--- a/crates/unblock-mcp/src/tools/ready.rs
+++ b/crates/unblock-mcp/src/tools/ready.rs
@@ -134,11 +134,11 @@ pub fn filter_ready_set(
 
     ready_set
         .iter()
-        // Filter by issue_type (case-insensitive Debug match).
+        // Filter by issue_type (case-insensitive match).
         .filter(|s| {
             issue_type.is_none_or(|filter| {
                 s.issue_type
-                    .is_some_and(|it| format!("{it:?}").eq_ignore_ascii_case(filter))
+                    .is_some_and(|it| it.to_string().eq_ignore_ascii_case(filter))
             })
         })
         // Filter by priority (case-insensitive Debug match).


### PR DESCRIPTION
Replace `format!("{it:?}")` with `it.to_string()` in the issue_type filter closure and update the comment to remove the misleading "Debug match" wording. This aligns the filter with the Display impl added in commit 5a90774, ensuring correctness if Debug output ever diverges from Display.