### PR TITLE
chore(mcp): rename ServerState.client to github per ARCH §9.1

### DIFF
--- a/crates/unblock-mcp/src/main.rs
+++ b/crates/unblock-mcp/src/main.rs
@@ -40,19 +40,19 @@ async fn main() -> Result<(), unblock_mcp::errors::BootstrapError> {
     // 5. Build server state.
     let state = ServerState {
         config: Arc::new(config),
-        client: Arc::new(client) as Arc<dyn GitHubApi>,
+        github: Arc::new(client) as Arc<dyn GitHubApi>,
         cache: Arc::new(cache),
         agent_kind: std::sync::OnceLock::new(),
         agent_client: std::sync::OnceLock::new(),
         connected_at: std::sync::OnceLock::new(),
     };
 
-    let repo_slug = format!("{}/{}", state.client.owner(), state.client.repo());
+    let repo_slug = format!("{}/{}", state.github.owner(), state.github.repo());
     info!(
         server_name = "unblock",
         version = env!("CARGO_PKG_VERSION"),
         repo = %repo_slug,
-        project = ?state.client.project_number(),
+        project = ?state.github.project_number(),
         "Starting unblock MCP server"
     );
 

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -130,7 +130,7 @@ pub struct ServerState {
     /// implementations (e.g. mocks introduced in sibling beads) can be
     /// substituted for the real [`GitHubClient`](unblock_github::client::GitHubClient) without changing the handler
     /// surface.
-    pub client: Arc<dyn GitHubApi>,
+    pub github: Arc<dyn GitHubApi>,
     /// In-memory cache for the dependency graph and ready set.
     pub cache: Arc<GraphCache>,
     /// Resolved once during the MCP `initialize` handshake.
@@ -154,12 +154,12 @@ pub struct ServerState {
 }
 
 impl std::fmt::Debug for ServerState {
-    /// Manual [`Debug`] implementation that intentionally omits the `client`
+    /// Manual [`Debug`] implementation that intentionally omits the `github`
     /// field because [`dyn GitHubApi`](GitHubApi) does not require [`Debug`].
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServerState")
             .field("config", &self.config)
-            .field("client", &"<dyn GitHubApi>")
+            .field("github", &"<dyn GitHubApi>")
             .field("cache", &self.cache)
             .field("agent_kind", &self.agent_kind)
             .field("agent_client", &self.agent_client)
@@ -372,7 +372,7 @@ impl UnblockServer {
     ) -> Result<Json<InitResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = &state.client;
+        let client = &state.github;
 
         // Step 1: Detect or use provided owner type.
         let owner_type = if let Some(ref scope) = params.scope {
@@ -489,7 +489,7 @@ impl UnblockServer {
         let dry_run = params.dry_run.unwrap_or(false);
 
         // Resolve project info — use param override or configured project number.
-        let client = &state.client;
+        let client = &state.github;
 
         // The `project` param is accepted for forward-compatibility but not yet
         // wired to resolve_project_info(). Warn agents so the silent ignore is
@@ -636,7 +636,7 @@ impl UnblockServer {
     ) -> Result<Json<ShowResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = &state.client;
+        let client = &state.github;
 
         let include_comments = params.include_comments.unwrap_or(true);
         let include_deps = params.include_deps.unwrap_or(true);
@@ -847,7 +847,7 @@ impl UnblockServer {
     ) -> Result<Json<ClaimResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = Arc::clone(&state.client);
+        let client = Arc::clone(&state.github);
         let config = Arc::clone(&state.config);
 
         let issue_number = params.id;
@@ -986,7 +986,7 @@ impl UnblockServer {
     ) -> Result<Json<CloseResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = Arc::clone(&state.client);
+        let client = Arc::clone(&state.github);
 
         let issue_number = params.id;
         // Treat Some("") (or whitespace-only) the same as None to avoid posting
@@ -1209,7 +1209,7 @@ impl UnblockServer {
     ) -> Result<Json<DependsResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = Arc::clone(&state.client);
+        let client = Arc::clone(&state.github);
 
         let source = params.source;
         let target_str = params.target.clone();
@@ -1352,7 +1352,7 @@ impl UnblockServer {
     ) -> Result<Json<CreateResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = Arc::clone(&state.client);
+        let client = Arc::clone(&state.github);
 
         info!(
             agent.kind = %kind,
@@ -1633,7 +1633,7 @@ impl UnblockServer {
     ) -> Result<Json<CommentResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = &state.client;
+        let client = &state.github;
         let issue_number = params.id;
         let body = params.body;
 
@@ -1680,7 +1680,7 @@ impl UnblockServer {
     ) -> Result<Json<UpdateResult>, ErrorData> {
         let state = self.state();
         let kind = state.agent_kind_str();
-        let client = Arc::clone(&state.client);
+        let client = Arc::clone(&state.github);
 
         let issue_number = params.id;
 
@@ -2184,7 +2184,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client) as Arc<dyn GitHubApi>,
+            github: Arc::new(client) as Arc<dyn GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: OnceLock::new(),
             agent_client: OnceLock::new(),

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -144,7 +144,7 @@ where
 pub async fn rebuild_cache(state: &ServerState) {
     state.cache.invalidate().await;
 
-    match state.client.fetch_graph_data().await {
+    match state.github.fetch_graph_data().await {
         Ok((issues, edges)) => {
             let graph = DependencyGraph::build(&issues, &edges);
             let ready_set = graph.compute_ready_set(&issues);
@@ -250,7 +250,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
+            github: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -341,7 +341,7 @@ pub async fn handle_prime(
 
     // 2. Always fresh fetch — bypasses cache entirely.
     let (issues_vec, edges) = state
-        .client
+        .github
         .fetch_graph_data()
         .await
         .map_err(github_error_to_mcp)?;
@@ -801,7 +801,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
+            github: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -143,7 +143,7 @@ impl ReconcileReport {
 /// 2. Rebuild `DependencyGraph` from scratch.
 /// 3. Compute ready set.
 /// 4. Call `ReconcileEngine::analyse()` with all 4 args.
-/// 5. Set `report.repo` from `state.client.owner()/repo()`.
+/// 5. Set `report.repo` from `state.github.owner()/repo()`.
 /// 6. If `fix: true`, repair `StaleReadyState` and `UncascadedClosure` drift.
 /// 7. Update cache with the fresh graph already fetched.
 /// 8. Return `ReconcileOutput { report }`.
@@ -163,7 +163,7 @@ pub async fn handle_reconcile(
 
     // 1. Always fresh fetch — bypasses cache entirely.
     let (issues_vec, edges) = state
-        .client
+        .github
         .fetch_graph_data()
         .await
         .map_err(github_error_to_mcp)?;
@@ -186,7 +186,7 @@ pub async fn handle_reconcile(
     // 3. Analyse drift.
     let engine = ReconcileEngine::new(params.stale_claim_hours);
     let mut report = engine.analyse(&graph, &issues, &computed_ready, Utc::now());
-    report.repo = format!("{}/{}", state.client.owner(), state.client.repo());
+    report.repo = format!("{}/{}", state.github.owner(), state.github.repo());
 
     // 4. fix: true repair path — repair StaleReadyState and UncascadedClosure.
     if params.fix {
@@ -235,13 +235,13 @@ async fn resolve_repair_context<'a>(
     match ctx {
         RepairContext::Resolved(_) | RepairContext::Failed => {}
         RepairContext::Unresolved => {
-            let Some(field_ids) = state.client.field_ids().await else {
+            let Some(field_ids) = state.github.field_ids().await else {
                 errors
                     .push("Field IDs not available — run setup first. Skipping repair.".to_owned());
                 *ctx = RepairContext::Failed;
                 return None;
             };
-            let Ok(project_info) = state.client.resolve_project_info().await else {
+            let Ok(project_info) = state.github.resolve_project_info().await else {
                 errors.push("Failed to resolve project info — skipping repair.".to_owned());
                 *ctx = RepairContext::Failed;
                 return None;
@@ -341,7 +341,7 @@ async fn apply_repairs(
                             repaired_qids.iter().map(|q| (*q).clone()).collect();
                         let comment_body = format_cascade_repair_comment(&comment_qids);
                         if let Err(e) = state
-                            .client
+                            .github
                             .add_comment(closed_issue.number, comment_body)
                             .await
                         {
@@ -424,7 +424,7 @@ async fn repair_ready_state(
 
     // Resolve the project item ID for this issue.
     let item_id = state
-        .client
+        .github
         .get_project_item_id(&issue.node_id, &project_info.id)
         .await
         .map_err(|e| format!("Failed to get project item ID for {qid}: {e}"))?;
@@ -439,7 +439,7 @@ async fn repair_ready_state(
 
     // Update the field.
     state
-        .client
+        .github
         .update_field(
             &project_info.id,
             &item_id,
@@ -545,7 +545,7 @@ mod tests {
 
         ServerState {
             config: Arc::new(config),
-            client: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
+            github: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),
@@ -567,7 +567,7 @@ mod tests {
         let client: Arc<dyn unblock_github::GitHubApi> = mock;
         ServerState {
             config: Arc::new(config),
-            client,
+            github: client,
             cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
             agent_kind: std::sync::OnceLock::new(),
             agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/tests/common/mod.rs
+++ b/crates/unblock-mcp/tests/common/mod.rs
@@ -38,7 +38,7 @@ pub async fn test_server_state() -> ServerState {
         .expect("GitHubClient::new() should succeed");
     ServerState {
         config: Arc::new(config),
-        client: Arc::new(client),
+        github: Arc::new(client),
         cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
         agent_kind: std::sync::OnceLock::new(),
         agent_client: std::sync::OnceLock::new(),

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -70,7 +70,7 @@ fn state_with_mock(mock: Arc<MockGitHubClient>) -> ServerState {
     let client: Arc<dyn GitHubApi> = mock;
     ServerState {
         config: Arc::new(config),
-        client,
+        github: client,
         cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
         agent_kind: OnceLock::new(),
         agent_client: OnceLock::new(),

--- a/crates/unblock-mcp/tests/e2e_workflow.rs
+++ b/crates/unblock-mcp/tests/e2e_workflow.rs
@@ -118,7 +118,7 @@ async fn e2e_workflow_all_10_tools() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Unique label to isolate test issues from other issues in the repo.
     let test_label = format!("e2e-test-{}", chrono::Utc::now().timestamp());

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -70,7 +70,7 @@ async fn show_existing_issue_returns_all_fields_populated() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Use issue #1, which should exist in any non-empty repo.
     let issue_number = 1;
@@ -114,7 +114,7 @@ async fn show_nonexistent_issue_returns_issue_not_found() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Use a very large number that should not exist.
     let result = client.fetch_issue(999_999_999).await;
@@ -711,7 +711,7 @@ async fn create_issue_with_all_params_and_refetch() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let title = format!(
         "[test] create tool integration test {}",
@@ -771,7 +771,7 @@ async fn create_issue_with_blocked_by_local() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Create blocker issue first.
     let blocking_title = format!("[test] blocker issue {}", chrono::Utc::now().timestamp());
@@ -847,7 +847,7 @@ async fn create_issue_with_blocked_by_cross_repo() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Extract owner/repo from the client so we can construct a CrossRepo ref
     // pointing at the same repo.
@@ -937,7 +937,7 @@ async fn create_issue_with_parent_sub_issue() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Create parent issue.
     let parent_title = format!("[test] parent issue {}", chrono::Utc::now().timestamp());
@@ -1011,7 +1011,7 @@ async fn create_issue_with_defaults() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let title = format!("[test] defaults test {}", chrono::Utc::now().timestamp());
 
@@ -1052,7 +1052,7 @@ async fn ensure_labels_creates_missing_labels() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     // Use a unique label name to avoid collisions.
     let label_name = format!("test-label-{}", chrono::Utc::now().timestamp());
@@ -1085,7 +1085,7 @@ async fn create_issue_appears_in_ready_set_after_rebuild() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let title = format!("[test] ready set test {}", chrono::Utc::now().timestamp());
 
@@ -1143,7 +1143,7 @@ async fn setup_creates_fields_on_first_run() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let project_info = client
         .resolve_project_info()
@@ -1180,7 +1180,7 @@ async fn setup_fields_idempotent_no_duplicates() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let project_info = client
         .resolve_project_info()
@@ -1225,7 +1225,7 @@ async fn setup_creates_views_with_correct_layout() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let owner_type = client
         .detect_owner_type()
@@ -1298,7 +1298,7 @@ async fn setup_views_idempotent_no_duplicates() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let owner_type = client
         .detect_owner_type()
@@ -1341,7 +1341,7 @@ async fn setup_dry_run_reports_without_mutations() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let project_info = client
         .resolve_project_info()
@@ -1446,7 +1446,7 @@ async fn setup_owner_type_detection_works() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let owner_type = client
         .detect_owner_type()
@@ -1473,7 +1473,7 @@ async fn setup_visible_fields_use_integer_ids() {
     }
 
     let state = test_server_state().await;
-    let client = &state.client;
+    let client = &state.github;
 
     let owner_type = client
         .detect_owner_type()


### PR DESCRIPTION
Aligns the field name with the spec naming convention. Field type remains Arc<dyn GitHubApi>. All call sites in server.rs, main.rs, tools/mod.rs, tools/reconcile.rs, tools/prime.rs, and tests updated. Resolves unblock-b6b.40.