### PR TITLE
chore(mcp): remove stale allow(dead_code) on github_error_to_mcp

### DIFF
--- a/crates/unblock-mcp/src/errors.rs
+++ b/crates/unblock-mcp/src/errors.rs
@@ -67,7 +67,6 @@ pub enum BootstrapError {
 /// | other                    | `INTERNAL_ERROR` (-32603) |
 ///
 /// The error's `Display` output becomes the JSON-RPC error message.
-#[allow(dead_code)] // Used by tool handlers added in beads 45a.3–45a.11.
 #[allow(clippy::needless_pass_by_value)] // Intentional: consumes the error in a map_err chain.
 pub(crate) fn github_error_to_mcp(err: unblock_github::errors::Error) -> ErrorData {
     let code = match err.status_code() {


### PR DESCRIPTION
The function is now called by the setup tool handler (unblock-45a.3), so the suppression is obsolete. Removing it lets the compiler catch future unused functions naturally.