### PR TITLE
chore: gate set_project_fields behind test-hooks cargo feature

### DIFF
--- a/crates/unblock-mcp/Cargo.toml
+++ b/crates/unblock-mcp/Cargo.toml
@@ -6,6 +6,11 @@ license.workspace = true
 repository.workspace = true
 description = "MCP server binary for unblock — 17 tools for dependency-aware task tracking"
 
+[features]
+# Exposes test-only helpers (e.g. `set_project_fields`) for integration tests
+# under `tests/`. Off by default — production builds never expose them.
+test-hooks = []
+
 [lints]
 workspace = true
 
@@ -34,3 +39,7 @@ snafu = { workspace = true }
 [dev-dependencies]
 reqwest = { workspace = true }
 unblock-github = { path = "../unblock-github", features = ["test-hooks"] }
+
+[[test]]
+name = "e2e_workflow"
+required-features = ["test-hooks"]

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -226,13 +226,74 @@ impl UnblockServer {
 /// should pass `"Blocked"` when the issue has blockers, or `"Backlog"` otherwise
 /// (per PRD section 6.1 and ARCH section 10.4).
 ///
-/// Exposed as `#[doc(hidden)] pub` so external integration tests under
-/// `tests/` can drive project field updates through the same code path the
-/// production server uses, eliminating duplicated test helpers. Not part of
-/// the stable surface — consumers outside this crate must not depend on it.
-#[doc(hidden)]
+/// Exposed to integration tests when the `test-hooks` feature is enabled.
+/// Production builds keep this `pub(crate)` so it never appears on the
+/// library surface.
 #[allow(clippy::too_many_arguments)]
+#[cfg(feature = "test-hooks")]
 pub async fn set_project_fields(
+    client: &dyn GitHubApi,
+    project_id: &str,
+    item_id: &str,
+    field_ids: &unblock_github::projects::ProjectFieldIds,
+    priority: &str,
+    issue_type: &str,
+    status: &str,
+    ready_state: &str,
+    story_points: Option<f64>,
+    defer_until: Option<chrono::NaiveDate>,
+) {
+    set_project_fields_inner(
+        client,
+        project_id,
+        item_id,
+        field_ids,
+        priority,
+        issue_type,
+        status,
+        ready_state,
+        story_points,
+        defer_until,
+    )
+    .await;
+}
+
+/// Non-public variant compiled when `test-hooks` is disabled.
+#[allow(clippy::too_many_arguments)]
+#[cfg(not(feature = "test-hooks"))]
+pub(crate) async fn set_project_fields(
+    client: &dyn GitHubApi,
+    project_id: &str,
+    item_id: &str,
+    field_ids: &unblock_github::projects::ProjectFieldIds,
+    priority: &str,
+    issue_type: &str,
+    status: &str,
+    ready_state: &str,
+    story_points: Option<f64>,
+    defer_until: Option<chrono::NaiveDate>,
+) {
+    set_project_fields_inner(
+        client,
+        project_id,
+        item_id,
+        field_ids,
+        priority,
+        issue_type,
+        status,
+        ready_state,
+        story_points,
+        defer_until,
+    )
+    .await;
+}
+
+/// Shared implementation for [`set_project_fields`].
+///
+/// Delegates to this inner function so the two `cfg`-gated wrappers
+/// (one `pub`, one `pub(crate)`) share a single body.
+#[allow(clippy::too_many_arguments)]
+async fn set_project_fields_inner(
     client: &dyn GitHubApi,
     project_id: &str,
     item_id: &str,


### PR DESCRIPTION
The `set_project_fields` helper in server.rs was unconditionally `pub`, exposing it on the library surface even in production builds. It is now `pub(crate)` by default and promoted to `pub` only when the `test-hooks` feature is enabled.

A shared `set_project_fields_inner` function holds the implementation so the two cfg-gated visibility wrappers share a single body. The `e2e_workflow` integration test declares `required-features = ["test-hooks"]` so it is automatically skipped by `cargo test` unless the feature is explicitly opted in.