### PR TITLE
chore: add GitHubApi::debug_label and redact Config.token in ServerSt…

### DIFF
--- a/crates/unblock-github/src/api.rs
+++ b/crates/unblock-github/src/api.rs
@@ -41,6 +41,28 @@ use crate::projects::{
 /// `Arc<dyn GitHubApi>` and shared across tokio tasks.
 #[async_trait]
 pub trait GitHubApi: Send + Sync {
+    // ── Diagnostics ───────────────────────────────────────────────────
+
+    /// Returns a human-readable label identifying the concrete implementation
+    /// behind the trait object, for use in [`Debug`](std::fmt::Debug) output
+    /// and structured logs.
+    ///
+    /// Because [`Debug`](std::fmt::Debug) is intentionally **not** a
+    /// supertrait of `GitHubApi`, callers cannot forward formatting through
+    /// the trait object. This method gives them a stable hook for emitting a
+    /// meaningful identifier (e.g. `unblock_github::client::GitHubClient` vs.
+    /// `unblock_github::mock::MockGitHubClient`) without forcing every
+    /// implementor to derive `Debug` over its private state.
+    ///
+    /// The default implementation returns [`std::any::type_name::<Self>()`],
+    /// which resolves to the concrete impl type at each call site (the trait
+    /// object's vtable carries the right monomorphisation). The exact output
+    /// of `type_name` is not guaranteed stable across compiler versions, so
+    /// the returned string is suitable for diagnostics only — never parse it.
+    fn debug_label(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     // ── Sync accessors ────────────────────────────────────────────────
 
     /// Returns the repository owner (e.g. `websublime`).

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -153,13 +153,48 @@ pub struct ServerState {
     pub connected_at: OnceLock<chrono::DateTime<Utc>>,
 }
 
+/// Local newtype that wraps a [`Config`] reference and renders it via
+/// [`Debug`](std::fmt::Debug) with the GitHub PAT replaced by a redaction
+/// marker.
+///
+/// This wrapper exists solely to keep [`ServerState`]'s [`Debug`] impl from
+/// leaking the token to logs, traces, or panic messages. It is **not** a
+/// substitute for `Config`'s derived [`Debug`] impl — other call sites that
+/// format `Config` directly remain unchanged on purpose.
+struct RedactedConfig<'a>(&'a Config);
+
+impl std::fmt::Debug for RedactedConfig<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            .field("token", &"[REDACTED]")
+            .field("api_base_url", &self.0.api_base_url)
+            .field("github_url", &self.0.github_url)
+            .field("repo", &self.0.repo)
+            .field("project_number", &self.0.project_number)
+            .field("agent", &self.0.agent)
+            .field("cache_ttl", &self.0.cache_ttl)
+            .field("log_level", &self.0.log_level)
+            .field("otel_endpoint", &self.0.otel_endpoint)
+            .finish()
+    }
+}
+
 impl std::fmt::Debug for ServerState {
-    /// Manual [`Debug`] implementation that intentionally omits the `github`
-    /// field because [`dyn GitHubApi`](GitHubApi) does not require [`Debug`].
+    /// Manual [`Debug`] implementation that:
+    ///
+    /// - Renders [`Config`] through a private `RedactedConfig` wrapper so the
+    ///   GitHub PAT stored in `config.token` never leaks via `{:?}` formatting.
+    /// - Substitutes a meaningful identifier for the `github` field instead
+    ///   of forwarding to a [`Debug`](std::fmt::Debug) impl that does not
+    ///   exist on [`dyn GitHubApi`](GitHubApi). The label is obtained via
+    ///   [`GitHubApi::debug_label`], which defaults to
+    ///   `std::any::type_name::<Self>()` and therefore reports the concrete
+    ///   implementation type behind the trait object (e.g. `GitHubClient` or
+    ///   `MockGitHubClient`).
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServerState")
-            .field("config", &self.config)
-            .field("github", &"<dyn GitHubApi>")
+            .field("config", &RedactedConfig(&self.config))
+            .field("github", &self.github.debug_label())
             .field("cache", &self.cache)
             .field("agent_kind", &self.agent_kind)
             .field("agent_client", &self.agent_client)
@@ -2205,6 +2240,57 @@ mod tests {
             agent_client: OnceLock::new(),
             connected_at: OnceLock::new(),
         }
+    }
+
+    /// The manual [`Debug`] impl for [`ServerState`] must:
+    ///
+    /// 1. Never leak the raw `Config.token` (a GitHub PAT) into the
+    ///    formatted output, replacing it with a `[REDACTED]` marker via
+    ///    the local `RedactedConfig` wrapper.
+    /// 2. Render the `github` trait-object field with a meaningful
+    ///    concrete-type label sourced from
+    ///    [`GitHubApi::debug_label`](unblock_github::api::GitHubApi::debug_label),
+    ///    rather than the historical `<dyn GitHubApi>` placeholder.
+    #[tokio::test]
+    async fn debug_redacts_token_and_labels_github_concrete_type() {
+        const SECRET: &str = "ghp_test_token_for_unit_tests";
+
+        let state = test_state().await;
+
+        // Sanity-check the precondition: the test fixture really did load
+        // the secret value into Config.token. Without this guard, a future
+        // refactor of `test_state` could silently turn the redaction
+        // assertion into a no-op.
+        assert_eq!(
+            state.config.token, SECRET,
+            "test fixture must keep using the documented test token"
+        );
+
+        let rendered = format!("{state:?}");
+
+        // Invariant 1: token must be absent from the Debug output.
+        assert!(
+            !rendered.contains(SECRET),
+            "ServerState Debug output leaked the GitHub PAT: {rendered}"
+        );
+        assert!(
+            rendered.contains("[REDACTED]"),
+            "ServerState Debug output should mark the token as [REDACTED]: {rendered}"
+        );
+
+        // Invariant 2: github field must surface a meaningful concrete label,
+        // not the legacy `<dyn GitHubApi>` placeholder. The default
+        // `debug_label` impl forwards to `std::any::type_name::<Self>()`,
+        // which on the production `GitHubClient` resolves to a path
+        // containing `GitHubClient`.
+        assert!(
+            !rendered.contains("<dyn GitHubApi>"),
+            "ServerState Debug output still uses the legacy placeholder: {rendered}"
+        );
+        assert!(
+            rendered.contains("GitHubClient"),
+            "ServerState Debug output should mention the concrete GitHubClient type: {rendered}"
+        );
     }
 
     /// `ServerState.agent_kind` starts empty (`OnceLock` not yet set).


### PR DESCRIPTION
…ate Debug

Replace the static `<dyn GitHubApi>` placeholder in `ServerState`'s manual `Debug` impl with a label sourced from a new `GitHubApi::debug_label` trait method, and stop leaking the GitHub PAT (`Config.token`) through the same `Debug` output.

`debug_label` ships with a default implementation that returns `std::any::type_name::<Self>()`, so existing implementors (`GitHubClient`, `MockGitHubClient`) need no changes and the trait addition is purely additive. Token redaction is performed via a private `RedactedConfig` newtype local to `ServerState` so other call sites that format `Config` directly are unaffected.

A focused unit test (`debug_redacts_token_and_labels_github_concrete_type`) asserts both invariants: the rendered `ServerState` debug output never contains the raw token value and surfaces the concrete `GitHubClient` type instead of the legacy placeholder.

API: GitHubApi gained `fn debug_label(&self) -> &'static str` with a default impl returning `std::any::type_name::<Self>()`. Additive change, no implementor updates required.