### PR TITLE
chore(core): co-locate IssueType exhaustive-match guard with its test

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -717,6 +717,8 @@ mod tests {
     // of the enums below without updating the corresponding Display test
     // array.  No wildcard (`_`) arm — that would defeat the purpose.
 
+    // ── IssueType Display ─────────────────────────────────────────────
+
     fn _assert_all_issue_type_variants_covered(v: IssueType) {
         match v {
             IssueType::Task
@@ -727,8 +729,6 @@ mod tests {
             | IssueType::Spike => {}
         }
     }
-
-    // ── IssueType Display ─────────────────────────────────────────────
 
     #[test]
     fn issue_type_display_renders_without_quotes() {


### PR DESCRIPTION
Move _assert_all_issue_type_variants_covered() from the top of the test module to immediately above issue_type_display_renders_without_quotes(), matching the co-location pattern used by the other four guards.