### PR TITLE
docs: update §10.6 show tool flow to reference fetch_issue_ref

### DIFF
--- a/docs/unblock-architecture-github.md
+++ b/docs/unblock-architecture-github.md
@@ -1169,7 +1169,7 @@ Output: ShowResult { issue with full details, parsed body sections, deps, commen
 Accepts `owner/repo#number` for cross-repo issues.
 
 Flow:
-  1. Single GraphQL query (fetch_issue with comments, blockedBy, blocking, parent, subIssues, fields)
+  1. Single GraphQL query (fetch_issue_ref with comments, blockedBy, blocking, parent, subIssues, fields)
   2. Parse body sections (BodySections::from_markdown)
   3. Return
 


### PR DESCRIPTION
The show tool now accepts IssueRef input and uses fetch_issue_ref, but the §10.6 flow narrative still referenced fetch_issue. Align the narrative with the §8.2 method signatures and the actual implementation.