### PR TITLE
perf(reconcile): drop per-call clone in check_uncascaded_closures

### DIFF
--- a/crates/unblock-core/src/reconcile.rs
+++ b/crates/unblock-core/src/reconcile.rs
@@ -291,11 +291,13 @@ impl ReconcileEngine {
         issues: &HashMap<QualifiedId, Issue>,
         drift: &mut Vec<DriftKind>,
     ) {
-        let issues_vec: Vec<Issue> = issues.values().cloned().collect();
         for (qid, issue) in issues {
             if issue.state == IssueState::Closed {
+                // `compute_unblock_cascade` reserves an `_all_issues` slice for
+                // future use but currently ignores it; pass an empty slice to
+                // avoid cloning every issue on each reconcile cycle.
                 let should_have_unblocked: Vec<QualifiedId> = graph
-                    .compute_unblock_cascade(qid, &issues_vec)
+                    .compute_unblock_cascade(qid, &[])
                     .into_iter()
                     .filter(|id| {
                         issues.get(id).is_some_and(|i| {


### PR DESCRIPTION
compute_unblock_cascade reserves an _all_issues parameter for future use but currently ignores it. Pass an empty slice instead of cloning every Issue on each reconcile cycle, eliminating an O(n) deep clone allocation per pass. The parameter is preserved on the public API to keep the reservation intent intact.