### PR TITLE
feat(depends): accept IssueRef for source to enable cross-repo depend…

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -469,6 +469,56 @@ impl IssueRef {
             } => QualifiedId::new(owner.clone(), repo.clone(), *number),
         }
     }
+
+    /// Normalize this reference against a repository context.
+    ///
+    /// Collapses a [`CrossRepo`](Self::CrossRepo) variant that happens to
+    /// spell the context repo back to [`Local`](Self::Local), so that
+    /// callers' downstream dispatch (pattern-matching on `Local` vs.
+    /// `CrossRepo`) treats both input forms identically. A [`Local`](Self::Local)
+    /// variant is returned unchanged — it is already in canonical form
+    /// relative to any context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use unblock_core::types::IssueRef;
+    ///
+    /// // CrossRepo pointing at the configured repo collapses to Local.
+    /// let r = IssueRef::CrossRepo {
+    ///     owner: "acme".to_owned(),
+    ///     repo: "widgets".to_owned(),
+    ///     number: 42,
+    /// };
+    /// assert_eq!(r.normalize("acme", "widgets"), IssueRef::Local(42));
+    ///
+    /// // CrossRepo pointing elsewhere is unchanged.
+    /// let r = IssueRef::CrossRepo {
+    ///     owner: "other".to_owned(),
+    ///     repo: "repo".to_owned(),
+    ///     number: 7,
+    /// };
+    /// assert_eq!(
+    ///     r.clone().normalize("acme", "widgets"),
+    ///     r
+    /// );
+    ///
+    /// // Local is always canonical.
+    /// assert_eq!(IssueRef::Local(3).normalize("acme", "widgets"), IssueRef::Local(3));
+    /// ```
+    #[must_use]
+    pub fn normalize(&self, owner: &str, repo: &str) -> Self {
+        match self {
+            Self::CrossRepo {
+                owner: ref_owner,
+                repo: ref_repo,
+                number,
+            } if ref_owner == owner && ref_repo == repo => Self::Local(*number),
+            // Local is already canonical; non-matching CrossRepo keeps
+            // its owner/repo and is returned unchanged.
+            Self::Local(_) | Self::CrossRepo { .. } => self.clone(),
+        }
+    }
 }
 
 impl std::fmt::Display for IssueRef {
@@ -969,6 +1019,57 @@ mod tests {
         };
         let qid = r.resolve("acme", "widgets");
         assert_eq!(qid, QualifiedId::new("other", "stuff", 7));
+    }
+
+    // ── IssueRef::normalize ────────────────────────────────────────────
+
+    #[test]
+    fn issue_ref_normalize_local_unchanged() {
+        let r = IssueRef::Local(42);
+        assert_eq!(r.normalize("acme", "widgets"), IssueRef::Local(42));
+    }
+
+    #[test]
+    fn issue_ref_normalize_cross_repo_aliased_to_local() {
+        let r = IssueRef::CrossRepo {
+            owner: "acme".to_owned(),
+            repo: "widgets".to_owned(),
+            number: 42,
+        };
+        assert_eq!(r.normalize("acme", "widgets"), IssueRef::Local(42));
+    }
+
+    #[test]
+    fn issue_ref_normalize_cross_repo_different_owner_unchanged() {
+        let r = IssueRef::CrossRepo {
+            owner: "other".to_owned(),
+            repo: "widgets".to_owned(),
+            number: 42,
+        };
+        assert_eq!(r.clone().normalize("acme", "widgets"), r);
+    }
+
+    #[test]
+    fn issue_ref_normalize_cross_repo_different_repo_unchanged() {
+        let r = IssueRef::CrossRepo {
+            owner: "acme".to_owned(),
+            repo: "other".to_owned(),
+            number: 42,
+        };
+        assert_eq!(r.clone().normalize("acme", "widgets"), r);
+    }
+
+    #[test]
+    fn issue_ref_normalize_preserves_resolve_identity() {
+        // Normalization must preserve the resolved QualifiedId — the two
+        // forms are equivalent identities by construction.
+        let a = IssueRef::CrossRepo {
+            owner: "acme".to_owned(),
+            repo: "widgets".to_owned(),
+            number: 42,
+        };
+        let b = a.normalize("acme", "widgets");
+        assert_eq!(a.resolve("acme", "widgets"), b.resolve("acme", "widgets"));
     }
 
     // ── Priority::as_sort_key ───────────────────────────────────────────

--- a/crates/unblock-github/src/api.rs
+++ b/crates/unblock-github/src/api.rs
@@ -240,6 +240,18 @@ pub trait GitHubApi: Send + Sync {
 
     /// Adds a blocking edge using an [`IssueRef`] as the blocker.
     async fn add_blocked_by_ref(&self, issue_number: u64, blocker: &IssueRef) -> Result<(), Error>;
+
+    /// Adds a blocking edge using [`IssueRef`] for both endpoints.
+    ///
+    /// Enables cross-repo `source` issues (e.g. a dependency where the
+    /// blocked issue lives outside the configured project). For `Local`
+    /// sources this delegates to
+    /// [`add_blocked_by_ref`](Self::add_blocked_by_ref) so the existing
+    /// local-source duplicate pre-check is preserved.
+    ///
+    /// See spec §8.4 (`depends` tool contract) and §5 cross-repo scope table.
+    async fn add_blocked_by_refs(&self, source: &IssueRef, blocker: &IssueRef)
+    -> Result<(), Error>;
 }
 
 // ── Blanket delegation impl on GitHubClient ──────────────────────────
@@ -450,5 +462,13 @@ impl GitHubApi for GitHubClient {
 
     async fn add_blocked_by_ref(&self, issue_number: u64, blocker: &IssueRef) -> Result<(), Error> {
         GitHubClient::add_blocked_by_ref(self, issue_number, blocker).await
+    }
+
+    async fn add_blocked_by_refs(
+        &self,
+        source: &IssueRef,
+        blocker: &IssueRef,
+    ) -> Result<(), Error> {
+        GitHubClient::add_blocked_by_refs(self, source, blocker).await
     }
 }

