### PR TITLE
chore: validate UTF-8 once at construction in CapturedOutput

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,6 +1,5 @@
 # Dolt database (managed by Dolt, not git)
 dolt/
-dolt-access.lock
 
 # Runtime files
 bd.sock
@@ -35,6 +34,7 @@ redirect
 # These files are machine-specific and should not be shared across clones
 .sync.lock
 export-state/
+export-state.json
 
 # Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
 ephemeral.sqlite3

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.62.0 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.62.0 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.62.0 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.62.0 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.62.0 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -2050,7 +2050,7 @@ const _: () = {
 mod tests {
     use super::*;
     use std::io;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::sync::{Mutex, OnceLock};
     use std::time::Duration;
     use tracing_subscriber::fmt;
     use tracing_subscriber::prelude::*;
@@ -2064,27 +2064,29 @@ mod tests {
     /// be used as a `tracing_subscriber` writer. Call [`TracingCapture::new`]
     /// to create an instance, [`TracingCapture::subscriber`] to build a
     /// JSON subscriber wired to the buffer, and [`TracingCapture::output`]
-    /// to retrieve the captured output as a zero-copy `&str` borrow.
+    /// to retrieve a snapshot of the captured output as a `String` with
+    /// UTF-8 validated once at construction time.
     #[derive(Clone)]
     struct TracingCapture(Arc<Mutex<Vec<u8>>>);
 
-    /// RAII guard that holds a [`MutexGuard`] and exposes the captured
-    /// bytes as a `&str` without cloning.
+    /// Owned snapshot of the captured tracing output, validated as UTF-8
+    /// once at construction time.
     ///
-    /// Returned by [`TracingCapture::output`]. The guard keeps the mutex
-    /// locked while the caller inspects the output; it is released when
-    /// the guard is dropped.
-    struct CapturedOutput<'a>(MutexGuard<'a, Vec<u8>>);
+    /// Returned by [`TracingCapture::output`]. UTF-8 validation happens
+    /// exactly once when the snapshot is created; subsequent [`Deref`]
+    /// calls are zero-cost borrows. The mutex is released immediately
+    /// after the snapshot is taken.
+    struct CapturedOutput(String);
 
-    impl std::ops::Deref for CapturedOutput<'_> {
+    impl std::ops::Deref for CapturedOutput {
         type Target = str;
 
         fn deref(&self) -> &str {
-            std::str::from_utf8(&self.0).expect("captured output is not valid UTF-8")
+            &self.0
         }
     }
 
-    impl std::fmt::Display for CapturedOutput<'_> {
+    impl std::fmt::Display for CapturedOutput {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.write_str(self)
         }
@@ -2107,18 +2109,21 @@ mod tests {
             )
         }
 
-        /// Return the captured output as a zero-copy `&str` borrow.
+        /// Return a snapshot of the captured output as a validated UTF-8
+        /// string.
         ///
-        /// Returns a [`CapturedOutput`] guard that derefs to `&str`,
-        /// avoiding a full buffer clone. The mutex stays locked while
-        /// the guard is alive.
+        /// UTF-8 validation is performed exactly once when the snapshot
+        /// is created. The mutex is released immediately after copying
+        /// the buffer, so callers can inspect the output without holding
+        /// the lock.
         ///
         /// # Panics
         ///
         /// Panics if the mutex is poisoned or the buffer is not valid
         /// UTF-8.
-        fn output(&self) -> CapturedOutput<'_> {
-            CapturedOutput(self.0.lock().unwrap())
+        fn output(&self) -> CapturedOutput {
+            let bytes = self.0.lock().unwrap().clone();
+            CapturedOutput(String::from_utf8(bytes).expect("captured output is not valid UTF-8"))
         }
     }
 


### PR DESCRIPTION
CapturedOutput now stores a String validated at construction time instead of re-validating via from_utf8() on every Deref call.