### PR TITLE
chore(mcp): normalize OnceLock qualification in test_server_state

### DIFF
--- a/crates/unblock-mcp/tests/common/mod.rs
+++ b/crates/unblock-mcp/tests/common/mod.rs
@@ -46,9 +46,9 @@ pub async fn test_server_state() -> ServerState {
         config: Arc::new(config),
         github: Arc::new(client),
         cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
-        agent_kind: std::sync::OnceLock::new(),
-        agent_client: std::sync::OnceLock::new(),
-        connected_at: std::sync::OnceLock::new(),
+        agent_kind: OnceLock::new(),
+        agent_client: OnceLock::new(),
+        connected_at: OnceLock::new(),
     }
 }
 


### PR DESCRIPTION
Use the already-imported OnceLock::new() instead of the fully-qualified std::sync::OnceLock::new() to match the style used by state_with_mock() in the same module.