--- a/crates/unblock-github/src/mock.rs
+++ b/crates/unblock-github/src/mock.rs
@@ -109,6 +109,7 @@ pub struct CallCounts {
     get_project_item_id: AtomicUsize,
     ensure_labels: AtomicUsize,
     add_blocked_by_ref: AtomicUsize,
+    add_blocked_by_refs: AtomicUsize,
 }
 
 macro_rules! count_getters {
@@ -160,6 +161,7 @@ impl CallCounts {
         get_project_item_id,
         ensure_labels,
         add_blocked_by_ref,
+        add_blocked_by_refs,
     );
 
     /// Resets every counter to zero. Useful between phases of a single test.
@@ -206,6 +208,7 @@ impl CallCounts {
             get_project_item_id,
             ensure_labels,
             add_blocked_by_ref,
+            add_blocked_by_refs,
         );
     }
 }
@@ -259,6 +262,7 @@ pub struct Stubs {
     get_project_item_id: Mutex<VecDeque<Result<String, Error>>>,
     ensure_labels: Mutex<VecDeque<Result<(), Error>>>,
     add_blocked_by_ref: Mutex<VecDeque<Result<(), Error>>>,
+    add_blocked_by_refs: Mutex<VecDeque<Result<(), Error>>>,
 }
 
 /// Hand-written mock for [`GitHubApi`].
@@ -409,6 +413,7 @@ push_result!(resolve_issue_ref, push_resolve_issue_ref, String);
 push_result!(get_project_item_id, push_get_project_item_id, String);
 push_result!(ensure_labels, push_ensure_labels, ());
 push_result!(add_blocked_by_ref, push_add_blocked_by_ref, ());
+push_result!(add_blocked_by_refs, push_add_blocked_by_refs, ());
 push_result!(field_ids, push_field_ids, Option<ProjectFieldIds>);
 
 /// Pops the next stub off a queue, or returns `Error::MockNotStubbed` with
@@ -703,6 +708,17 @@ impl GitHubApi for MockGitHubClient {
     ) -> Result<(), Error> {
         self.calls.add_blocked_by_ref.fetch_add(1, Ordering::SeqCst);
         pop_or_unstubbed(&self.stubs.add_blocked_by_ref, "add_blocked_by_ref")
+    }
+
+    async fn add_blocked_by_refs(
+        &self,
+        _source: &IssueRef,
+        _blocker: &IssueRef,
+    ) -> Result<(), Error> {
+        self.calls
+            .add_blocked_by_refs
+            .fetch_add(1, Ordering::SeqCst);
+        pop_or_unstubbed(&self.stubs.add_blocked_by_refs, "add_blocked_by_refs")
     }
 }
 

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -1349,6 +1349,127 @@ impl GitHubClient {
             }
         }
     }
