### PR TITLE
refactor(mcp): migrate ServerState and handlers to Arc<dyn GitHubApi>

### DIFF
--- a/crates/unblock-mcp/src/main.rs
+++ b/crates/unblock-mcp/src/main.rs
@@ -14,6 +14,7 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 use unblock_core::cache::GraphCache;
 use unblock_core::config::Config;
+use unblock_github::GitHubApi;
 use unblock_github::client::GitHubClient;
 use unblock_mcp::errors::{ClientInitSnafu, ConfigLoadSnafu, RuntimeSnafu, TransportSnafu};
 use unblock_mcp::server::{ServerState, UnblockServer};
@@ -39,7 +40,7 @@ async fn main() -> Result<(), unblock_mcp::errors::BootstrapError> {
     // 5. Build server state.
     let state = ServerState {
         config: Arc::new(config),
-        client: Arc::new(client),
+        client: Arc::new(client) as Arc<dyn GitHubApi>,
         cache: Arc::new(cache),
         agent_kind: std::sync::OnceLock::new(),
         agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1,7 +1,7 @@
 //! MCP server bootstrap and state management.
 //!
 //! [`ServerState`](crate::server::ServerState) holds
-//! [`GitHubClient`](unblock_github::client::GitHubClient),
+//! [`GitHubClient`](unblock_github::client::GitHubClient)(unblock_github::client::GitHubClient),
 //! [`GraphCache`](unblock_core::cache::GraphCache), and
 //! [`Config`](unblock_core::config::Config).
 //! [`UnblockServer`](crate::server::UnblockServer) implements the rmcp
@@ -47,7 +47,7 @@ use unblock_core::config::Config;
 use unblock_core::detection::ClientDetector;
 use unblock_core::errors::{CircularDependencySnafu, IssueClosedSnafu};
 use unblock_core::types::IssueState;
-use unblock_github::client::GitHubClient;
+use unblock_github::GitHubApi;
 use unblock_github::projects::FieldValue;
 use unblock_github::projects::{CreateViewParams, ViewLayout};
 
@@ -113,18 +113,24 @@ unblock turns GitHub Issues into a dependency graph. Ask `ready` to get unblocke
 ///
 /// `ServerState` is `Send + Sync` because all inner types are `Send + Sync`:
 /// - [`Config`] is `Clone + Send + Sync` (plain data).
-/// - [`GitHubClient`] wraps `reqwest::Client` which is `Send + Sync`.
+/// - [`GitHubApi`] is a trait object (`dyn GitHubApi`) bounded by `Send + Sync`;
+///   the production blanket impl on [`GitHubClient`](unblock_github::client::GitHubClient) wraps `reqwest::Client`
+///   which is `Send + Sync`.
 /// - [`GraphCache`] uses `tokio::sync::RwLock` which is `Send + Sync`.
 /// - [`OnceLock<AgentKind>`] is `Send + Sync` because `AgentKind` is `Send + Sync`.
 /// - [`OnceLock<AgentClient>`] is `Send + Sync` because `AgentClient` is `Send + Sync`.
 /// - [`OnceLock<DateTime<Utc>>`] is `Send + Sync` because `DateTime<Utc>` is `Send + Sync`.
-#[derive(Debug)]
 pub struct ServerState {
     /// Application configuration loaded from environment variables.
     #[allow(dead_code)] // Used by tool handlers added in beads 45a.4–45a.11.
     pub config: Arc<Config>,
     /// GitHub API client for GraphQL and REST operations.
-    pub client: Arc<GitHubClient>,
+    ///
+    /// Stored as a [`GitHubApi`] trait object so tests and alternative
+    /// implementations (e.g. mocks introduced in sibling beads) can be
+    /// substituted for the real [`GitHubClient`](unblock_github::client::GitHubClient) without changing the handler
+    /// surface.
+    pub client: Arc<dyn GitHubApi>,
     /// In-memory cache for the dependency graph and ready set.
     pub cache: Arc<GraphCache>,
     /// Resolved once during the MCP `initialize` handshake.
@@ -145,6 +151,21 @@ pub struct ServerState {
     /// [`SessionMeta`](crate::tools::prime::SessionMeta) for the
     /// `connected_at` field.
     pub connected_at: OnceLock<chrono::DateTime<Utc>>,
+}
+
+impl std::fmt::Debug for ServerState {
+    /// Manual [`Debug`] implementation that intentionally omits the `client`
+    /// field because [`dyn GitHubApi`](GitHubApi) does not require [`Debug`].
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerState")
+            .field("config", &self.config)
+            .field("client", &"<dyn GitHubApi>")
+            .field("cache", &self.cache)
+            .field("agent_kind", &self.agent_kind)
+            .field("agent_client", &self.agent_client)
+            .field("connected_at", &self.connected_at)
+            .finish()
+    }
 }
 
 impl ServerState {
@@ -206,7 +227,7 @@ impl UnblockServer {
 /// (per PRD section 6.1 and ARCH section 10.4).
 #[allow(clippy::too_many_arguments)]
 async fn set_project_fields(
-    client: &GitHubClient,
+    client: &dyn GitHubApi,
     project_id: &str,
     item_id: &str,
     field_ids: &unblock_github::projects::ProjectFieldIds,
@@ -1496,7 +1517,7 @@ impl UnblockServer {
                                         };
 
                                     set_project_fields(
-                                        &client,
+                                        client.as_ref(),
                                         &project_info.id,
                                         &item_id,
                                         &field_ids,
@@ -2145,13 +2166,13 @@ mod tests {
         })
         .expect("test config should load");
 
-        let client = GitHubClient::new(&config)
+        let client = unblock_github::client::GitHubClient::new(&config)
             .await
             .expect("test client should initialize");
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client),
+            client: Arc::new(client) as Arc<dyn GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: OnceLock::new(),
             agent_client: OnceLock::new(),

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1,7 +1,8 @@
 //! MCP server bootstrap and state management.
 //!
-//! [`ServerState`](crate::server::ServerState) holds
-//! [`GitHubClient`](unblock_github::client::GitHubClient)(unblock_github::client::GitHubClient),
+//! [`ServerState`](crate::server::ServerState) holds an
+//! [`Arc`](std::sync::Arc) over a [`GitHubApi`](unblock_github::GitHubApi) trait object
+//! (typically backed by [`GitHubClient`](unblock_github::client::GitHubClient)),
 //! [`GraphCache`](unblock_core::cache::GraphCache), and
 //! [`Config`](unblock_core::config::Config).
 //! [`UnblockServer`](crate::server::UnblockServer) implements the rmcp

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -250,7 +250,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client),
+            client: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -801,7 +801,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client),
+            client: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -544,7 +544,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client),
+            client: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/tests/e2e_workflow.rs
+++ b/crates/unblock-mcp/tests/e2e_workflow.rs
@@ -18,7 +18,7 @@
 //! fires on both success and panic unwind. This ensures the test repository is
 //! not polluted with orphaned open issues.
 
-use unblock_github::client::GitHubClient;
+use unblock_github::GitHubApi;
 use unblock_github::mutations::CreateIssueParams;
 use unblock_github::projects::{CreateViewParams, FieldValue, ViewLayout};
 use unblock_mcp::tools::ready::{ReadyParams, filter_ready_set};
@@ -35,7 +35,7 @@ use common::{has_github_token, has_project_number, test_server_state};
 /// On drop, iterates over all tracked issue numbers and closes each one.
 /// Individual close failures are logged but do not abort the remaining cleanup.
 struct CloseIssuesGuard<'a> {
-    client: &'a GitHubClient,
+    client: &'a dyn GitHubApi,
     issue_numbers: Vec<u64>,
     /// Set to `true` once the test completes successfully and the caller has
     /// already cleaned up. When `true`, the guard skips cleanup in `Drop`.
@@ -44,7 +44,7 @@ struct CloseIssuesGuard<'a> {
 
 impl<'a> CloseIssuesGuard<'a> {
     /// Creates an armed guard with no issues tracked.
-    fn new(client: &'a GitHubClient) -> Self {
+    fn new(client: &'a dyn GitHubApi) -> Self {
         Self {
             client,
             issue_numbers: Vec::new(),
@@ -123,7 +123,7 @@ async fn e2e_workflow_all_10_tools() {
     let test_label = format!("e2e-test-{}", chrono::Utc::now().timestamp());
 
     // Drop guard for cleanup — tracks all created issues.
-    let mut guard = CloseIssuesGuard::new(client);
+    let mut guard = CloseIssuesGuard::new(client.as_ref());
 
     // ── Step 1: init — create or reuse project ──────────────────────
     eprintln!("=== Step 1: init ===");
@@ -257,7 +257,7 @@ async fn e2e_workflow_all_10_tools() {
         && let Some(field_ids) = client.field_ids().await
     {
         set_project_fields_helper(
-            client,
+            client.as_ref(),
             &project_info.id,
             &item_id,
             &field_ids,
@@ -299,7 +299,7 @@ async fn e2e_workflow_all_10_tools() {
         && let Some(field_ids) = client.field_ids().await
     {
         set_project_fields_helper(
-            client,
+            client.as_ref(),
             &project_info.id,
             &item_id,
             &field_ids,
@@ -335,7 +335,7 @@ async fn e2e_workflow_all_10_tools() {
         && let Some(field_ids) = client.field_ids().await
     {
         set_project_fields_helper(
-            client,
+            client.as_ref(),
             &project_info.id,
             &item_id,
             &field_ids,
@@ -688,7 +688,7 @@ async fn e2e_workflow_all_10_tools() {
 /// the client without the server framework.
 #[allow(clippy::too_many_arguments)]
 async fn set_project_fields_helper(
-    client: &GitHubClient,
+    client: &dyn GitHubApi,
     project_id: &str,
     item_id: &str,
     field_ids: &unblock_github::projects::ProjectFieldIds,

--- a/crates/unblock-mcp/tests/e2e_workflow.rs
+++ b/crates/unblock-mcp/tests/e2e_workflow.rs
@@ -1,3 +1,8 @@
+// TODO(unblock-paw): Full migration of this file (and tests/integration.rs, tests/common/mod.rs)
+// to the GitHubApi trait abstraction is tracked in unblock-paw. The minimal &dyn GitHubApi shim
+// applied here under unblock-uzo only exists to keep the workspace compiling after the
+// ServerState.client flip; revisit and align with unblock-paw's broader migration.
+
 //! End-to-end workflow integration test exercising all 10 Phase 1 MCP tools.
 //!
 //! This test creates real GitHub Issues and a real GitHub Project, running


### PR DESCRIPTION
Flips ServerState.client from Arc<GitHubClient> to Arc<dyn GitHubApi> so
tool handlers consume the trait. Production still uses GitHubClient via
the blanket impl; tests are unchanged.

- ServerState gets a manual Debug impl that skips the trait-object client
  (dyn GitHubApi is not Debug).
- set_project_fields free helper in server.rs now takes &dyn GitHubApi
  (compilation necessity for the field flip).
- e2e_workflow.rs CloseIssuesGuard and set_project_fields_helper migrated
  to &dyn GitHubApi to keep the test crate building.
- Test helpers in server.rs, tools/mod.rs, tools/reconcile.rs, tools/prime.rs
  cast Arc::new(client) as Arc<dyn GitHubApi>.