### PR TITLE
refactor(github): extract shared check_rest_response helper

### DIFF
--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -379,26 +379,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        // Handle rate limiting.
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        // Handle non-2xx status codes.
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let json: serde_json::Value = response
             .json()
@@ -421,6 +402,49 @@ impl GitHubClient {
 
         Ok(json)
     }
+}
+
+/// Checks an HTTP response for rate limiting and non-2xx status codes.
+///
+/// Consumes the response on the error path (reading the body as text for the
+/// [`Error::GitHubApi`](errors::Error::GitHubApi) variant's `message` field),
+/// and passes the response through unchanged on success so callers can still
+/// deserialize the JSON body.
+///
+/// Behavior:
+/// - HTTP 429: returns [`Error::RateLimited`](errors::Error::RateLimited) with
+///   `reset_at` parsed from the `X-RateLimit-Reset` header.
+/// - Non-2xx (other than 429): reads the body as text and returns
+///   [`Error::GitHubApi`](errors::Error::GitHubApi).
+/// - 2xx: returns `Ok(response)`.
+///
+/// Callers that need to distinguish HTTP 404 (to surface
+/// [`IssueNotFound`](unblock_core::errors::DomainError::IssueNotFound)) must
+/// check `response.status()` for 404 **before** calling this helper, otherwise
+/// 404 will be collapsed into a generic `GitHubApi` error.
+pub(crate) async fn check_rest_response(
+    response: reqwest::Response,
+) -> Result<reqwest::Response, errors::Error> {
+    let status = response.status();
+
+    if status.as_u16() == 429 {
+        let reset_at = parse_rate_limit_reset(&response);
+        return Err(errors::RateLimitedSnafu { reset_at }.build());
+    }
+
+    if !status.is_success() {
+        let message = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "unknown error".to_owned());
+        return Err(errors::GitHubApiSnafu {
+            status: status.as_u16(),
+            message,
+        }
+        .build());
+    }
+
+    Ok(response)
 }
 
 /// Parses the `X-RateLimit-Reset` header from a response into a `DateTime<Utc>`.

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -28,7 +28,7 @@ use unblock_core::types::Issue;
 
 use crate::client::GitHubClient;
 use crate::errors::{self, Error};
-use crate::graphql::parse_rate_limit_reset;
+use crate::graphql::check_rest_response;
 
 /// Parameters for creating a new GitHub issue.
 ///
@@ -165,24 +165,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let created: CreateIssueResponse = response
             .json()
@@ -261,30 +244,13 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             return Err(unblock_core::errors::IssueNotFoundSnafu { number }
                 .build()
                 .into());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         Ok(())
     }
@@ -320,30 +286,13 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             return Err(unblock_core::errors::IssueNotFoundSnafu { number }
                 .build()
                 .into());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let comment: CreateCommentResponse = response
             .json()
@@ -384,30 +333,13 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             return Err(unblock_core::errors::IssueNotFoundSnafu { number }
                 .build()
                 .into());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         debug!(number, "Updated issue body");
         Ok(())
@@ -444,30 +376,13 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             return Err(unblock_core::errors::IssueNotFoundSnafu { number }
                 .build()
                 .into());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         debug!(number, "Added labels to issue");
         Ok(())
@@ -502,14 +417,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             // 404 can mean the issue doesn't exist or the label isn't on the issue.
             // Log and treat as success — the label is not on the issue either way.
             warn!(
@@ -519,17 +427,7 @@ impl GitHubClient {
             return Ok(());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         debug!(number, label, "Removed label from issue");
         Ok(())
@@ -573,30 +471,13 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             return Err(unblock_core::errors::IssueNotFoundSnafu { number }
                 .build()
                 .into());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         debug!(number, "Added assignees to issue");
         Ok(())
@@ -638,14 +519,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             warn!(
                 number,
                 "Assignees not found on issue (404) — treating as success"
@@ -653,17 +527,7 @@ impl GitHubClient {
             return Ok(());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         debug!(number, "Removed assignees from issue");
         Ok(())
@@ -697,24 +561,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let milestones: Vec<Milestone> = response
             .json()
@@ -762,30 +609,13 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if status.as_u16() == 404 {
+        if response.status().as_u16() == 404 {
             return Err(unblock_core::errors::IssueNotFoundSnafu { number }
                 .build()
                 .into());
         }
 
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        check_rest_response(response).await?;
 
         debug!(number, milestone_number, "Updated issue milestone");
         Ok(())

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -18,7 +18,7 @@ use tracing::{debug, instrument, warn};
 
 use crate::client::GitHubClient;
 use crate::errors::{self, Error};
-use crate::graphql::parse_rate_limit_reset;
+use crate::graphql::check_rest_response;
 
 /// Information about a resolved GitHub Projects V2 project.
 #[derive(Debug, Clone)]
@@ -987,24 +987,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let user_info: UserTypeResponse = response
             .json()
@@ -1063,24 +1046,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let raw_fields: Vec<RestFieldResponse> = response
             .json()
@@ -1153,24 +1119,7 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let status = response.status();
-
-        if status.as_u16() == 429 {
-            let reset_at = parse_rate_limit_reset(&response);
-            return Err(errors::RateLimitedSnafu { reset_at }.build());
-        }
-
-        if !status.is_success() {
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_owned());
-            return Err(errors::GitHubApiSnafu {
-                status: status.as_u16(),
-                message,
-            }
-            .build());
-        }
+        let response = check_rest_response(response).await?;
 
         let view: RestViewResponse = response
             .json()


### PR DESCRIPTION
Deduplicates the 429 rate-limit + non-2xx error handling pattern across ~14 REST call sites in unblock-github. The helper lives in graphql.rs next to parse_rate_limit_reset and is pub(crate).

Migrated sites:
- graphql.rs execute() (GraphQL HTTP error shape is identical)
- projects.rs detect_owner_type, list_rest_fields, create_view
- mutations.rs create_issue, close_issue, add_comment, update_issue_body, add_labels_to_issue, remove_label_from_issue, add_assignees_to_issue, remove_assignees_from_issue, list_milestones, update_issue_milestone, add_sub_issue and others

For call sites that also need a 404 -> IssueNotFound branch, the 404 check is performed before the helper call to preserve the domain error variant. create_label is intentionally NOT migrated because it has a 422 'already exists' special case.

Internal refactor only — no public API changes.