### PR TITLE
docs(arch): document hint field in InitResult spec (§10.18)

### DIFF
--- a/docs/unblock-architecture-github.md
+++ b/docs/unblock-architecture-github.md
@@ -1361,7 +1361,19 @@ API calls: 2-3 (queries) + 0-N (repairs if fix=true)
 
 ```
 Input:  InitParams { scope?, title?, description?, public? }
-Output: InitResult { project_number, url, created, scope }
+Output: InitResult { project_number, url, created, scope, hint }
+
+Fields:
+  - project_number: u64  — project number (visible in GitHub UI URL)
+  - url: String          — canonical project URL
+  - created: bool        — true if newly created, false if an existing project with matching title was found
+  - scope: String        — resolved owner scope: "org" or "user"
+  - hint: String         — agent-facing, advisory guidance string suggesting the
+                           next step (typically recommending a `setup` invocation
+                           with the returned project_number). Emitted for both
+                           the created=true and created=false (idempotent) branches.
+                           Content is human-readable and intentionally not
+                           schema-constrained beyond being a non-empty string.
 
 Flow:
   1. Detect owner type from repo owner (GET /orgs/{owner} → 200=org, 404=user)


### PR DESCRIPTION
Align ARCH §10.18 with the init tool implementation by adding the hint field to the InitResult output shape and describing its purpose as agent-facing advisory guidance suggesting the next step.

Resolves unblock-b6b.57.