### PR TITLE
docs: normalize required_field_names doc to plain code spans

### DIFF
--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -91,7 +91,7 @@ pub enum FieldValue {
 pub const REQUIRED_FIELD_NAMES: &[&str] = &required_field_names();
 
 /// Compile-time derivation of the canonical field name list from
-/// [`REQUIRED_FIELDS`]. Kept private — callers use [`REQUIRED_FIELD_NAMES`].
+/// `REQUIRED_FIELDS` (private). Kept private — callers use `REQUIRED_FIELD_NAMES`.
 const fn required_field_names() -> [&'static str; REQUIRED_FIELDS.len()] {
     let mut names = [""; REQUIRED_FIELDS.len()];
     let mut i = 0;


### PR DESCRIPTION
## Summary
- Replaces intra-doc links `[\`REQUIRED_FIELDS\`]` and `[\`REQUIRED_FIELD_NAMES\`]` in the private `required_field_names` doc comment with plain backtick code spans, matching the convention established at line 88 by unblock-b6b.182.
- Annotates `REQUIRED_FIELDS` as `(private)` so the two lines are stylistically consistent across the file.
- Pure stylistic cleanup; no functional or API change.

Implements unblock-b6b.184 (epic parent: unblock-b6b Review Findings).

## Test plan
- [x] cargo fmt --check --all
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --lib (150 passed)
- [x] cargo doc --no-deps --workspace (zero warnings)

Note: the `unblock-github` integration tests are pre-existing environment failures (require a real `.git/config` remote) and fail identically on `main` — not caused by this change.