### PR TITLE
docs: fix cargo doc intra-doc link warnings

### DIFF
--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -85,7 +85,7 @@ pub enum FieldValue {
 /// Used by the setup tool to report which fields were created vs. skipped,
 /// and by the dry-run mode to check field presence without mutating.
 ///
-/// Derived at compile time from [`REQUIRED_FIELDS`] so the two lists cannot
+/// Derived at compile time from `REQUIRED_FIELDS` (private) so the two lists cannot
 /// drift: adding, removing, or renaming a field in `REQUIRED_FIELDS`
 /// automatically updates this slice.
 pub const REQUIRED_FIELD_NAMES: &[&str] = &required_field_names();

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -2010,7 +2010,7 @@ impl UnblockServer {
     ///
     /// Performs a fresh fetch from GitHub (bypasses cache), rebuilds the graph,
     /// and runs the reconciliation engine to detect divergence. Returns a
-    /// [`DriftReport`] with all detected drift.
+    /// [`DriftReport`](unblock_core::reconcile::DriftReport) with all detected drift.
     ///
     /// By default operates in read-only mode (`fix: false`). The `fix: true`
     /// repair path is implemented by task 1.6.4.


### PR DESCRIPTION
Resolves two pre-existing `cargo doc --no-deps --workspace` warnings that block the quality gate. Both are doc-comment-only fixes — no public API changes.

unblock-b6b.183: server.rs:2013 referenced `DriftReport` via intra-doc link syntax but the type was not in scope. Rewrote the link with a fully-qualified disambiguator
(`unblock_core::reconcile::DriftReport`) rather than importing the type (which would trigger `unused_imports` under `-D warnings`, since server.rs does not use the type at the type level).

unblock-b6b.182: projects.rs:88 contained a public doc comment on `REQUIRED_FIELD_NAMES` that intra-doc-linked to the private `REQUIRED_FIELDS` constant. Rustdoc rejects public-to-private intra-doc links. Rewrote the one offending line as a plain backtick code span (matching the existing pattern on lines 89 and 94) and annotated it as `(private)` for reader clarity. No visibility change — `REQUIRED_FIELDS` remains private as intended.