### PR TITLE
fix(github): error on unknown GitHub account types in detect_owner_type

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -79,6 +79,21 @@ pub enum Error {
         message: String,
     },
 
+    /// GitHub returned an account type that is not recognized as either
+    /// `Organization` or `User`.
+    ///
+    /// This guards against silent misrouting of REST calls to `/users/{owner}`
+    /// when GitHub introduces new account types (e.g., `Bot`, `Enterprise`).
+    #[snafu(display(
+        "Unknown GitHub account type '{account_type}' for owner '{owner}' — expected 'Organization' or 'User'"
+    ))]
+    UnknownOwnerType {
+        /// The GitHub login of the owner being queried.
+        owner: String,
+        /// The `type` field returned by the GitHub REST API.
+        account_type: String,
+    },
+
     /// A `MockGitHubClient` method was called without a queued stub response.
     ///
     /// Only constructible when the `test-hooks` feature is enabled. Tests
@@ -109,6 +124,7 @@ impl Error {
             Self::RateLimited { .. } => 429,
             Self::ProjectNotConfigured => 412,
             Self::GitRemote { .. } => 500,
+            Self::UnknownOwnerType { .. } => 502,
             #[cfg(feature = "test-hooks")]
             Self::MockNotStubbed { .. } => 500,
         }

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -994,10 +994,16 @@ impl GitHubClient {
             .await
             .context(errors::GitHubUnavailableSnafu)?;
 
-        let owner_type = if user_info.account_type == "Organization" {
-            OwnerType::Org
-        } else {
-            OwnerType::User
+        let owner_type = match user_info.account_type.as_str() {
+            "Organization" => OwnerType::Org,
+            "User" => OwnerType::User,
+            _ => {
+                return errors::UnknownOwnerTypeSnafu {
+                    owner: self.owner().to_owned(),
+                    account_type: user_info.account_type.clone(),
+                }
+                .fail();
+            }
         };
 
         debug!(
@@ -1466,5 +1472,90 @@ impl GitHubClient {
 
         debug!(number, url = %url, "Created project V2");
         Ok(CreatedProject { number, url })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OwnerType;
+    use crate::client::GitHubClient;
+    use crate::errors::Error;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn detect_owner_type_returns_org_for_organization_account() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/users/test-owner"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "login": "test-owner",
+                "type": "Organization"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let owner_type = client
+            .detect_owner_type()
+            .await
+            .expect("detect_owner_type should succeed");
+        assert_eq!(owner_type, OwnerType::Org);
+    }
+
+    #[tokio::test]
+    async fn detect_owner_type_returns_user_for_user_account() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/users/test-owner"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "login": "test-owner",
+                "type": "User"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let owner_type = client
+            .detect_owner_type()
+            .await
+            .expect("detect_owner_type should succeed");
+        assert_eq!(owner_type, OwnerType::User);
+    }
+
+    #[tokio::test]
+    async fn detect_owner_type_errors_on_unknown_account_type() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("GET"))
+            .and(path("/users/test-owner"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "login": "test-owner",
+                "type": "Bot"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let err = client
+            .detect_owner_type()
+            .await
+            .expect_err("detect_owner_type should fail for unknown account type");
+
+        match err {
+            Error::UnknownOwnerType {
+                owner,
+                account_type,
+            } => {
+                assert_eq!(owner, "test-owner");
+                assert_eq!(account_type, "Bot");
+            }
+            other => panic!("expected UnknownOwnerType, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Replaces the silent catch-all that routed any non-Organization account type to `/users/{owner}/...` REST endpoints with an explicit match on `Organization` and `User`. Unknown types (e.g. `Bot`, `Enterprise`) now surface an `UnknownOwnerType` error instead of causing hard-to-debug API routing failures far from the source.

API: add `Error::UnknownOwnerType { owner, account_type }` variant (status_code 502) to unblock-github.