### PR TITLE
refactor(mcp): migrate show tool input from u64 to IssueRef

### DIFF
--- a/crates/unblock-github/src/api.rs
+++ b/crates/unblock-github/src/api.rs
@@ -123,6 +123,12 @@ pub trait GitHubApi: Send + Sync {
     /// Fetches a single issue by number.
     async fn fetch_issue(&self, number: u64) -> Result<Issue, Error>;
 
+    /// Fetches a single issue identified by an [`IssueRef`].
+    ///
+    /// Supports both `Local` (configured repository) and `CrossRepo`
+    /// (arbitrary `owner/repo`) references.
+    async fn fetch_issue_ref(&self, issue_ref: &IssueRef) -> Result<Issue, Error>;
+
     /// Fetches the full set of project issues and blocking edges in one pass.
     async fn fetch_graph_data(&self) -> Result<(Vec<Issue>, Vec<BlockingEdge>), Error>;
 
@@ -300,6 +306,10 @@ impl GitHubApi for GitHubClient {
 
     async fn fetch_issue(&self, number: u64) -> Result<Issue, Error> {
         GitHubClient::fetch_issue(self, number).await
+    }
+
+    async fn fetch_issue_ref(&self, issue_ref: &IssueRef) -> Result<Issue, Error> {
+        GitHubClient::fetch_issue_ref(self, issue_ref).await
     }
 
     async fn fetch_graph_data(&self) -> Result<(Vec<Issue>, Vec<BlockingEdge>), Error> {

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -199,9 +199,32 @@ impl GitHubClient {
     /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
     #[instrument(skip(self), fields(owner = %self.owner(), repo = %self.repo()))]
     pub async fn fetch_issue(&self, number: u64) -> Result<Issue, Error> {
+        self.fetch_issue_in_repo(self.owner(), self.repo(), number)
+            .await
+    }
+
+    /// Fetches a single issue by owner/repo/number.
+    ///
+    /// Like [`fetch_issue`](Self::fetch_issue), but targets an arbitrary
+    /// `owner/repo` instead of the configured repository. Used to back
+    /// [`fetch_issue_ref`](Self::fetch_issue_ref) for cross-repo reads.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if the
+    /// issue number does not exist in the target repository.
+    ///
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    #[instrument(skip(self))]
+    pub async fn fetch_issue_in_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Result<Issue, Error> {
         let variables = serde_json::json!({
-            "owner": self.owner(),
-            "repo": self.repo(),
+            "owner": owner,
+            "repo": repo,
             "number": number.cast_signed(),
         });
 
@@ -215,7 +238,34 @@ impl GitHubClient {
                 .into());
         }
 
-        Ok(parse_issue(issue_value, self.owner(), self.repo()))
+        Ok(parse_issue(issue_value, owner, repo))
+    }
+
+    /// Fetches a single issue identified by an [`IssueRef`].
+    ///
+    /// Resolves `Local` refs against the configured repository and
+    /// `CrossRepo` refs against the specified `owner/repo`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if the
+    /// referenced issue does not exist.
+    ///
+    /// [`IssueRef`]: unblock_core::types::IssueRef
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    #[instrument(skip(self))]
+    pub async fn fetch_issue_ref(
+        &self,
+        issue_ref: &unblock_core::types::IssueRef,
+    ) -> Result<Issue, Error> {
+        match issue_ref {
+            unblock_core::types::IssueRef::Local(number) => self.fetch_issue(*number).await,
+            unblock_core::types::IssueRef::CrossRepo {
+                owner,
+                repo,
+                number,
+            } => self.fetch_issue_in_repo(owner, repo, *number).await,
+        }
     }
 
     /// Fetches all open issues and blocking edges for the dependency graph.

--- a/crates/unblock-github/src/mock.rs
+++ b/crates/unblock-github/src/mock.rs
@@ -88,6 +88,7 @@ pub struct CallCounts {
     list_owner_projects: AtomicUsize,
     create_project: AtomicUsize,
     fetch_issue: AtomicUsize,
+    fetch_issue_ref: AtomicUsize,
     fetch_graph_data: AtomicUsize,
     create_issue: AtomicUsize,
     close_issue: AtomicUsize,
@@ -136,6 +137,7 @@ impl CallCounts {
         list_owner_projects,
         create_project,
         fetch_issue,
+        fetch_issue_ref,
         fetch_graph_data,
         create_issue,
         close_issue,
@@ -179,6 +181,7 @@ impl CallCounts {
             list_owner_projects,
             create_project,
             fetch_issue,
+            fetch_issue_ref,
             fetch_graph_data,
             create_issue,
             close_issue,
@@ -229,6 +232,7 @@ pub struct Stubs {
     list_owner_projects: Mutex<VecDeque<Result<Vec<OwnerProject>, Error>>>,
     create_project: Mutex<VecDeque<Result<CreatedProject, Error>>>,
     fetch_issue: Mutex<VecDeque<Result<Issue, Error>>>,
+    fetch_issue_ref: Mutex<VecDeque<Result<Issue, Error>>>,
     fetch_graph_data: Mutex<VecDeque<GraphDataResult>>,
     create_issue: Mutex<VecDeque<Result<Issue, Error>>>,
     close_issue: Mutex<VecDeque<Result<(), Error>>>,
@@ -365,6 +369,7 @@ push_result!(
 );
 push_result!(create_project, push_create_project, CreatedProject);
 push_result!(fetch_issue, push_fetch_issue, Issue);
+push_result!(fetch_issue_ref, push_fetch_issue_ref, Issue);
 push_result!(
     fetch_graph_data,
     push_fetch_graph_data,
@@ -530,6 +535,11 @@ impl GitHubApi for MockGitHubClient {
     async fn fetch_issue(&self, _number: u64) -> Result<Issue, Error> {
         self.calls.fetch_issue.fetch_add(1, Ordering::SeqCst);
         pop_or_unstubbed(&self.stubs.fetch_issue, "fetch_issue")
+    }
+
+    async fn fetch_issue_ref(&self, _issue_ref: &IssueRef) -> Result<Issue, Error> {
+        self.calls.fetch_issue_ref.fetch_add(1, Ordering::SeqCst);
+        pop_or_unstubbed(&self.stubs.fetch_issue_ref, "fetch_issue_ref")
     }
 
     async fn fetch_graph_data(&self) -> Result<(Vec<Issue>, Vec<BlockingEdge>), Error> {

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -628,7 +628,7 @@ impl UnblockServer {
     /// This is a read tool — it does not mutate state or invalidate the cache.
     #[tool(
         name = "show",
-        description = "Get full details for a single issue: body sections, blocking relationships, dependency tree (from cache), and comments. Use include_comments=false or include_deps=false to skip optional sections."
+        description = "Get full details for a single issue: body sections, blocking relationships, dependency tree (from cache), and comments. The `issue` field accepts a local number (`42`), a hash-prefixed local number (`#42`), or a cross-repo reference (`owner/repo#42`). Use include_comments=false or include_deps=false to skip optional sections."
     )]
     pub async fn show(
         &self,
@@ -640,16 +640,29 @@ impl UnblockServer {
 
         let include_comments = params.include_comments.unwrap_or(true);
         let include_deps = params.include_deps.unwrap_or(true);
-        let issue_number = params.id;
+        let issue_str = params.issue.clone();
 
         info!(
             agent.kind = %kind,
-            issue_number,
+            issue = %issue_str,
             include_comments, include_deps, "Show tool invoked"
         );
 
-        // Step 1: Fetch the full issue via execute_read_tool.
-        let issue = execute_read_tool(state, || client.fetch_issue(issue_number)).await?;
+        // Parse the input string into an IssueRef. Mirrors the `depends`
+        // handler's parsing so error messages stay consistent.
+        let issue_ref = issue_str
+            .parse::<unblock_core::types::IssueRef>()
+            .map_err(|e| ErrorData {
+                code: rmcp::model::ErrorCode::INVALID_PARAMS,
+                message: format!("Invalid issue reference '{issue_str}': {e}").into(),
+                data: None,
+            })?;
+
+        // Step 1: Fetch the full issue via execute_read_tool. `fetch_issue_ref`
+        // dispatches to the local repo for `Local` refs and to the target
+        // `owner/repo` for `CrossRepo` refs.
+        let issue =
+            execute_read_tool(state, || async { client.fetch_issue_ref(&issue_ref).await }).await?;
 
         // Step 2: Parse body sections.
         let body_sections = unblock_core::types::BodySections::from_markdown(
@@ -665,9 +678,20 @@ impl UnblockServer {
         let sub_issues: Vec<ShowRelatedIssue> = issue.sub_issues.iter().map(Into::into).collect();
 
         // Step 4: If include_deps, get dependency tree from cached graph.
+        // Only local issues live in the cached graph — cross-repo targets
+        // return `None` (no tree) since the graph doesn't track them.
         let dependency_tree = if include_deps {
-            let issue_qid =
-                unblock_core::types::QualifiedId::new(client.owner(), client.repo(), issue_number);
+            let (owner, repo, number) = match &issue_ref {
+                unblock_core::types::IssueRef::Local(n) => {
+                    (client.owner().to_owned(), client.repo().to_owned(), *n)
+                }
+                unblock_core::types::IssueRef::CrossRepo {
+                    owner,
+                    repo,
+                    number,
+                } => (owner.clone(), repo.clone(), *number),
+            };
+            let issue_qid = unblock_core::types::QualifiedId::new(&owner, &repo, number);
             state.cache.get_graph().await.map(|graph| {
                 graph
                     .dependency_tree(&issue_qid, unblock_core::types::TraversalDirection::Both, 3)

--- a/crates/unblock-mcp/src/tools/show.rs
+++ b/crates/unblock-mcp/src/tools/show.rs
@@ -10,12 +10,23 @@ use unblock_core::types::RelatedIssue;
 
 /// Input parameters for the `show` MCP tool.
 ///
-/// Requires the issue number. Optional flags control whether comments
-/// and the dependency tree are included in the response.
+/// Requires an [`IssueRef`](unblock_core::types::IssueRef)-compatible
+/// string identifying the target issue. Accepts:
+///
+/// - a bare number for a local issue (`"42"`),
+/// - a hash-prefixed local number (`"#42"`), or
+/// - a cross-repo reference (`"owner/repo#42"`).
+///
+/// The field is typed as `String` because `IssueRef` does not derive
+/// `JsonSchema`; the handler parses the string into an `IssueRef` and
+/// resolves it via the GitHub client, mirroring the `depends` tool.
+///
+/// Optional flags control whether comments and the dependency tree are
+/// included in the response.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ShowParams {
-    /// GitHub issue number to fetch (e.g. `42`).
-    pub id: u64,
+    /// Issue reference to fetch. Accepts `42`, `#42`, or `owner/repo#42`.
+    pub issue: String,
     /// Whether to include comments in the response. Defaults to `true`.
     pub include_comments: Option<bool>,
     /// Whether to include the dependency tree in the response. Defaults to `true`.

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -207,12 +207,12 @@ async fn setup_dry_run_dispatches_through_dyn_vtable() {
 #[tokio::test]
 async fn show_dispatches_through_dyn_vtable() {
     let mock = new_mock();
-    mock.push_fetch_issue(Ok(make_issue(10)));
+    mock.push_fetch_issue_ref(Ok(make_issue(10)));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server
         .show(Parameters(ShowParams {
-            id: 10,
+            issue: "10".to_owned(),
             include_comments: Some(false),
             include_deps: Some(false),
         }))
@@ -220,7 +220,34 @@ async fn show_dispatches_through_dyn_vtable() {
         .expect("show should succeed via dyn dispatch");
 
     assert_eq!(result.issue.number, 10);
-    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+}
+
+/// Show accepts a cross-repo `owner/repo#number` reference and dispatches
+/// `fetch_issue_ref` through the trait-object vtable, confirming alignment
+/// with ARCH §10.6 (`IssueRef` input). Mirrors the cross-repo pattern used
+/// in the `depends` / `create.blocked_by` integration tests.
+#[tokio::test]
+async fn show_accepts_cross_repo_issue_ref() {
+    let mock = new_mock();
+    mock.push_fetch_issue_ref(Ok(make_issue(42)));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .show(Parameters(ShowParams {
+            issue: "acme/widgets#42".to_owned(),
+            include_comments: Some(false),
+            include_deps: Some(false),
+        }))
+        .await
+        .expect("show should accept owner/repo#number and dispatch through dyn vtable");
+
+    assert_eq!(result.issue.number, 42);
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+    // Cross-repo issues are not in the local cache graph — dependency tree
+    // is always absent here because include_deps=false, and additionally the
+    // handler must not have attempted a local-repo fetch_issue call.
+    assert_eq!(mock.calls().fetch_issue(), 0);
 }
 
 /// Negative-path coverage: prove that an `Err` returned by the mock also
@@ -230,7 +257,7 @@ async fn show_dispatches_through_dyn_vtable() {
 #[tokio::test]
 async fn show_err_propagates_through_dyn_vtable() {
     let mock = new_mock();
-    mock.push_fetch_issue(Err(unblock_github::errors::Error::GitHubApi {
+    mock.push_fetch_issue_ref(Err(unblock_github::errors::Error::GitHubApi {
         status: 404,
         message: "Not Found".to_owned(),
     }));
@@ -238,7 +265,7 @@ async fn show_err_propagates_through_dyn_vtable() {
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let result = server
         .show(Parameters(ShowParams {
-            id: 999,
+            issue: "999".to_owned(),
             include_comments: Some(false),
             include_deps: Some(false),
         }))
@@ -248,7 +275,7 @@ async fn show_err_propagates_through_dyn_vtable() {
     };
 
     // The vtable call must have happened exactly once even on the Err path.
-    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
     // Sanity: the propagated MCP error carries the upstream message.
     assert!(
         err.message.contains("Not Found") || err.message.contains("404"),

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -252,8 +252,8 @@ Design detail here.
 async fn show_include_deps_false_skips_graph_traversal() {
     let mock = new_mock();
     // Two fetches: one for include_deps=false, one for include_deps=true.
-    mock.push_fetch_issue(Ok(mock_issue(1)));
-    mock.push_fetch_issue(Ok(mock_issue(1)));
+    mock.push_fetch_issue_ref(Ok(mock_issue(1)));
+    mock.push_fetch_issue_ref(Ok(mock_issue(1)));
 
     let state = state_with_mock(Arc::clone(&mock));
 
@@ -278,7 +278,7 @@ async fn show_include_deps_false_skips_graph_traversal() {
     // include_deps=false: dependency_tree must be None despite populated cache.
     let Json(result_false) = server
         .show(Parameters(ShowParams {
-            id: 1,
+            issue: "1".to_owned(),
             include_comments: Some(true),
             include_deps: Some(false),
         }))
@@ -290,7 +290,7 @@ async fn show_include_deps_false_skips_graph_traversal() {
         result_false.dependency_tree,
     );
     assert_eq!(
-        mock.calls().fetch_issue(),
+        mock.calls().fetch_issue_ref(),
         1,
         "handler must still fetch the issue when include_deps=false",
     );
@@ -299,7 +299,7 @@ async fn show_include_deps_false_skips_graph_traversal() {
     // same cache — confirming the branch is exercised end-to-end.
     let Json(result_true) = server
         .show(Parameters(ShowParams {
-            id: 1,
+            issue: "1".to_owned(),
             include_comments: Some(true),
             include_deps: Some(true),
         }))
@@ -309,7 +309,7 @@ async fn show_include_deps_false_skips_graph_traversal() {
         result_true.dependency_tree.is_some(),
         "dependency_tree must be Some when include_deps=true and cache has graph",
     );
-    assert_eq!(mock.calls().fetch_issue(), 2);
+    assert_eq!(mock.calls().fetch_issue_ref(), 2);
 }
 
 /// End-to-end: `include_comments=false` on the real `show` handler returns
@@ -319,8 +319,8 @@ async fn show_include_deps_false_skips_graph_traversal() {
 async fn show_include_comments_false_skips_comments() {
     let mock = new_mock();
     // Two fetches: one for include_comments=false, one for =true.
-    mock.push_fetch_issue(Ok(mock_issue(7)));
-    mock.push_fetch_issue(Ok(mock_issue(7)));
+    mock.push_fetch_issue_ref(Ok(mock_issue(7)));
+    mock.push_fetch_issue_ref(Ok(mock_issue(7)));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
 
@@ -328,7 +328,7 @@ async fn show_include_comments_false_skips_comments() {
     // issue carries one comment.
     let Json(result_false) = server
         .show(Parameters(ShowParams {
-            id: 7,
+            issue: "7".to_owned(),
             include_comments: Some(false),
             include_deps: Some(false),
         }))
@@ -340,7 +340,7 @@ async fn show_include_comments_false_skips_comments() {
         result_false.comments,
     );
     assert_eq!(
-        mock.calls().fetch_issue(),
+        mock.calls().fetch_issue_ref(),
         1,
         "handler must still fetch the issue when include_comments=false",
     );
@@ -348,7 +348,7 @@ async fn show_include_comments_false_skips_comments() {
     // include_comments=true: comments must be Some(len==1).
     let Json(result_true) = server
         .show(Parameters(ShowParams {
-            id: 7,
+            issue: "7".to_owned(),
             include_comments: Some(true),
             include_deps: Some(false),
         }))
@@ -362,7 +362,7 @@ async fn show_include_comments_false_skips_comments() {
         1,
         "comments must surface the single fixture comment",
     );
-    assert_eq!(mock.calls().fetch_issue(), 2);
+    assert_eq!(mock.calls().fetch_issue_ref(), 2);
 }
 
 /// `dependency_tree` returned for issues with blocking relationships.


### PR DESCRIPTION
Aligns the `show` MCP tool with ARCH §10.6, which specifies an `IssueRef`-typed input that also supports cross-repo references (`owner/repo#number`). Previously `ShowParams.id: u64` restricted `show` to same-repo issues and diverged from `depends`, `dep_remove`, and `create.blocked_by`, which already accept `IssueRef` strings.

Schema change: the `show` tool's required field is now `issue: string` (accepts `42`, `#42`, or `owner/repo#42`) instead of `id: number`. This is a BREAKING CHANGE to the MCP `show` tool input schema. `unblock-mcp` is a binary crate so no library semver footer applies.

To back the cross-repo fetch path, `unblock-github` gains two additive methods on the `GitHubApi` trait: `fetch_issue_in_repo(owner, repo, n)` and `fetch_issue_ref(&IssueRef)`. The existing `FETCH_ISSUE_QUERY` already parameterizes owner/repo, so the cross-repo code path reuses it verbatim. `MockGitHubClient` gains a matching stub queue.

API: unblock-github GitHubApi trait: added fetch_issue_ref method. API: unblock-github GitHubClient: added fetch_issue_ref and fetch_issue_in_repo methods.

Tests:
- Existing `show_include_*` and dyn-dispatch show tests migrated from `push_fetch_issue` / `fetch_issue()` call counters to the new `fetch_issue_ref` counterparts.
- New `show_accepts_cross_repo_issue_ref` test exercises the `owner/repo#42` form through the real handler, mirroring the cross-repo pattern used in `create_issue_with_blocked_by_cross_repo`.

Refs: unblock-b6b.67