### PR TITLE
chore(mcp): add debug_assert! for non-empty hint invariant in InitResult

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -423,7 +423,7 @@ impl UnblockServer {
                 title = %existing.title,
                 "Found existing project with matching title"
             );
-            return Ok(Json(InitResult {
+            let result = InitResult {
                 project_number: existing.number,
                 url: existing.url.clone(),
                 created: false,
@@ -432,7 +432,12 @@ impl UnblockServer {
                     "Project already exists. Run `setup` with project number {} to configure fields and views.",
                     existing.number
                 ),
-            }));
+            };
+            debug_assert!(
+                !result.hint.is_empty(),
+                "InitResult hint must be non-empty per ARCH §10.18"
+            );
+            return Ok(Json(result));
         }
 
         // Log forward-compat params that are accepted but not wired.
@@ -459,7 +464,7 @@ impl UnblockServer {
             "Created new project V2"
         );
 
-        Ok(Json(InitResult {
+        let result = InitResult {
             project_number: created.number,
             url: created.url,
             created: true,
@@ -468,7 +473,12 @@ impl UnblockServer {
                 "Project created! Run `setup` with project number {} to configure fields and views.",
                 created.number
             ),
-        }))
+        };
+        debug_assert!(
+            !result.hint.is_empty(),
+            "InitResult hint must be non-empty per ARCH §10.18"
+        );
+        Ok(Json(result))
     }
 
     /// Configure required Projects V2 fields and views (idempotent).

--- a/crates/unblock-mcp/src/tools/init.rs
+++ b/crates/unblock-mcp/src/tools/init.rs
@@ -51,3 +51,50 @@ pub struct InitResult {
     /// A hint message for the agent, suggesting the next step.
     pub hint: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the construction in `server.rs` for the "already exists" branch.
+    /// Ensures the hint produced by `format!()` is never empty (ARCH §10.18).
+    #[test]
+    fn init_result_existing_project_hint_is_non_empty() {
+        let project_number: u64 = 42;
+        let result = InitResult {
+            project_number,
+            url: String::from("https://github.com/orgs/acme/projects/42"),
+            created: false,
+            scope: String::from("org"),
+            hint: format!(
+                "Project already exists. Run `setup` with project number {project_number} \
+                 to configure fields and views.",
+            ),
+        };
+        assert!(
+            !result.hint.is_empty(),
+            "InitResult hint must be non-empty per ARCH §10.18"
+        );
+    }
+
+    /// Mirrors the construction in `server.rs` for the "newly created" branch.
+    /// Ensures the hint produced by `format!()` is never empty (ARCH §10.18).
+    #[test]
+    fn init_result_created_project_hint_is_non_empty() {
+        let project_number: u64 = 7;
+        let result = InitResult {
+            project_number,
+            url: String::from("https://github.com/orgs/acme/projects/7"),
+            created: true,
+            scope: String::from("org"),
+            hint: format!(
+                "Project created! Run `setup` with project number {project_number} \
+                 to configure fields and views.",
+            ),
+        };
+        assert!(
+            !result.hint.is_empty(),
+            "InitResult hint must be non-empty per ARCH §10.18"
+        );
+    }
+}


### PR DESCRIPTION
Add debug_assert!(!result.hint.is_empty()) at both InitResult construction sites in server.rs (existing-project and created-project branches) to enforce the ARCH §10.18 non-empty string contract as a regression safety net.

Add two unit tests in init.rs mirroring both construction patterns to verify the hint is never empty.