+
+    /// Adds a blocking relationship using [`IssueRef`] for both endpoints.
+    ///
+    /// Spec §8.4 requires the `depends` tool to accept cross-repo references
+    /// for both `source` and `target`. This method generalises
+    /// [`add_blocked_by_ref()`](Self::add_blocked_by_ref) (which only accepts a
+    /// cross-repo blocker) to also accept a cross-repo source.
+    ///
+    /// Dispatch:
+    /// - `source = Local(n)` → delegates to
+    ///   [`add_blocked_by_ref()`](Self::add_blocked_by_ref) so the existing
+    ///   local-source fast path (single `fetch_issue` + duplicate pre-check) is
+    ///   preserved.
+    /// - `source = CrossRepo { .. }` → fetches the source via
+    ///   [`fetch_issue_ref()`](Self::fetch_issue_ref) against its own
+    ///   owner/repo, performs the duplicate pre-check against its
+    ///   `blocked_by` list, resolves the blocker via
+    ///   [`resolve_issue_ref()`](Self::resolve_issue_ref), and runs the
+    ///   `addIssueDependency` mutation with both node IDs.
+    ///
+    /// The duplicate pre-check has a TOCTOU race like
+    /// [`add_blocked_by()`](Self::add_blocked_by) — acceptable for the
+    /// single-agent MCP server use case.
+    ///
+    /// [`IssueRef`]: unblock_core::types::IssueRef
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if either
+    /// issue does not exist.
+    /// Returns [`Error::Domain`] with [`DomainError::DuplicateDependency`] if
+    /// the blocking relationship already exists on the source.
+    /// Returns [`Error::GitHubGraphQL`] for other GraphQL errors.
+    ///
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    /// [`DomainError::DuplicateDependency`]: unblock_core::errors::DomainError::DuplicateDependency
+    #[instrument(skip(self), fields(owner = %self.owner(), repo = %self.repo()))]
+    pub async fn add_blocked_by_refs(
+        &self,
+        source: &unblock_core::types::IssueRef,
+        blocker: &unblock_core::types::IssueRef,
+    ) -> Result<(), Error> {
+        match source {
+            unblock_core::types::IssueRef::Local(source_number) => {
+                // Preserve the local-source fast path and its existing
+                // duplicate pre-check (performed inside add_blocked_by for
+                // local blockers; preserved by add_blocked_by_ref delegation
+                // for cross-repo blockers).
+                self.add_blocked_by_ref(*source_number, blocker).await
+            }
+            unblock_core::types::IssueRef::CrossRepo {
+                owner: source_owner,
+                repo: source_repo,
+                number: source_number,
+            } => {
+                // Fetch source via its own owner/repo: validates existence,
+                // gives us the node_id, and provides blocked_by for the
+                // duplicate pre-check in a single round-trip.
+                let source_issue = self.fetch_issue_ref(source).await?;
+
+                // Duplicate pre-check: GitHub's `trackedByIssues` connection
+                // only surfaces blockers within the same `owner/repo` as the
+                // source issue. Therefore the `blocked_by` list on a
+                // cross-repo source contains only entries in the source's
+                // own repo.
+                //
+                // So a duplicate match only exists when the blocker resolves
+                // to the same `owner/repo` as the source. For any other
+                // blocker (including a `Local` blocker, which lives in the
+                // configured project repo and not in the source repo), we
+                // cannot detect a duplicate client-side and rely on GitHub
+                // server-side rejection instead.
+                let blocker_number_in_source_repo = match blocker {
+                    unblock_core::types::IssueRef::CrossRepo {
+                        owner,
+                        repo,
+                        number,
+                    } if owner == source_owner && repo == source_repo => Some(*number),
+                    _ => None,
+                };
+
+                if let Some(n) = blocker_number_in_source_repo
+                    && source_issue.blocked_by.iter().any(|r| r.number == n)
+                {
+                    return Err(unblock_core::errors::DuplicateDependencySnafu {
+                        source: *source_number,
+                        target: n,
+                    }
+                    .build()
+                    .into());
+                }
+
+                let source_id = source_issue.node_id;
+                let blocker_id = self.resolve_issue_ref(blocker).await?;
+
+                let mutation = "
+                    mutation AddBlockedBy($dependentId: ID!, $dependencyId: ID!) {
+                        addIssueDependency(input: {dependentId: $dependentId, dependencyId: $dependencyId}) {
+                            clientMutationId
+                        }
+                    }
+                ";
+
+                let variables = serde_json::json!({
+                    "dependentId": source_id,
+                    "dependencyId": blocker_id,
+                });
+
+                self.graphql(mutation, variables).await?;
+
+                debug!(
+                    source_owner = %source_owner,
+                    source_repo = %source_repo,
+                    source_number,
+                    blocker = %blocker,
+                    "Added cross-repo blocking relationship (cross-repo source)"
+                );
+                Ok(())
+            }
+        }
+    }
 }
 
 /// Percent-encodes a string for use as a URL path segment.

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -1433,6 +1433,12 @@ impl GitHubClient {
                 if let Some(n) = blocker_number_in_source_repo
                     && source_issue.blocked_by.iter().any(|r| r.number == n)
                 {
+                    // TODO(unblock-29p.25): DuplicateDependencySnafu's `source`
+                    // field is `u64` and loses the cross-repo source's
+                    // owner/repo context — the error message is ambiguous
+                    // with a same-numbered local issue. Tracked as a spec
+                    // §11.1 revision (extend CircularDependency /
+                    // DuplicateDependency with cross-repo context).
                     return Err(unblock_core::errors::DuplicateDependencySnafu {
                         source: *source_number,
                         target: n,

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -84,8 +84,8 @@ unblock turns GitHub Issues into a dependency graph. Ask `ready` to get unblocke
 ### Query & Dependencies
 | Tool    | Purpose                                              | Key Params                          |
 |---------|------------------------------------------------------|-------------------------------------|
-| show    | Get full details for a single issue                  | issue_number                        |
-| depends | Show the dependency tree for an issue                | issue_number, direction?            |
+| show    | Get full details for a single issue                  | issue                               |
+| depends | Add a blocking dependency (source blocked by target) | source, target                      |
 | comment | Add a comment to an issue                            | issue_number, body                  |
 | update  | Update issue fields (priority, labels, body, etc.)   | issue_number, fields...             |
 
@@ -99,8 +99,8 @@ unblock turns GitHub Issues into a dependency graph. Ask `ready` to get unblocke
 - Always call `ready` first to find unblocked work.
 - Use `claim` before starting work to prevent conflicts.
 - After `close`, dependents are automatically re-evaluated.
-- Write tools (create, close, update, claim) trigger a graph rebuild.
-- Read tools (ready, show, depends, comment) use the cache for fast responses.
+- Write tools (create, close, update, claim, depends, comment) trigger a graph rebuild.
+- Read tools (ready, show) use the cache for fast responses.
 - Bootstrap tools (init, setup) manage the project itself and do not affect the dependency graph.
 ";
 
@@ -1184,7 +1184,7 @@ impl UnblockServer {
     /// cache rebuild.
     #[tool(
         name = "depends",
-        description = "Add a blocking dependency: source becomes blocked by target. Validates both issues exist, rejects cycles and duplicates. Target accepts local number or owner/repo#number for cross-repo. Updates project fields (Status=Blocked) on source. Triggers graph rebuild."
+        description = "Add a blocking dependency: source becomes blocked by target. Validates both issues exist, rejects cycles and duplicates, and rejects source == target. Both source and target accept a local number (42 / #42) or owner/repo#number for cross-repo. Updates project fields (Status=Blocked) on source when source is local to the configured project. Triggers graph rebuild."
     )]
     pub async fn depends(
         &self,
@@ -1194,13 +1194,27 @@ impl UnblockServer {
         let kind = state.agent_kind_str();
         let client = Arc::clone(&state.github);
 
-        let source = params.source;
+        let source_str = params.source.clone();
         let target_str = params.target.clone();
 
-        info!(agent.kind = %kind, source, target = %target_str, "Depends tool invoked");
+        info!(
+            agent.kind = %kind,
+            source = %source_str,
+            target = %target_str,
+            "Depends tool invoked"
+        );
+
+        // Parse source string into IssueRef.
+        let source_ref = source_str
+            .parse::<unblock_core::types::IssueRef>()
+            .map_err(|e| ErrorData {
+                code: rmcp::model::ErrorCode::INVALID_PARAMS,
+                message: format!("Invalid source reference '{source_str}': {e}").into(),
+                data: None,
+            })?;
 
         // Parse target string into IssueRef.
-        let issue_ref = target_str
+        let target_ref = target_str
             .parse::<unblock_core::types::IssueRef>()
             .map_err(|e| ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -1208,93 +1222,150 @@ impl UnblockServer {
                 data: None,
             })?;
 
-        // Step 1: Validate source issue exists.
-        let source_issue = client
-            .fetch_issue(source)
-            .await
-            .map_err(crate::errors::github_error_to_mcp)?;
-
-        // Step 2: Cycle detection using cached graph (local targets only).
-        // Cross-repo targets are not present in the local graph, so cycle
-        // detection is skipped — no local cycle is possible. Checking with
-        // the bare number from a CrossRepo ref would incorrectly match a
-        // local issue with the same number, causing false positive rejections.
-        if let unblock_core::types::IssueRef::Local(target_number) = &issue_ref
-            && let Some(graph) = state.cache.get_graph().await
-            && graph.would_create_cycle(
-                &unblock_core::types::QualifiedId::new(client.owner(), client.repo(), source),
-                &unblock_core::types::QualifiedId::new(
-                    client.owner(),
-                    client.repo(),
-                    *target_number,
-                ),
-            )
-        {
+        // Spec §8.4: source != target is a required validation.
+        // Compare on the fully-qualified id (resolved against the configured
+        // repo) so that e.g. `"42"` and `"#42"` collapse to the same identity
+        // and the check also rejects a Local vs. CrossRepo pointing at the
+        // same configured-repo issue.
+        let source_qid = source_ref.resolve(client.owner(), client.repo());
+        let target_qid = target_ref.resolve(client.owner(), client.repo());
+        if source_qid == target_qid {
             return Err(crate::errors::github_error_to_mcp(
-                CircularDependencySnafu {
-                    source,
-                    target: *target_number,
+                unblock_core::errors::ValidationSnafu {
+                    message: format!(
+                        "depends: source and target must differ (both resolved to {source_qid})"
+                    ),
                 }
                 .build()
                 .into(),
             ));
         }
 
+        // Step 1: Validate source issue exists, resolving against its own
+        // owner/repo so cross-repo sources are fetched correctly.
+        let source_issue = client
+            .fetch_issue_ref(&source_ref)
+            .await
+            .map_err(crate::errors::github_error_to_mcp)?;
+
+        // Step 2: Cycle detection using cached graph.
+        // The cache only covers the configured project's repo, so we can
+        // only detect cycles when BOTH endpoints are local to that repo.
+        // When either endpoint is cross-repo, the cached graph does not
+        // contain it; we skip client-side cycle detection and rely on
+        // GitHub's server-side rejection at mutation time.
+        match (&source_ref, &target_ref) {
+            (
+                unblock_core::types::IssueRef::Local(source_number),
+                unblock_core::types::IssueRef::Local(target_number),
+            ) => {
+                if let Some(graph) = state.cache.get_graph().await
+                    && graph.would_create_cycle(
+                        &unblock_core::types::QualifiedId::new(
+                            client.owner(),
+                            client.repo(),
+                            *source_number,
+                        ),
+                        &unblock_core::types::QualifiedId::new(
+                            client.owner(),
+                            client.repo(),
+                            *target_number,
+                        ),
+                    )
+                {
+                    return Err(crate::errors::github_error_to_mcp(
+                        CircularDependencySnafu {
+                            source: *source_number,
+                            target: *target_number,
+                        }
+                        .build()
+                        .into(),
+                    ));
+                }
+            }
+            _ => {
+                tracing::warn!(
+                    source = %source_ref,
+                    target = %target_ref,
+                    "Cross-repo endpoint: client-side cycle detection skipped (graph covers configured repo only); relying on server-side rejection."
+                );
+            }
+        }
+
         // Step 3: Add blocking relationship and rebuild cache via execute_write_tool.
         execute_write_tool(state, || {
             let client = Arc::clone(&client);
-            let issue_ref = issue_ref.clone();
+            let source_ref = source_ref.clone();
+            let target_ref = target_ref.clone();
 
-            async move { client.add_blocked_by_ref(source, &issue_ref).await }
+            async move { client.add_blocked_by_refs(&source_ref, &target_ref).await }
         })
         .await?;
 
-        // Step 4: Update Projects V2 fields on source issue:
-        // Status → Blocked.
+        // Step 4: Update Projects V2 fields on source issue (Status=Blocked).
+        // Only applies when source is local to the configured project: the
+        // Projects V2 item lookup (`get_project_item_id`) is scoped to the
+        // configured project, so cross-repo sources cannot have their
+        // fields updated here per spec §5 cross-repo scope table.
         // TODO(unblock-b6b.79): Fourth copy of field update ladder — extract shared helper.
-        if let Some(field_ids) = client.field_ids().await {
-            if let Ok(project_info) = client.resolve_project_info().await {
-                if let Ok(item_id) = client
-                    .get_project_item_id(&source_issue.node_id, &project_info.id)
-                    .await
-                {
-                    // Status → blocked
-                    if let Some(option_id) = field_ids.status.options.get("blocked")
-                        && let Err(e) = client
-                            .update_field(
-                                &project_info.id,
-                                &item_id,
-                                &field_ids.status.field_id,
-                                &FieldValue::SingleSelectOption(option_id.clone()),
-                            )
-                            .await
+        if matches!(source_ref, unblock_core::types::IssueRef::Local(_)) {
+            if let Some(field_ids) = client.field_ids().await {
+                if let Ok(project_info) = client.resolve_project_info().await {
+                    if let Ok(item_id) = client
+                        .get_project_item_id(&source_issue.node_id, &project_info.id)
+                        .await
                     {
+                        // Status → blocked
+                        if let Some(option_id) = field_ids.status.options.get("blocked")
+                            && let Err(e) = client
+                                .update_field(
+                                    &project_info.id,
+                                    &item_id,
+                                    &field_ids.status.field_id,
+                                    &FieldValue::SingleSelectOption(option_id.clone()),
+                                )
+                                .await
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                "Failed to set Status=blocked on source issue"
+                            );
+                        }
+                    } else {
                         tracing::warn!(
-                            error = %e,
-                            "Failed to set Status=blocked on source issue"
+                            "Failed to get project item ID for source issue — fields will not be set"
                         );
                     }
                 } else {
                     tracing::warn!(
-                        "Failed to get project item ID for source issue — fields will not be set"
+                        "Failed to resolve project info — source issue fields will not be set"
                     );
                 }
             } else {
-                tracing::warn!(
-                    "Failed to resolve project info — source issue fields will not be set"
+                tracing::debug!(
+                    "No field IDs cached — run setup first to enable project field assignment"
                 );
             }
         } else {
             tracing::debug!(
-                "No field IDs cached — run setup first to enable project field assignment"
+                source = %source_ref,
+                "Cross-repo source: skipping Projects V2 field update (source is outside the configured project)."
             );
         }
 
+        // Render source and target refs in canonical form. For a bare local
+        // number (e.g. "42"), IssueRef::Local Display writes "#42"; we
+        // preserve that shape for both endpoints so the result format is
+        // stable regardless of which accepted input form the caller used.
+        let source_rendered = source_ref.to_string();
+        let target_rendered = target_ref.to_string();
+
         Ok(Json(DependsResult {
-            source,
-            target: target_str,
+            created: true,
+            source: source_rendered.clone(),
+            target: target_rendered.clone(),
             message: format!(
-                "Issue #{source} is now blocked by {issue_ref}. Source marked as blocked."
+                "Issue {source_rendered} is now blocked by {target_rendered}. Source marked as blocked."
             ),
         }))
     }

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1205,7 +1205,7 @@ impl UnblockServer {
         );
 
         // Parse source string into IssueRef.
-        let source_ref = source_str
+        let source_ref_raw = source_str
             .parse::<unblock_core::types::IssueRef>()
             .map_err(|e| ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -1214,7 +1214,7 @@ impl UnblockServer {
             })?;
 
         // Parse target string into IssueRef.
-        let target_ref = target_str
+        let target_ref_raw = target_str
             .parse::<unblock_core::types::IssueRef>()
             .map_err(|e| ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
@@ -1222,11 +1222,23 @@ impl UnblockServer {
                 data: None,
             })?;
 
+        // Normalize both refs against the configured repo. A
+        // `CrossRepo { owner, repo, number }` that happens to spell the
+        // configured repo collapses to `Local(number)`, so every
+        // downstream guard that dispatches on `Local` vs `CrossRepo`
+        // (fetch path, cycle detection, Projects V2 field update,
+        // mutation dispatch) treats aliased forms identically to the
+        // canonical local form. See `IssueRef::normalize` for details.
+        let source_ref = source_ref_raw.normalize(client.owner(), client.repo());
+        let target_ref = target_ref_raw.normalize(client.owner(), client.repo());
+
         // Spec §8.4: source != target is a required validation.
         // Compare on the fully-qualified id (resolved against the configured
         // repo) so that e.g. `"42"` and `"#42"` collapse to the same identity
         // and the check also rejects a Local vs. CrossRepo pointing at the
-        // same configured-repo issue.
+        // same configured-repo issue. Both `resolve` and `normalize` agree
+        // on this identity, so using the normalized refs here is equivalent
+        // to using the raw refs.
         let source_qid = source_ref.resolve(client.owner(), client.repo());
         let target_qid = target_ref.resolve(client.owner(), client.repo());
         if source_qid == target_qid {
@@ -1242,7 +1254,9 @@ impl UnblockServer {
         }
 
         // Step 1: Validate source issue exists, resolving against its own
-        // owner/repo so cross-repo sources are fetched correctly.
+        // owner/repo so cross-repo sources are fetched correctly. After
+        // normalization, a source that aliases the configured repo is
+        // `Local(n)` and `fetch_issue_ref` takes the repo-scoped fast path.
         let source_issue = client
             .fetch_issue_ref(&source_ref)
             .await
@@ -1253,7 +1267,9 @@ impl UnblockServer {
         // only detect cycles when BOTH endpoints are local to that repo.
         // When either endpoint is cross-repo, the cached graph does not
         // contain it; we skip client-side cycle detection and rely on
-        // GitHub's server-side rejection at mutation time.
+        // GitHub's server-side rejection at mutation time. Normalization
+        // above ensures that a caller spelling the configured repo as
+        // `owner/repo#n` still enters this arm.
         match (&source_ref, &target_ref) {
             (
                 unblock_core::types::IssueRef::Local(source_number),
@@ -1307,6 +1323,8 @@ impl UnblockServer {
         // Projects V2 item lookup (`get_project_item_id`) is scoped to the
         // configured project, so cross-repo sources cannot have their
         // fields updated here per spec §5 cross-repo scope table.
+        // Normalization above ensures a caller spelling the configured
+        // repo as `owner/repo#n` still takes this branch.
         // TODO(unblock-b6b.79): Fourth copy of field update ladder — extract shared helper.
         if matches!(source_ref, unblock_core::types::IssueRef::Local(_)) {
             if let Some(field_ids) = client.field_ids().await {
@@ -1353,10 +1371,12 @@ impl UnblockServer {
             );
         }
 
-        // Render source and target refs in canonical form. For a bare local
-        // number (e.g. "42"), IssueRef::Local Display writes "#42"; we
-        // preserve that shape for both endpoints so the result format is
-        // stable regardless of which accepted input form the caller used.
+        // Render source and target refs in canonical form. After
+        // normalization, `owner/repo#n` aliasing the configured repo
+        // renders as `#n` (Local), matching the `"42"` and `"#42"` input
+        // forms and fulfilling the "stable output regardless of input
+        // form" contract. Cross-repo refs that point at other repos
+        // render as `owner/repo#n`.
         let source_rendered = source_ref.to_string();
         let target_rendered = target_ref.to_string();
 

--- a/crates/unblock-mcp/src/tools/depends.rs
+++ b/crates/unblock-mcp/src/tools/depends.rs
@@ -2,41 +2,51 @@
 //!
 //! Validates both issues exist, checks for cycles and duplicates, then creates
 //! the blocking relationship via the GitHub API. Updates Projects V2 fields on
-//! the source issue (Status=Blocked), and rebuilds the
-//! cache so the ready set reflects the new dependency.
+//! the source issue (Status=Blocked) when the source is local to the
+//! configured project; skips field updates for cross-repo sources. Rebuilds
+//! the cache so the ready set reflects the new dependency.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Input parameters for the `depends` MCP tool.
 ///
-/// The `source` issue will become blocked by the `target` issue. The source
-/// must be in the configured repository. The target can be a local issue
-/// number or a cross-repo reference in `owner/repo#number` format.
+/// The `source` issue will become blocked by the `target` issue. Both sides
+/// accept an [`IssueRef`](unblock_core::types::IssueRef)-compatible string:
+///
+/// - a bare number for a local issue (`"42"`),
+/// - a hash-prefixed local number (`"#42"`), or
+/// - a cross-repo reference (`"owner/repo#42"`).
+///
+/// Per spec §8.4, `source != target` is required. Cross-repo sources are
+/// outside the configured project, so the Projects V2 field update on the
+/// source (Status=Blocked) is skipped for them — GitHub still records the
+/// dependency edge itself cross-repo.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DependsParams {
-    /// Issue number that will be blocked (must be in the configured repo).
-    pub source: u64,
-    /// The issue that blocks source. Accepts a plain integer for local issues
-    /// (e.g. `"42"`) or `owner/repo#number` for cross-repo (e.g.
-    /// `"websublime/other-repo#7"`).
+    /// Issue that will be blocked. Accepts `42`, `#42`, or `owner/repo#42`.
+    pub source: String,
+    /// Issue that blocks `source`. Accepts `42`, `#42`, or `owner/repo#42`.
     pub target: String,
 }
 
 /// Result returned by the `depends` MCP tool.
 ///
-/// Confirms the blocking relationship was created, including the source issue
-/// number, the resolved target reference, and a human-readable message.
+/// Confirms the blocking relationship was created, including a `created` flag
+/// (spec §8.4), the resolved source and target references as strings, and a
+/// human-readable message.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct DependsResult {
-    /// The source issue number (the one that is now blocked).
-    pub source: u64,
-    /// The target reference as provided (local number or cross-repo ref).
+    /// `true` when a new blocking edge was created by this call.
+    pub created: bool,
+    /// The source issue reference as resolved (local `#n` or `owner/repo#n`).
+    pub source: String,
+    /// The target issue reference as resolved (local `#n` or `owner/repo#n`).
     pub target: String,
     /// Human-readable confirmation message.
     pub message: String,
 }
 
-// TODO(unblock-45a.12): Add integration tests for depends tool (local dep,
+// TODO(unblock-29p.13): Add integration tests for depends tool (local dep,
 // cross-repo dep, cycle detection, duplicate detection, non-existent issue)
 // as part of the E2E workflow integration test.

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -429,8 +429,8 @@ async fn close_with_empty_reason_skips_comment() {
 #[tokio::test]
 async fn depends_dispatches_through_dyn_vtable() {
     let mock = new_mock();
-    mock.push_fetch_issue(Ok(make_issue(3))); // source
-    mock.push_add_blocked_by_ref(Ok(()));
+    mock.push_fetch_issue_ref(Ok(make_issue(3))); // source (local)
+    mock.push_add_blocked_by_refs(Ok(()));
     // field_ids=Some enters the project-field update branch. With empty
     // option maps, no update_field calls are made (Status=Blocked is
     // gated by options.get()).
@@ -445,21 +445,107 @@ async fn depends_dispatches_through_dyn_vtable() {
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server
         .depends(Parameters(DependsParams {
-            source: 3,
+            source: "3".to_owned(),
             target: "5".to_owned(),
         }))
         .await
         .expect("depends should succeed via dyn dispatch");
 
-    assert_eq!(result.source, 3);
-    assert_eq!(result.target, "5");
-    assert_eq!(mock.calls().fetch_issue(), 1);
-    assert_eq!(mock.calls().add_blocked_by_ref(), 1);
+    assert!(result.created, "created flag must be true on success");
+    // Both source and target render in canonical Display form: local refs
+    // use the hash-prefix shape (e.g. "#3"), matching IssueRef::Local Display.
+    assert_eq!(result.source, "#3");
+    assert_eq!(result.target, "#5");
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+    assert_eq!(mock.calls().add_blocked_by_refs(), 1);
     assert_eq!(mock.calls().fetch_graph_data(), 1);
     assert_eq!(mock.calls().field_ids(), 1);
     assert_eq!(mock.calls().resolve_project_info(), 1);
     assert_eq!(mock.calls().get_project_item_id(), 1);
     assert_eq!(mock.calls().update_field(), 0);
+    // Old local-source entry points must NOT be called.
+    assert_eq!(mock.calls().fetch_issue(), 0);
+    assert_eq!(mock.calls().add_blocked_by_ref(), 0);
+}
+
+/// Exercises the cross-repo source path (`source: "other-owner/other-repo#7"`).
+///
+/// Verifies:
+/// - `fetch_issue_ref` is called for source (not `fetch_issue`, which is
+///   local-only).
+/// - `add_blocked_by_refs` is the mutation entry point used.
+/// - Projects V2 field update on source is SKIPPED (source is outside the
+///   configured project), so `field_ids`, `resolve_project_info`,
+///   `get_project_item_id`, and `update_field` are not called.
+/// - Cache rebuild (`fetch_graph_data`) still runs.
+/// - The result renders `source` and `target` in their canonical `IssueRef`
+///   `Display` forms.
+#[tokio::test]
+async fn depends_accepts_cross_repo_source() {
+    let mock = new_mock();
+    // Source fetch uses fetch_issue_ref for the cross-repo source.
+    // Build a shaped issue — number is 7 in other-owner/other-repo.
+    let mut source_issue = make_issue(7);
+    source_issue.qualified_id = QualifiedId::new("other-owner", "other-repo", 7);
+    source_issue.url = "https://github.com/other-owner/other-repo/issues/7".to_owned();
+    mock.push_fetch_issue_ref(Ok(source_issue));
+    mock.push_add_blocked_by_refs(Ok(()));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(5)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .depends(Parameters(DependsParams {
+            source: "other-owner/other-repo#7".to_owned(),
+            target: "5".to_owned(),
+        }))
+        .await
+        .expect("depends should succeed for cross-repo source");
+
+    assert!(result.created);
+    assert_eq!(result.source, "other-owner/other-repo#7");
+    assert_eq!(result.target, "#5");
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+    assert_eq!(mock.calls().add_blocked_by_refs(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // Field update path MUST be skipped for cross-repo source.
+    assert_eq!(mock.calls().field_ids(), 0);
+    assert_eq!(mock.calls().resolve_project_info(), 0);
+    assert_eq!(mock.calls().get_project_item_id(), 0);
+    assert_eq!(mock.calls().update_field(), 0);
+}
+
+/// Rejects `source == target` (spec §8.4 validation requirement).
+///
+/// The check operates on the resolved [`QualifiedId`], so local variants
+/// `"42"` and `"#42"` collapse to the same identity and are rejected. No
+/// network calls should be issued.
+#[tokio::test]
+async fn depends_rejects_self_reference() {
+    let mock = new_mock();
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let err = server
+        .depends(Parameters(DependsParams {
+            source: "42".to_owned(),
+            target: "#42".to_owned(),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("source == target must be rejected as a validation error");
+
+    // Mapped to INVALID_PARAMS by github_error_to_mcp (HTTP 400).
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("source and target"),
+        "message should mention the self-ref validation: {}",
+        err.message
+    );
+
+    // No outbound calls should have been made.
+    assert_eq!(mock.calls().fetch_issue(), 0);
+    assert_eq!(mock.calls().fetch_issue_ref(), 0);
+    assert_eq!(mock.calls().add_blocked_by_ref(), 0);
+    assert_eq!(mock.calls().add_blocked_by_refs(), 0);
 }
 
 // ── create ─────────────────────────────────────────────────────────────

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -19,7 +19,10 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use unblock_core::types::{Issue, IssueState, IssueType, Priority, QualifiedId, Status};
+use unblock_core::graph::DependencyGraph;
+use unblock_core::types::{
+    BlockingEdge, Issue, IssueState, IssueType, Priority, QualifiedId, Status,
+};
 use unblock_github::GitHubApi;
 use unblock_github::projects::{
     CreatedProject, FieldMeta, OwnerType, ProjectFieldIds, ProjectInfo, ProjectView, SetupStatus,
@@ -546,6 +549,189 @@ async fn depends_rejects_self_reference() {
     assert_eq!(mock.calls().fetch_issue_ref(), 0);
     assert_eq!(mock.calls().add_blocked_by_ref(), 0);
     assert_eq!(mock.calls().add_blocked_by_refs(), 0);
+}
+
+/// Exercises the aliasing case for `source`: when the caller spells the
+/// configured repo explicitly as a cross-repo ref (`acme/widgets#N` where
+/// the configured repo IS `acme/widgets`), the handler must treat the ref
+/// as local for every downstream guard.
+///
+/// Verifies the normalization fix for the review [WARNING]s:
+/// 1. Cycle detection runs: a pre-populated cache with an edge
+///    `target -> source` causes `would_create_cycle` to fire, and the
+///    handler returns a `CircularDependency` error — proving it took the
+///    `(Local, Local)` arm rather than the cross-repo skip-warn arm.
+/// 2. Result rendering is the canonical Local form (`"#N"`), matching
+///    what `"N"` and `"#N"` inputs produce, fulfilling the "stable
+///    output regardless of input form" contract.
+///
+/// Notes: this test is scoped to cycle rejection, so it does NOT invoke
+/// the mutation, field update, or graph rebuild paths. A sibling test
+/// below covers the happy path and asserts the field-update call
+/// counters.
+#[tokio::test]
+async fn depends_aliased_configured_repo_source_cycle_detection() {
+    let mock = new_mock();
+    // Source (issue #3) is in the configured repo (acme/widgets). The
+    // handler must fetch it via fetch_issue_ref(Local(3)) after
+    // normalization.
+    mock.push_fetch_issue_ref(Ok(make_issue(3)));
+
+    // Pre-populate the cache with a graph containing a cycle that
+    // would_create_cycle(source=3, target=5) will detect:
+    // path target(5) -> source(3) already exists.
+    let issues = vec![make_issue(3), make_issue(5)];
+    let edges = vec![BlockingEdge {
+        source: QualifiedId::new("acme", "widgets", 5),
+        target: QualifiedId::new("acme", "widgets", 3),
+    }];
+    let graph = DependencyGraph::build(&issues, &edges);
+    let ready_set = graph.compute_ready_set(&issues);
+
+    let state = state_with_mock(Arc::clone(&mock));
+    let cache = Arc::clone(&state.cache);
+    cache.update(ready_set, graph).await;
+
+    let server = UnblockServer::new(state);
+
+    // Caller passes source as CrossRepo form pointing at the configured
+    // repo. Without normalization, the handler would take the skip-warn
+    // cross-repo arm and the mutation would proceed. With normalization,
+    // the handler enters the (Local, Local) arm, runs would_create_cycle,
+    // and rejects.
+    let err = server
+        .depends(Parameters(DependsParams {
+            source: "acme/widgets#3".to_owned(),
+            target: "5".to_owned(),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("cycle must be detected for aliased-configured-repo source");
+
+    // CircularDependency maps to 422 → INVALID_PARAMS.
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.to_lowercase().contains("circular"),
+        "error message should reference a circular dependency: {}",
+        err.message
+    );
+
+    // Source fetch happened (step 1 of the handler).
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+    // Mutation MUST NOT run when cycle is rejected.
+    assert_eq!(mock.calls().add_blocked_by_refs(), 0);
+    assert_eq!(mock.calls().add_blocked_by_ref(), 0);
+    // Rebuild does not run when we rejected before the mutation.
+    assert_eq!(mock.calls().fetch_graph_data(), 0);
+}
+
+/// Exercises the aliasing-case happy path for `source`: `acme/widgets#N`
+/// where the configured repo IS `acme/widgets`.
+///
+/// Verifies the normalization fix for the review [WARNING]s (happy path):
+/// - The Projects V2 field update ladder runs (`field_ids`,
+///   `resolve_project_info`, `get_project_item_id` each called once). Under
+///   the aliasing bug this was skipped.
+/// - The mutation entry point is still `add_blocked_by_refs` (the
+///   `GitHubApi` trait method), invoked exactly once.
+/// - Result rendering: `source` is the canonical Local form (`"#3"`),
+///   matching the `"3"` and `"#3"` input forms — fulfills the
+///   "stable output regardless of input form" contract.
+#[tokio::test]
+async fn depends_aliased_configured_repo_source_happy_path() {
+    let mock = new_mock();
+    mock.push_fetch_issue_ref(Ok(make_issue(3))); // source (aliased as cross-repo)
+    mock.push_add_blocked_by_refs(Ok(()));
+    mock.push_field_ids(Some(empty_field_ids()));
+    mock.push_resolve_project_info(Ok(ProjectInfo {
+        id: "PVT_1".to_owned(),
+        number: 1,
+    }));
+    mock.push_get_project_item_id(Ok("PVTI_aliased".to_owned()));
+    mock.push_fetch_graph_data(Ok((vec![make_issue(3), make_issue(5)], vec![])));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .depends(Parameters(DependsParams {
+            source: "acme/widgets#3".to_owned(),
+            target: "5".to_owned(),
+        }))
+        .await
+        .expect("depends should succeed for aliased-configured-repo source");
+
+    assert!(result.created);
+    // Source renders as the canonical Local form "#3", matching the
+    // unaliased "3" and "#3" inputs.
+    assert_eq!(result.source, "#3");
+    assert_eq!(result.target, "#5");
+
+    // Source fetch path (step 1 of the handler) ran once.
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+    // Mutation dispatch (step 3).
+    assert_eq!(mock.calls().add_blocked_by_refs(), 1);
+    // Cache rebuild (wrap in execute_write_tool).
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // Projects V2 field update ladder MUST run for aliased local source.
+    // Under the aliasing bug these counters would all be 0.
+    assert_eq!(mock.calls().field_ids(), 1);
+    assert_eq!(mock.calls().resolve_project_info(), 1);
+    assert_eq!(mock.calls().get_project_item_id(), 1);
+    // Empty option maps gate the SingleSelectOption update, so
+    // update_field is not called — identical to the canonical-form test.
+    assert_eq!(mock.calls().update_field(), 0);
+    // The local-only fallbacks must NOT be called.
+    assert_eq!(mock.calls().fetch_issue(), 0);
+    assert_eq!(mock.calls().add_blocked_by_ref(), 0);
+}
+
+/// Mirrors `depends_aliased_configured_repo_source_cycle_detection` with
+/// the alias on `target` instead of `source`. Source is local (`"3"`);
+/// target is `"acme/widgets#5"` (aliased cross-repo form of the
+/// configured repo's issue #5).
+///
+/// Without normalization on `target_ref`, the cycle-detection `match` arm
+/// would skip with a warn because the `(Local, CrossRepo)` pattern falls
+/// through. With normalization, both refs are `Local`, the arm runs, and
+/// the pre-seeded cycle is detected.
+#[tokio::test]
+async fn depends_aliased_configured_repo_target_cycle_detection() {
+    let mock = new_mock();
+    mock.push_fetch_issue_ref(Ok(make_issue(3)));
+
+    let issues = vec![make_issue(3), make_issue(5)];
+    let edges = vec![BlockingEdge {
+        source: QualifiedId::new("acme", "widgets", 5),
+        target: QualifiedId::new("acme", "widgets", 3),
+    }];
+    let graph = DependencyGraph::build(&issues, &edges);
+    let ready_set = graph.compute_ready_set(&issues);
+
+    let state = state_with_mock(Arc::clone(&mock));
+    let cache = Arc::clone(&state.cache);
+    cache.update(ready_set, graph).await;
+
+    let server = UnblockServer::new(state);
+
+    let err = server
+        .depends(Parameters(DependsParams {
+            source: "3".to_owned(),
+            target: "acme/widgets#5".to_owned(),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("cycle must be detected for aliased-configured-repo target");
+
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.to_lowercase().contains("circular"),
+        "error message should reference a circular dependency: {}",
+        err.message
+    );
+
+    assert_eq!(mock.calls().fetch_issue_ref(), 1);
+    assert_eq!(mock.calls().add_blocked_by_refs(), 0);
+    assert_eq!(mock.calls().add_blocked_by_ref(), 0);
+    assert_eq!(mock.calls().fetch_graph_data(), 0);
 }
 
 // ── create ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
…encies

Brings the `depends` MCP tool in line with spec §8.4. Both `source` and `target` now accept IssueRef-compatible strings (local `42`/`#42` or cross-repo `owner/repo#42`), not just target.

- unblock-mcp:
  - DependsParams.source: u64 -> String; DependsResult.source: u64 ->
    String; add DependsResult.created: bool (spec §8.4).
  - Validate source != target (compared on resolved QualifiedId so "42" == "#42" and Local vs CrossRepo-to-same-id are rejected).
  - Fetch source via fetch_issue_ref so cross-repo sources resolve against their own owner/repo, not the configured project.
  - Cycle detection only when BOTH endpoints are local; for cross-repo endpoints the cached graph cannot prove a cycle, so we log a warn and rely on GitHub's server-side rejection.
  - Projects V2 field update (Status=Blocked) guarded by IssueRef::Local(_) on source — cross-repo sources are outside the configured project, so field updates are skipped with a debug log.
  - Render source/target in the result via IssueRef Display (canonical `#n` or `owner/repo#n`) regardless of input shape.
  - Tool description and INSTRUCTIONS_STR updated to reflect both-sides IssueRef and the correct read/write classification.
  - TODO bead reference in depends.rs refreshed to unblock-29p.13.

- unblock-github:
  - New GitHubClient::add_blocked_by_refs(source, blocker) on both the concrete client and the GitHubApi trait. Preserves the existing add_blocked_by_ref fast path when source is Local; for cross-repo source fetches via fetch_issue_ref, does a best-effort duplicate pre-check when the blocker's owner/repo matches the source's (per GitHub's repo-scoped trackedByIssues limitation), resolves the blocker node ID, and runs addIssueDependency.
  - MockGitHubClient mirrors the new method with counter + stub queue + push_add_blocked_by_refs helper.

- Tests (crates/unblock-mcp/tests/dyn_dispatch.rs):
  - depends_dispatches_through_dyn_vtable updated for String params, created flag, canonical Display output, and add_blocked_by_refs dispatch.
  - depends_accepts_cross_repo_source: exercises source = "other-owner/other-repo#7", asserts Projects V2 field update path is fully skipped.
  - depends_rejects_self_reference: asserts source == target is rejected via INVALID_PARAMS without any network calls.

MCP tool contract break: JSON callers previously sending `source: 42` (integer) must now send `source: "42"` (string). MCP is a binary crate with no downstream library consumers, so no API: footer is required on that shift.

API: add GitHubApi::add_blocked_by_refs(&IssueRef, &IssueRef) and the matching inherent method on GitHubClient.

Refs: spec §8.4, §5 cross-repo scope table; plan GAP-06. Closes bead unblock-29p.4 implementation scope (review pending).