### PR TITLE
chore(mcp): drop unnecessary issue_str clone in show handler

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -640,21 +640,21 @@ impl UnblockServer {
 
         let include_comments = params.include_comments.unwrap_or(true);
         let include_deps = params.include_deps.unwrap_or(true);
-        let issue_str = params.issue.clone();
 
         info!(
             agent.kind = %kind,
-            issue = %issue_str,
+            issue = %params.issue,
             include_comments, include_deps, "Show tool invoked"
         );
 
         // Parse the input string into an IssueRef. Mirrors the `depends`
         // handler's parsing so error messages stay consistent.
-        let issue_ref = issue_str
+        let issue_ref = params
+            .issue
             .parse::<unblock_core::types::IssueRef>()
             .map_err(|e| ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
-                message: format!("Invalid issue reference '{issue_str}': {e}").into(),
+                message: format!("Invalid issue reference '{}': {e}", params.issue).into(),
                 data: None,
             })?;
 


### PR DESCRIPTION
Remove the intermediate `issue_str` local that cloned `params.issue` before passing it to tracing and the IssueRef parser. Both call sites can operate directly on `params.issue` — tracing borrows via `%` and `str::parse` takes `&self` — so the heap allocation was unnecessary.