### PR TITLE
refactor(mcp): extract RelatedIssue to ShowRelatedIssue conversion

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -657,43 +657,12 @@ impl UnblockServer {
         );
 
         // Step 3: Extract blocking/blocked_by from the issue.
-        // TODO(unblock-b6b.62): Extract shared helper fn for RelatedIssue-to-ShowRelatedIssue mapping
-        let blocking: Vec<ShowRelatedIssue> = issue
-            .blocking
-            .iter()
-            .map(|r| ShowRelatedIssue {
-                number: r.number,
-                title: r.title.clone(),
-                state: format!("{:?}", r.state),
-            })
-            .collect();
-
-        let blocked_by: Vec<ShowRelatedIssue> = issue
-            .blocked_by
-            .iter()
-            .map(|r| ShowRelatedIssue {
-                number: r.number,
-                title: r.title.clone(),
-                state: format!("{:?}", r.state),
-            })
-            .collect();
+        let blocking: Vec<ShowRelatedIssue> = issue.blocking.iter().map(Into::into).collect();
+        let blocked_by: Vec<ShowRelatedIssue> = issue.blocked_by.iter().map(Into::into).collect();
 
         // Step 3b: Extract parent and sub-issues from the issue.
-        let parent: Option<ShowRelatedIssue> = issue.parent.as_ref().map(|r| ShowRelatedIssue {
-            number: r.number,
-            title: r.title.clone(),
-            state: format!("{:?}", r.state),
-        });
-
-        let sub_issues: Vec<ShowRelatedIssue> = issue
-            .sub_issues
-            .iter()
-            .map(|r| ShowRelatedIssue {
-                number: r.number,
-                title: r.title.clone(),
-                state: format!("{:?}", r.state),
-            })
-            .collect();
+        let parent: Option<ShowRelatedIssue> = issue.parent.as_ref().map(Into::into);
+        let sub_issues: Vec<ShowRelatedIssue> = issue.sub_issues.iter().map(Into::into).collect();
 
         // Step 4: If include_deps, get dependency tree from cached graph.
         let dependency_tree = if include_deps {

--- a/crates/unblock-mcp/src/tools/show.rs
+++ b/crates/unblock-mcp/src/tools/show.rs
@@ -6,6 +6,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use unblock_core::types::RelatedIssue;
 
 /// Input parameters for the `show` MCP tool.
 ///
@@ -118,6 +119,20 @@ pub struct ShowRelatedIssue {
     pub title: String,
     /// GitHub native issue state: "Open" or "Closed".
     pub state: String,
+}
+
+impl From<&RelatedIssue> for ShowRelatedIssue {
+    /// Convert a core `RelatedIssue` into the schemars-friendly wire type.
+    ///
+    /// The `state` field is produced by `Debug` formatting to preserve
+    /// the exact byte shape of the MCP tool output.
+    fn from(r: &RelatedIssue) -> Self {
+        Self {
+            number: r.number,
+            title: r.title.clone(),
+            state: format!("{:?}", r.state),
+        }
+    }
 }
 
 /// A single entry in the dependency tree.


### PR DESCRIPTION
Eliminate four identical mapping closures in the show tool handler (blocking, blocked_by, parent, sub_issues) by introducing a `From<&RelatedIssue> for ShowRelatedIssue` impl. Preserves the exact Debug-formatted `state` field to keep MCP tool output byte-identical.

Removes the TODO(unblock-b6b.62) marker at server.rs:660.

Closes unblock-b6b.62