### PR TITLE
chore: harden client name filter to trim whitespace-only names

### DIFF
--- a/crates/unblock-core/src/detection.rs
+++ b/crates/unblock-core/src/detection.rs
@@ -117,7 +117,7 @@ impl ClientDetector {
         env: impl Fn(&str) -> Result<String, VarError>,
     ) -> AgentKind {
         mcp_client
-            .filter(|c| !c.name.is_empty())
+            .filter(|c| !c.name.trim().is_empty())
             .map(AgentClient::kind)
             .or_else(|| Self::from_env_reader(env))
             .unwrap_or_else(|| AgentKind::Unknown("unknown".into()))
@@ -304,6 +304,40 @@ mod tests {
     fn resolve_with_empty_name_no_env_returns_unknown_sentinel() {
         let client = AgentClient {
             name: String::new(),
+            version: String::new(),
+        };
+        let env = make_env(&[]);
+        assert_eq!(
+            ClientDetector::resolve_with(Some(&client), env),
+            AgentKind::Unknown("unknown".into()),
+        );
+    }
+
+    /// MCP client with whitespace-only name + env set → env fallback wins.
+    ///
+    /// A name composed entirely of whitespace (spaces, tabs) is semantically
+    /// empty and should not be treated as a valid MCP client identity.
+    #[test]
+    fn resolve_with_whitespace_name_falls_through_to_env() {
+        let client = AgentClient {
+            name: "   ".into(),
+            version: "1.0.0".into(),
+        };
+        let env = make_env(&[("CLAUDE_CODE_ENTRYPOINT", "1")]);
+        assert_eq!(
+            ClientDetector::resolve_with(Some(&client), env),
+            AgentKind::ClaudeCode,
+        );
+    }
+
+    /// MCP client with whitespace-only name + no env → `Unknown("unknown")` sentinel.
+    ///
+    /// When the MCP name is only whitespace and no environment variable is
+    /// set, the standard unknown sentinel is returned (not `Unknown("   ")`).
+    #[test]
+    fn resolve_with_whitespace_name_no_env_returns_unknown_sentinel() {
+        let client = AgentClient {
+            name: " \t ".into(),
             version: String::new(),
         };
         let env = make_env(&[]);


### PR DESCRIPTION
The .filter() check in ClientDetector::resolve_with called is_empty() on the client name but did not guard against whitespace-only names.
A name like "   " would pass the filter and be treated as valid.

Use .trim().is_empty() instead so whitespace-only names fall through to env-based detection, matching the behavior of truly empty names.

Closes: unblock-b6b.139