### PR TITLE
chore(mcp): remove dead_code allow on ServerState::config

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -123,7 +123,6 @@ unblock turns GitHub Issues into a dependency graph. Ask `ready` to get unblocke
 /// - [`OnceLock<DateTime<Utc>>`] is `Send + Sync` because `DateTime<Utc>` is `Send + Sync`.
 pub struct ServerState {
     /// Application configuration loaded from environment variables.
-    #[allow(dead_code)] // Used by tool handlers added in beads 45a.4–45a.11.
     pub config: Arc<Config>,
     /// GitHub API client for GraphQL and REST operations.
     ///


### PR DESCRIPTION
Tool handlers now reference ServerState, so the compiler can catch unused fields naturally. The config field remains pub so no warning triggers, but removing the suppression lets future refactors surface dead code.

Closes unblock-b6b.39