### PR TITLE
test(mcp): cover all 12 tool handlers via Arc<dyn GitHubApi> dispatch

### DIFF
--- a/crates/unblock-mcp/Cargo.toml
+++ b/crates/unblock-mcp/Cargo.toml
@@ -33,3 +33,4 @@ snafu = { workspace = true }
 
 [dev-dependencies]
 reqwest = { workspace = true }
+unblock-github = { path = "../unblock-github", features = ["test-hooks"] }

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -367,7 +367,7 @@ impl UnblockServer {
         name = "init",
         description = "Bootstrap a new GitHub Projects V2 project for the repository. Idempotent — returns existing project if a matching title is found. Run this before setup on a new repository."
     )]
-    async fn init(
+    pub async fn init(
         &self,
         Parameters(params): Parameters<InitParams>,
     ) -> Result<Json<InitResult>, ErrorData> {
@@ -481,7 +481,7 @@ impl UnblockServer {
         name = "setup",
         description = "Configure Projects V2 fields (Status, Priority, IssueType, Agent, StoryPoints, DeferUntil, ReadyState) and views (://ready, ://team, ://pipeline, ://roadmap, ://timeline). Safe to call repeatedly — existing fields/views are skipped. Use dry_run=true to check without mutating."
     )]
-    async fn setup(
+    pub async fn setup(
         &self,
         Parameters(params): Parameters<SetupParams>,
     ) -> Result<Json<SetupResult>, ErrorData> {
@@ -631,7 +631,7 @@ impl UnblockServer {
         name = "show",
         description = "Get full details for a single issue: body sections, blocking relationships, dependency tree (from cache), and comments. Use include_comments=false or include_deps=false to skip optional sections."
     )]
-    async fn show(
+    pub async fn show(
         &self,
         Parameters(params): Parameters<ShowParams>,
     ) -> Result<Json<ShowResult>, ErrorData> {
@@ -782,7 +782,7 @@ impl UnblockServer {
         name = "ready",
         description = "Find issues with no active blockers, sorted by priority. Filters: limit, issue_type, priority, milestone, agent, label, include_claimed. Returns from cache (rebuilds lazily if stale)."
     )]
-    async fn ready(
+    pub async fn ready(
         &self,
         Parameters(params): Parameters<ReadyParams>,
     ) -> Result<Json<ReadyResult>, ErrorData> {
@@ -842,7 +842,7 @@ impl UnblockServer {
         name = "claim",
         description = "Claim an issue for an agent. Validates the issue is open, unblocked, not deferred, and not already claimed. Sets Status=In Progress, Agent=name, ReadyState=Not Ready, and posts a comment. Triggers graph rebuild."
     )]
-    async fn claim(
+    pub async fn claim(
         &self,
         Parameters(params): Parameters<ClaimParams>,
     ) -> Result<Json<ClaimResult>, ErrorData> {
@@ -977,7 +977,7 @@ impl UnblockServer {
         name = "close",
         description = "Close an issue and cascade-unblock dependents. Validates the issue is open, closes it, updates project fields (Status=Done, ReadyState=Not Ready), and auto-unblocks any dependent issues whose blockers are now all closed. Returns the list of newly unblocked issue numbers. Triggers graph rebuild."
     )]
-    async fn close(
+    pub async fn close(
         &self,
         Parameters(params): Parameters<CloseParams>,
     ) -> Result<Json<CloseResult>, ErrorData> {
@@ -1198,7 +1198,7 @@ impl UnblockServer {
         name = "depends",
         description = "Add a blocking dependency: source becomes blocked by target. Validates both issues exist, rejects cycles and duplicates. Target accepts local number or owner/repo#number for cross-repo. Updates project fields (ReadyState=Not Ready, Status=Blocked) on source. Triggers graph rebuild."
     )]
-    async fn depends(
+    pub async fn depends(
         &self,
         Parameters(params): Parameters<DependsParams>,
     ) -> Result<Json<DependsResult>, ErrorData> {
@@ -1341,7 +1341,7 @@ impl UnblockServer {
         name = "create",
         description = "Create a new GitHub Issue. Set title (required), issue_type (default Task), priority (default P2), body, labels, blocked_by (local number or owner/repo#number), parent, story_points, defer_until. Labels are auto-created if missing. Triggers graph rebuild."
     )]
-    async fn create(
+    pub async fn create(
         &self,
         Parameters(params): Parameters<CreateParams>,
     ) -> Result<Json<CreateResult>, ErrorData> {
@@ -1622,7 +1622,7 @@ impl UnblockServer {
         name = "comment",
         description = "Post a comment on an issue. Does not affect the dependency graph or ready set — no graph rebuild is triggered. Returns the URL of the new comment."
     )]
-    async fn comment(
+    pub async fn comment(
         &self,
         Parameters(params): Parameters<CommentParams>,
     ) -> Result<Json<CommentResult>, ErrorData> {
@@ -1669,7 +1669,7 @@ impl UnblockServer {
         name = "update",
         description = "Update issue fields selectively. Supports: priority, status, labels_add, labels_remove, body_section (section: Description/Acceptance/Design, content), milestone (title), story_points, defer_until (YYYY-MM-DD). Only provided fields are changed. Triggers graph rebuild."
     )]
-    async fn update(
+    pub async fn update(
         &self,
         Parameters(params): Parameters<UpdateParams>,
     ) -> Result<Json<UpdateResult>, ErrorData> {
@@ -1973,7 +1973,7 @@ impl UnblockServer {
         name = "prime",
         description = "Session entry point for every agent session. Returns categorised issue lists: in_progress, ready, blocked, hotspots (most-blocking), and stale claims. Includes session metadata and drift warnings. Always does a fresh fetch — bypasses cache. Use stale_threshold_hours to configure stale claim detection (default 24h), max_per_category to limit output size (default 10), and agent to filter in_progress/ready/blocked/stale by agent name (exact match; completed and hotspots are never filtered)."
     )]
-    async fn prime(
+    pub async fn prime(
         &self,
         Parameters(params): Parameters<PrimeParams>,
     ) -> Result<Json<PrimeResult>, ErrorData> {
@@ -2000,7 +2000,7 @@ impl UnblockServer {
         name = "reconcile",
         description = "Detect drift between the computed dependency graph and GitHub state. Returns a DriftReport listing stale ready states, uncascaded closures, orphaned edges, cycles, and stale claims. Use fix=true to auto-repair (not yet implemented). Always does a fresh fetch — bypasses cache."
     )]
-    async fn reconcile(
+    pub async fn reconcile(
         &self,
         Parameters(params): Parameters<ReconcileParams>,
     ) -> Result<Json<ReconcileOutput>, ErrorData> {

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -1,0 +1,478 @@
+//! Runtime coverage for the `Arc<dyn GitHubApi>` dispatch layer.
+//!
+//! These tests back [`ServerState`] with [`MockGitHubClient`] stored as an
+//! `Arc<dyn GitHubApi>` trait object and invoke every tool handler on
+//! [`UnblockServer`] through that vtable. Each test asserts both the handler
+//! result and that the mock's per-method call counter incremented, proving
+//! the call traversed the dyn-dispatch layer rather than being monomorphized
+//! away.
+//!
+//! Unlike [`integration.rs`](integration.rs) and
+//! [`e2e_workflow.rs`](e2e_workflow.rs), these tests do **not** require a
+//! `GITHUB_TOKEN` — they run unconditionally in CI and are the sole runtime
+//! signal that `Arc<dyn GitHubApi>` dispatch works end-to-end.
+
+#![allow(clippy::too_many_lines)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use chrono::Utc;
+use rmcp::handler::server::wrapper::{Json, Parameters};
+use unblock_core::cache::GraphCache;
+use unblock_core::config::Config;
+use unblock_core::types::{
+    Issue, IssueState, IssueType, Priority, QualifiedId, ReadyState, Status,
+};
+use unblock_github::GitHubApi;
+use unblock_github::mock::MockGitHubClient;
+use unblock_github::projects::{
+    CreatedProject, FieldMeta, OwnerType, ProjectFieldIds, ProjectInfo, ProjectView, SetupStatus,
+    ViewLayout,
+};
+use unblock_mcp::server::{ServerState, UnblockServer};
+use unblock_mcp::tools::claim::ClaimParams;
+use unblock_mcp::tools::close::CloseParams;
+use unblock_mcp::tools::comment::CommentParams;
+use unblock_mcp::tools::create::CreateParams;
+use unblock_mcp::tools::depends::DependsParams;
+use unblock_mcp::tools::init::InitParams;
+use unblock_mcp::tools::prime::PrimeParams;
+use unblock_mcp::tools::ready::ReadyParams;
+use unblock_mcp::tools::reconcile::ReconcileParams;
+use unblock_mcp::tools::setup::SetupParams;
+use unblock_mcp::tools::show::ShowParams;
+use unblock_mcp::tools::update::UpdateParams;
+
+// ── Test fixtures ──────────────────────────────────────────────────────
+
+/// Build a minimal, deterministic `Config` without touching the environment.
+fn test_config() -> Config {
+    Config::load_from(|key| match key {
+        "GITHUB_TOKEN" => Ok("ghp_mock_token_for_dyn_dispatch_tests".to_owned()),
+        "UNBLOCK_REPO" => Ok("acme/widgets".to_owned()),
+        _ => Err(std::env::VarError::NotPresent),
+    })
+    .expect("mock test config should load")
+}
+
+/// Build a fresh `MockGitHubClient` with the same coordinates as `test_config`.
+fn new_mock() -> Arc<MockGitHubClient> {
+    Arc::new(MockGitHubClient::new("acme", "widgets", Some(1)))
+}
+
+/// Wrap a mock in a `ServerState` whose `client` is typed as
+/// `Arc<dyn GitHubApi>`. Every handler call therefore goes through the
+/// dyn-dispatch vtable.
+fn state_with_mock(mock: Arc<MockGitHubClient>) -> ServerState {
+    let config = test_config();
+    let client: Arc<dyn GitHubApi> = mock;
+    ServerState {
+        config: Arc::new(config),
+        client,
+        cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
+        agent_kind: OnceLock::new(),
+        agent_client: OnceLock::new(),
+        connected_at: OnceLock::new(),
+    }
+}
+
+/// Build a minimal, open `Issue` suitable for most handler stubs.
+fn make_issue(number: u64) -> Issue {
+    Issue {
+        qualified_id: QualifiedId::new("acme", "widgets", number),
+        number,
+        node_id: format!("I_{number}"),
+        title: format!("Issue #{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Open,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        ready_state: ReadyState::Ready,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        url: format!("https://github.com/acme/widgets/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Helper: a minimal `ProjectFieldIds` with empty option maps. Not currently
+/// used by these tests because handlers gracefully skip project-field updates
+/// when `field_ids()` returns `None`, which keeps mocks small.
+#[allow(dead_code)]
+fn empty_field_ids() -> ProjectFieldIds {
+    let meta = || FieldMeta {
+        field_id: "f".to_owned(),
+        options: HashMap::new(),
+    };
+    ProjectFieldIds {
+        status: meta(),
+        priority: meta(),
+        issue_type: meta(),
+        agent: "agent".to_owned(),
+        story_points: "sp".to_owned(),
+        defer_until: "du".to_owned(),
+        ready_state: meta(),
+    }
+}
+
+// ── init ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn init_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_detect_owner_type(Ok(OwnerType::Org));
+    mock.push_resolve_owner_node_id(Ok("O_acme".to_owned()));
+    mock.push_list_owner_projects(Ok(vec![])); // no existing match
+    mock.push_create_project(Ok(CreatedProject {
+        number: 42,
+        url: "https://github.com/orgs/acme/projects/42".to_owned(),
+    }));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .init(Parameters(InitParams {
+            scope: None,
+            title: Some("Widgets Tasks".to_owned()),
+            description: None,
+            public: None,
+        }))
+        .await
+        .expect("init should succeed via dyn dispatch");
+
+    assert_eq!(result.project_number, 42);
+    assert!(result.created);
+    assert_eq!(mock.calls().detect_owner_type(), 1);
+    assert_eq!(mock.calls().resolve_owner_node_id(), 1);
+    assert_eq!(mock.calls().list_owner_projects(), 1);
+    assert_eq!(mock.calls().create_project(), 1);
+}
+
+// ── setup ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn setup_dry_run_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_resolve_project_info(Ok(ProjectInfo {
+        id: "PVT_1".to_owned(),
+        number: 1,
+    }));
+    mock.push_detect_owner_type(Ok(OwnerType::Org));
+    mock.push_query_setup_status(Ok(SetupStatus {
+        existing: vec![],
+        missing: vec![],
+    }));
+    mock.push_list_views(Ok(vec![ProjectView {
+        id: Some(1),
+        number: 1,
+        name: "://ready".to_owned(),
+        layout: ViewLayout::Board,
+        node_id: None,
+        filter: None,
+        visible_fields: vec![],
+    }]));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .setup(Parameters(SetupParams {
+            project: None,
+            dry_run: Some(true),
+        }))
+        .await
+        .expect("setup dry-run should succeed via dyn dispatch");
+
+    assert_eq!(result.project_number, 1);
+    assert!(result.dry_run);
+    assert_eq!(mock.calls().resolve_project_info(), 1);
+    assert_eq!(mock.calls().detect_owner_type(), 1);
+    assert_eq!(mock.calls().query_setup_status(), 1);
+    assert_eq!(mock.calls().list_views(), 1);
+}
+
+// ── show ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn show_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_fetch_issue(Ok(make_issue(10)));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .show(Parameters(ShowParams {
+            id: 10,
+            include_comments: Some(false),
+            include_deps: Some(false),
+        }))
+        .await
+        .expect("show should succeed via dyn dispatch");
+
+    assert_eq!(result.issue.number, 10);
+    assert_eq!(mock.calls().fetch_issue(), 1);
+}
+
+// ── ready ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ready_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    // ready triggers a lazy rebuild when cache is stale (empty).
+    mock.push_fetch_graph_data(Ok((vec![make_issue(1)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .ready(Parameters(ReadyParams {
+            limit: None,
+            issue_type: None,
+            priority: None,
+            milestone: None,
+            agent: None,
+            label: None,
+            include_claimed: None,
+        }))
+        .await
+        .expect("ready should succeed via dyn dispatch");
+
+    assert!(!result.stale);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+// ── claim ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn claim_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    // claim uses execute_write_tool → fetch_issue, add_comment, rebuild via
+    // fetch_graph_data. field_ids returns None so project-field updates are
+    // skipped, keeping the stub set minimal.
+    mock.push_fetch_issue(Ok(make_issue(7)));
+    mock.push_add_comment(Ok(
+        "https://github.com/acme/widgets/issues/7#comment-1".to_owned()
+    ));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(7)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .claim(Parameters(ClaimParams {
+            id: 7,
+            agent: Some("alice".to_owned()),
+        }))
+        .await
+        .expect("claim should succeed via dyn dispatch");
+
+    assert_eq!(result.issue_number, 7);
+    assert_eq!(result.agent, "alice");
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().add_comment(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    assert_eq!(mock.calls().field_ids(), 1);
+}
+
+// ── close ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn close_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_fetch_issue(Ok(make_issue(8)));
+    mock.push_close_issue(Ok(()));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(8)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await
+        .expect("close should succeed via dyn dispatch");
+
+    assert_eq!(result.issue_number, 8);
+    assert!(result.unblocked.is_empty());
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().close_issue(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+// ── depends ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn depends_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_fetch_issue(Ok(make_issue(3))); // source
+    mock.push_add_blocked_by_ref(Ok(()));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(3), make_issue(5)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .depends(Parameters(DependsParams {
+            source: 3,
+            target: "5".to_owned(),
+        }))
+        .await
+        .expect("depends should succeed via dyn dispatch");
+
+    assert_eq!(result.source, 3);
+    assert_eq!(result.target, "5");
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().add_blocked_by_ref(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+// ── create ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn create_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_create_issue(Ok(make_issue(100)));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(100)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .create(Parameters(CreateParams {
+            title: "Test issue".to_owned(),
+            issue_type: None,
+            priority: None,
+            body: None,
+            labels: None,
+            milestone: None,
+            blocked_by: None,
+            parent: None,
+            story_points: None,
+            defer_until: None,
+        }))
+        .await
+        .expect("create should succeed via dyn dispatch");
+
+    assert_eq!(result.number, 100);
+    assert_eq!(mock.calls().create_issue(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+// ── comment ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn comment_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_fetch_issue(Ok(make_issue(11)));
+    mock.push_add_comment(Ok(
+        "https://github.com/acme/widgets/issues/11#comment-9".to_owned()
+    ));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .comment(Parameters(CommentParams {
+            id: 11,
+            body: "hello".to_owned(),
+        }))
+        .await
+        .expect("comment should succeed via dyn dispatch");
+
+    assert_eq!(result.issue_number, 11);
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().add_comment(), 1);
+}
+
+// ── update ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn update_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    // update handler fetches the issue twice (step 1 validate + step 9 re-fetch)
+    // and triggers a cache rebuild via execute_write_tool.
+    mock.push_fetch_issue(Ok(make_issue(12)));
+    mock.push_fetch_issue(Ok(make_issue(12)));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(12)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .update(Parameters(UpdateParams {
+            id: 12,
+            priority: None,
+            status: None,
+            labels_add: None,
+            labels_remove: None,
+            assignees_add: None,
+            assignees_remove: None,
+            body_section: None,
+            milestone: None,
+            story_points: None,
+            defer_until: None,
+        }))
+        .await
+        .expect("update should succeed via dyn dispatch");
+
+    assert_eq!(result.number, 12);
+    assert_eq!(mock.calls().fetch_issue(), 2);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+// ── prime ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn prime_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    // prime spawns a background reconcile concurrently (which also calls
+    // fetch_graph_data) and itself fetches once directly. Queue two results
+    // to cover both; counter is asserted as ≥ 1 because the background
+    // reconcile may or may not land depending on scheduling — but it
+    // typically does, so assert == 2 for determinism via join.
+    mock.push_fetch_graph_data(Ok((vec![make_issue(1)], vec![])));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(1)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .prime(Parameters(PrimeParams {
+            stale_threshold_hours: None,
+            max_per_category: None,
+            agent: None,
+        }))
+        .await
+        .expect("prime should succeed via dyn dispatch");
+
+    // Counter must show at least the direct fetch; the background spawn
+    // may or may not have completed by the time prime returns.
+    assert!(mock.calls().fetch_graph_data() >= 1);
+    // Basic sanity on result shape.
+    let _ = result.counts.ready;
+}
+
+// ── reconcile ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn reconcile_dispatches_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_fetch_graph_data(Ok((vec![make_issue(1)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(_result) = server
+        .reconcile(Parameters(ReconcileParams {
+            fix: false,
+            stale_claim_hours: 24,
+        }))
+        .await
+        .expect("reconcile should succeed via dyn dispatch");
+
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+// ── Compile-time witness ───────────────────────────────────────────────
+
+/// Compile-time proof that `Arc<MockGitHubClient>` coerces to
+/// `Arc<dyn GitHubApi>`. A future dyn-incompatible change to the trait
+/// would break this line at build time.
+#[allow(dead_code)]
+fn _dyn_object_safety_witness() {
+    let _: Arc<dyn GitHubApi> = new_mock();
+}

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -223,6 +223,40 @@ async fn show_dispatches_through_dyn_vtable() {
     assert_eq!(mock.calls().fetch_issue(), 1);
 }
 
+/// Negative-path coverage: prove that an `Err` returned by the mock also
+/// crosses the `Arc<dyn GitHubApi>` vtable boundary and propagates out as an
+/// MCP `ErrorData`. Without this, only the Ok branch is exercised through
+/// dyn dispatch and a regression in the error-path call site could pass.
+#[tokio::test]
+async fn show_err_propagates_through_dyn_vtable() {
+    let mock = new_mock();
+    mock.push_fetch_issue(Err(unblock_github::errors::Error::GitHubApi {
+        status: 404,
+        message: "Not Found".to_owned(),
+    }));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let result = server
+        .show(Parameters(ShowParams {
+            id: 999,
+            include_comments: Some(false),
+            include_deps: Some(false),
+        }))
+        .await;
+    let Err(err) = result else {
+        panic!("show must surface mock Err through dyn dispatch");
+    };
+
+    // The vtable call must have happened exactly once even on the Err path.
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    // Sanity: the propagated MCP error carries the upstream message.
+    assert!(
+        err.message.contains("Not Found") || err.message.contains("404"),
+        "expected propagated GitHub error message, got: {}",
+        err.message
+    );
+}
+
 // ── ready ──────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -424,10 +458,11 @@ async fn update_dispatches_through_dyn_vtable() {
 async fn prime_dispatches_through_dyn_vtable() {
     let mock = new_mock();
     // prime spawns a background reconcile concurrently (which also calls
-    // fetch_graph_data) and itself fetches once directly. Queue two results
-    // to cover both; counter is asserted as ≥ 1 because the background
-    // reconcile may or may not land depending on scheduling — but it
-    // typically does, so assert == 2 for determinism via join.
+    // fetch_graph_data) and itself fetches once directly. The background
+    // JoinHandle is awaited inside prime via resolve_drift_warnings(), so by
+    // the time prime returns BOTH fetches have completed deterministically.
+    // Queue two stubs and assert exactly two calls to prove both vtable
+    // traversals occurred (direct + background).
     mock.push_fetch_graph_data(Ok((vec![make_issue(1)], vec![])));
     mock.push_fetch_graph_data(Ok((vec![make_issue(1)], vec![])));
 
@@ -441,9 +476,9 @@ async fn prime_dispatches_through_dyn_vtable() {
         .await
         .expect("prime should succeed via dyn dispatch");
 
-    // Counter must show at least the direct fetch; the background spawn
-    // may or may not have completed by the time prime returns.
-    assert!(mock.calls().fetch_graph_data() >= 1);
+    // Both the direct fetch AND the awaited background reconcile fetch must
+    // have traversed the dyn vtable by now.
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
     // Basic sanity on result shape.
     let _ = result.counts.ready;
 }


### PR DESCRIPTION
Adds tests/dyn_dispatch.rs that backs ServerState with MockGitHubClient stored as Arc<dyn GitHubApi> and invokes every tool handler (init, setup, show, ready, claim, close, depends, create, comment, update, prime, reconcile) through that vtable. Each test pre-loads the mock stub queue, calls the handler on UnblockServer, asserts the result, and asserts the mock per-method call counter incremented to prove the call traversed the trait object rather than being inlined.

Wires unblock-github with features=["test-hooks"] under unblock-mcp [dev-dependencies] so MockGitHubClient is visible to mcp test targets.

The 12 handler methods on UnblockServer were promoted from private to pub visibility so external test crates can drive them directly through the same path the rmcp tool router uses in production.

These tests run unconditionally — no GITHUB_TOKEN required — and are now the sole runtime signal that Arc<dyn GitHubApi> dispatch works end-to-end.