### PR TITLE
chore(mcp): extract duplicate mock helpers into shared test-support m…

### DIFF
--- a/crates/unblock-mcp/tests/common/mod.rs
+++ b/crates/unblock-mcp/tests/common/mod.rs
@@ -1,16 +1,20 @@
 //! Shared test helpers for `unblock-mcp` integration tests.
 //!
-//! Extracted to avoid duplication across `integration.rs` and `e2e_workflow.rs`.
+//! Extracted to avoid duplication across `integration.rs`, `dyn_dispatch.rs`,
+//! and `e2e_workflow.rs`.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use unblock_core::cache::GraphCache;
 use unblock_core::config::Config;
+use unblock_github::GitHubApi;
 use unblock_github::client::GitHubClient;
+use unblock_github::mock::MockGitHubClient;
 use unblock_mcp::server::ServerState;
 
 /// Returns `true` if the `GITHUB_TOKEN` env var is set and non-empty.
+#[allow(dead_code)] // Not every test binary uses this
 pub fn has_github_token() -> bool {
     std::env::var("GITHUB_TOKEN")
         .map(|v| !v.is_empty())
@@ -26,11 +30,13 @@ pub fn has_project_number() -> bool {
 }
 
 /// Builds a [`Config`] from the process environment for integration tests.
+#[allow(dead_code)]
 pub fn test_config() -> Config {
     Config::load().expect("Config::load() should succeed when GITHUB_TOKEN is set")
 }
 
 /// Creates a [`ServerState`] with a real client and empty cache.
+#[allow(dead_code)]
 pub async fn test_server_state() -> ServerState {
     let config = test_config();
     let client = GitHubClient::new(&config)
@@ -43,5 +49,41 @@ pub async fn test_server_state() -> ServerState {
         agent_kind: std::sync::OnceLock::new(),
         agent_client: std::sync::OnceLock::new(),
         connected_at: std::sync::OnceLock::new(),
+    }
+}
+
+// ── Mock helpers ──────────────────────────────────────────────────────
+
+/// Build a minimal, deterministic [`Config`] without touching the
+/// environment. Suitable for tests that use [`MockGitHubClient`].
+#[allow(dead_code)] // Not every test file uses every helper
+pub fn mock_test_config() -> Config {
+    Config::load_from(|key| match key {
+        "GITHUB_TOKEN" => Ok("ghp_mock_token".to_owned()),
+        "UNBLOCK_REPO" => Ok("acme/widgets".to_owned()),
+        _ => Err(std::env::VarError::NotPresent),
+    })
+    .expect("mock test config should load")
+}
+
+/// Build a fresh [`MockGitHubClient`] with fixed coordinates `acme/widgets`.
+#[allow(dead_code)]
+pub fn new_mock() -> Arc<MockGitHubClient> {
+    Arc::new(MockGitHubClient::new("acme", "widgets", Some(1)))
+}
+
+/// Wrap a mock in a [`ServerState`] whose `github` field is typed as
+/// `Arc<dyn GitHubApi>`, so handler calls traverse the dyn-dispatch vtable.
+#[allow(dead_code)]
+pub fn state_with_mock(mock: Arc<MockGitHubClient>) -> ServerState {
+    let config = mock_test_config();
+    let client: Arc<dyn GitHubApi> = mock;
+    ServerState {
+        config: Arc::new(config),
+        github: client,
+        cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
+        agent_kind: OnceLock::new(),
+        agent_client: OnceLock::new(),
+        connected_at: OnceLock::new(),
     }
 }

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -15,23 +15,19 @@
 #![allow(clippy::too_many_lines)]
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::sync::Arc;
 
 use chrono::Utc;
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use unblock_core::cache::GraphCache;
-use unblock_core::config::Config;
 use unblock_core::types::{
     Issue, IssueState, IssueType, Priority, QualifiedId, ReadyState, Status,
 };
 use unblock_github::GitHubApi;
-use unblock_github::mock::MockGitHubClient;
 use unblock_github::projects::{
     CreatedProject, FieldMeta, OwnerType, ProjectFieldIds, ProjectInfo, ProjectView, SetupStatus,
     ViewLayout,
 };
-use unblock_mcp::server::{ServerState, UnblockServer};
+use unblock_mcp::server::UnblockServer;
 use unblock_mcp::tools::claim::ClaimParams;
 use unblock_mcp::tools::close::CloseParams;
 use unblock_mcp::tools::comment::CommentParams;
@@ -45,38 +41,10 @@ use unblock_mcp::tools::setup::SetupParams;
 use unblock_mcp::tools::show::ShowParams;
 use unblock_mcp::tools::update::UpdateParams;
 
+mod common;
+use common::{new_mock, state_with_mock};
+
 // ── Test fixtures ──────────────────────────────────────────────────────
-
-/// Build a minimal, deterministic `Config` without touching the environment.
-fn test_config() -> Config {
-    Config::load_from(|key| match key {
-        "GITHUB_TOKEN" => Ok("ghp_mock_token_for_dyn_dispatch_tests".to_owned()),
-        "UNBLOCK_REPO" => Ok("acme/widgets".to_owned()),
-        _ => Err(std::env::VarError::NotPresent),
-    })
-    .expect("mock test config should load")
-}
-
-/// Build a fresh `MockGitHubClient` with the same coordinates as `test_config`.
-fn new_mock() -> Arc<MockGitHubClient> {
-    Arc::new(MockGitHubClient::new("acme", "widgets", Some(1)))
-}
-
-/// Wrap a mock in a `ServerState` whose `client` is typed as
-/// `Arc<dyn GitHubApi>`. Every handler call therefore goes through the
-/// dyn-dispatch vtable.
-fn state_with_mock(mock: Arc<MockGitHubClient>) -> ServerState {
-    let config = test_config();
-    let client: Arc<dyn GitHubApi> = mock;
-    ServerState {
-        config: Arc::new(config),
-        github: client,
-        cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
-        agent_kind: OnceLock::new(),
-        agent_client: OnceLock::new(),
-        connected_at: OnceLock::new(),
-    }
-}
 
 /// Build a minimal, open `Issue` suitable for most handler stubs.
 fn make_issue(number: u64) -> Issue {

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -4,7 +4,7 @@
 //! access to GitHub. They are skipped automatically when `GITHUB_TOKEN` is not
 //! set.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::handler::server::wrapper::{Json, Parameters};
@@ -15,17 +15,15 @@ use unblock_core::types::{
     BlockingEdge, IssueComment, IssueRef, IssueState, IssueType, Priority, QualifiedId, ReadyState,
     Status,
 };
-use unblock_github::GitHubApi;
 use unblock_github::client::GitHubClient;
-use unblock_github::mock::MockGitHubClient;
 use unblock_github::projects::{CreateViewParams, OwnerType, ViewLayout};
-use unblock_mcp::server::{ServerState, UnblockServer};
+use unblock_mcp::server::UnblockServer;
 use unblock_mcp::tools::reconcile::ReconcileParams;
 use unblock_mcp::tools::setup::REQUIRED_VIEWS;
 use unblock_mcp::tools::show::ShowParams;
 
 mod common;
-use common::{has_github_token, test_server_state};
+use common::{has_github_token, new_mock, state_with_mock, test_server_state};
 
 /// Helper to create a `QualifiedId` for tests.
 fn qid(number: u64) -> QualifiedId {
@@ -60,36 +58,6 @@ fn test_issue(number: u64, state: IssueState) -> unblock_core::types::Issue {
         blocking: vec![],
         parent: None,
         sub_issues: vec![],
-    }
-}
-
-/// Build a `Config` without touching the environment, matching `MockGitHubClient`.
-fn mock_test_config() -> Config {
-    Config::load_from(|key| match key {
-        "GITHUB_TOKEN" => Ok("ghp_mock_token_for_integration_tests".to_owned()),
-        "UNBLOCK_REPO" => Ok("acme/widgets".to_owned()),
-        _ => Err(std::env::VarError::NotPresent),
-    })
-    .expect("mock test config should load")
-}
-
-/// Build a fresh `MockGitHubClient` with fixed coordinates `acme/widgets`.
-fn new_mock() -> Arc<MockGitHubClient> {
-    Arc::new(MockGitHubClient::new("acme", "widgets", Some(1)))
-}
-
-/// Wrap a mock in a `ServerState` whose `github` field is typed as
-/// `Arc<dyn GitHubApi>`, so handler calls traverse the dyn-dispatch vtable.
-fn state_with_mock(mock: Arc<MockGitHubClient>) -> ServerState {
-    let config = mock_test_config();
-    let client: Arc<dyn GitHubApi> = mock;
-    ServerState {
-        config: Arc::new(config),
-        github: client,
-        cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
-        agent_kind: OnceLock::new(),
-        agent_client: OnceLock::new(),
-        connected_at: OnceLock::new(),
     }
 }
 


### PR DESCRIPTION
…odule

Move mock_test_config(), new_mock(), and state_with_mock() from integration.rs and dyn_dispatch.rs into tests/common/mod.rs so both test binaries share a single implementation. The token string is unified to "ghp_mock_token" (no test asserts on the value).

Issue-specific builders (mock_issue, make_issue, test_issue) remain local to each file since they differ in structure and purpose.