### PR TITLE
chore(github): add justification comment for 502 status on UnknownOwn…

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -124,6 +124,11 @@ impl Error {
             Self::RateLimited { .. } => 429,
             Self::ProjectNotConfigured => 412,
             Self::GitRemote { .. } => 500,
+            // 502 Bad Gateway: the upstream (GitHub) returned an unexpected account
+            // type, so our server cannot produce a valid response.  This distinguishes
+            // "GitHub gave us something we don't understand" (502) from "our own logic
+            // broke" (500).  The MCP layer maps all github errors to INTERNAL_ERROR
+            // regardless, so the distinction is informational for logs/diagnostics only.
             Self::UnknownOwnerType { .. } => 502,
             #[cfg(feature = "test-hooks")]
             Self::MockNotStubbed { .. } => 500,


### PR DESCRIPTION
…erType

Explains why UnknownOwnerType maps to HTTP 502 (Bad Gateway) rather than 500 (Internal Server Error): 502 signals that the upstream (GitHub) returned an unrecognized account type, distinguishing "unexpected upstream response" from "our own logic broke".  Notes that the MCP layer maps all github errors to INTERNAL_ERROR regardless, so the distinction is purely informational for logs and diagnostics.