### PR TITLE
docs: fix §8.1 caching strategy to reference fetch_issue_ref

### DIFF
--- a/docs/unblock-architecture-github.md
+++ b/docs/unblock-architecture-github.md
@@ -596,7 +596,7 @@ Read operation (ready, prime, stats, list, dep_cycles)
   │       └─→ fetch_graph_data()     → rebuild → cache.update(graph)
   └─→ cache.get() == Empty           → fetch_graph_data() → rebuild → cache.update(graph)
 
-show / fetch_issue (single issue with comments)
+show / fetch_issue_ref (single issue with comments)
   └─→ ALWAYS fetches fresh from GitHub (1 API call)
       No caching. Comments contain COMPLETED/DECISION/DEVIATION markers
       required for session context reconstruction. Stale comments = incorrect reviews.


### PR DESCRIPTION
The show tool's data-fetching path was migrated to fetch_issue_ref (accepting IssueRef) but §8.1 still referenced the old fetch_issue variant. Align with §8.2 and §10.6 which already use fetch_issue_ref.