### PR TITLE
feat(mcp): implement stats MCP tool for aggregated issue metrics

### DIFF
--- a/crates/unblock-core/benches/cache_bench.rs
+++ b/crates/unblock-core/benches/cache_bench.rs
@@ -106,7 +106,7 @@ fn build_populated_cache(rt: &Runtime, n: usize) -> Arc<GraphCache> {
     let graph = DependencyGraph::build(&issues, &edges);
     let ready_set = graph.compute_ready_set(&issues);
     let cache = Arc::new(GraphCache::new(Duration::from_secs(300)));
-    rt.block_on(cache.update(ready_set, graph));
+    rt.block_on(cache.update(issues, ready_set, graph));
     cache
 }
 

--- a/crates/unblock-core/src/cache.rs
+++ b/crates/unblock-core/src/cache.rs
@@ -4,13 +4,17 @@
 //! configurable TTL. Every write operation invalidates the cache, triggering a
 //! rebuild on the next read.
 //!
-//! The cache stores both the computed ready set and the full
-//! [`DependencyGraph`](crate::graph::DependencyGraph), so callers can run ad-hoc
-//! graph queries (e.g., dependency tree, cycle detection) without a full rebuild.
+//! The cache stores the full open-issue set, the computed ready set, and the
+//! full [`DependencyGraph`](crate::graph::DependencyGraph), so callers can run
+//! ad-hoc graph queries (dependency tree, cycle detection) **and** per-issue
+//! aggregations (status/priority/agent counts) without a full rebuild. Caching
+//! the issues vector is required by the `stats` MCP tool (spec §7.4) so that
+//! the cache-hit path issues zero GitHub API calls.
 //!
 //! Cached values are wrapped in [`Arc`](std::sync::Arc) so that read accessors return
 //! reference-counted handles instead of deep-cloning the entire data structure.
-//! This makes `get_ready_set()` and `get_graph()` O(1) regardless of graph size.
+//! This makes `get_ready_set()`, `get_graph()`, and `get_issues()` O(1) regardless
+//! of graph size.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -18,19 +22,27 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 use crate::graph::DependencyGraph;
-use crate::types::IssueSummary;
+use crate::types::{Issue, IssueSummary};
 
 /// A snapshot of the computed graph state at a point in time.
 ///
 /// Crate-internal only — external consumers access cached data through
-/// [`GraphCache`] accessor methods (`get_ready_set`, `get_graph`).
+/// [`GraphCache`] accessor methods (`get_ready_set`, `get_graph`, `get_issues`).
 ///
 /// Stored inside [`GraphCache`] and replaced atomically on each update.
-/// Both `ready_set` and `graph` are wrapped in [`Arc`] so that read
-/// accessors return cheap reference-counted handles (O(1) atomic
-/// increment) instead of deep-cloning the entire data structure.
+/// All three payload fields (`issues`, `ready_set`, `graph`) are wrapped in
+/// [`Arc`] so that read accessors return cheap reference-counted handles
+/// (O(1) atomic increment) instead of deep-cloning the entire data structure.
 #[derive(Debug, Clone)]
 pub(crate) struct CacheEntry {
+    /// The full open-issue set observed when the cache was populated.
+    ///
+    /// Required for per-issue aggregations (e.g. by-status/by-priority counts
+    /// in the `stats` tool) on the cache-hit path, where no GitHub fetch is
+    /// issued. Equivalent to the `issues` slice passed into
+    /// [`DependencyGraph::build`](crate::graph::DependencyGraph::build) at
+    /// cache population time.
+    pub(crate) issues: Arc<Vec<Issue>>,
     /// The pre-computed ready set (issues with no active blockers).
     pub(crate) ready_set: Arc<Vec<IssueSummary>>,
     /// Timestamp when this entry was computed.
@@ -92,15 +104,27 @@ impl GraphCache {
             .map(|entry| Arc::clone(&entry.ready_set))
     }
 
-    /// Replace the cached entry with a new ready set and graph.
+    /// Replace the cached entry with a new issue set, ready set, and graph.
     ///
     /// The provided values are wrapped in [`Arc`] before storing, so
     /// subsequent reads return cheap reference-counted handles.
     /// Sets `computed_at` to `Instant::now()`, resetting the TTL window.
     /// This acquires an exclusive write lock.
-    pub async fn update(&self, ready_set: Vec<IssueSummary>, graph: DependencyGraph) {
+    ///
+    /// `issues` must be the full open-issue slice used to build `graph`
+    /// (same slice passed to
+    /// [`DependencyGraph::build`](crate::graph::DependencyGraph::build)).
+    /// Callers that populate the cache via a fresh `fetch_graph_data()`
+    /// result already satisfy this invariant.
+    pub async fn update(
+        &self,
+        issues: Vec<Issue>,
+        ready_set: Vec<IssueSummary>,
+        graph: DependencyGraph,
+    ) {
         let mut guard = self.inner.write().await;
         *guard = Some(CacheEntry {
+            issues: Arc::new(issues),
             ready_set: Arc::new(ready_set),
             computed_at: Instant::now(),
             graph: Arc::new(graph),
@@ -142,6 +166,23 @@ impl GraphCache {
             .as_ref()
             .filter(|entry| entry.computed_at.elapsed() < self.ttl)
             .map(|entry| Arc::clone(&entry.graph))
+    }
+
+    /// Return the cached full open-issue set if fresh, or `None` if stale
+    /// or empty.
+    ///
+    /// Enables per-issue aggregations (status/priority/agent counts) on the
+    /// cache-hit path without re-fetching from GitHub. The cached slice is
+    /// the same `Vec<Issue>` passed into [`update`](Self::update) at cache
+    /// population time, wrapped in [`Arc`] so this accessor is O(1)
+    /// regardless of issue count.
+    #[must_use]
+    pub async fn get_issues(&self) -> Option<Arc<Vec<Issue>>> {
+        let guard = self.inner.read().await;
+        guard
+            .as_ref()
+            .filter(|entry| entry.computed_at.elapsed() < self.ttl)
+            .map(|entry| Arc::clone(&entry.issues))
     }
 }
 
@@ -195,7 +236,7 @@ mod tests {
     }
 
     /// Build a `DependencyGraph` with two issues and one blocking edge.
-    fn test_graph() -> (DependencyGraph, Vec<IssueSummary>) {
+    fn test_graph() -> (Vec<Issue>, DependencyGraph, Vec<IssueSummary>) {
         let issues = vec![
             test_issue(1, IssueState::Open),
             test_issue(2, IssueState::Open),
@@ -206,7 +247,7 @@ mod tests {
         }];
         let graph = DependencyGraph::build(&issues, &edges);
         let ready_set = graph.compute_ready_set(&issues);
-        (graph, ready_set)
+        (issues, graph, ready_set)
     }
 
     // ── update → get_ready_set returns data ────────────────────────────
@@ -214,12 +255,12 @@ mod tests {
     #[tokio::test]
     async fn update_then_get_ready_set_returns_data() {
         let cache = GraphCache::new(Duration::from_secs(60));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
         // Before update, cache is empty.
         assert!(cache.get_ready_set().await.is_none());
 
-        cache.update(ready_set.clone(), graph).await;
+        cache.update(issues, ready_set.clone(), graph).await;
 
         let cached = cache.get_ready_set().await;
         assert!(cached.is_some());
@@ -231,9 +272,9 @@ mod tests {
     #[tokio::test]
     async fn stale_cache_returns_none() {
         let cache = GraphCache::new(Duration::from_millis(10));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph).await;
+        cache.update(issues, ready_set, graph).await;
 
         // Cache is fresh immediately after update.
         assert!(cache.is_fresh().await);
@@ -245,6 +286,7 @@ mod tests {
         assert!(!cache.is_fresh().await);
         assert!(cache.get_ready_set().await.is_none());
         assert!(cache.get_graph().await.is_none());
+        assert!(cache.get_issues().await.is_none());
     }
 
     // ── invalidate → get_ready_set returns None ────────────────────────
@@ -252,15 +294,16 @@ mod tests {
     #[tokio::test]
     async fn invalidate_clears_cache() {
         let cache = GraphCache::new(Duration::from_secs(60));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph).await;
+        cache.update(issues, ready_set, graph).await;
         assert!(cache.get_ready_set().await.is_some());
 
         cache.invalidate().await;
 
         assert!(cache.get_ready_set().await.is_none());
         assert!(cache.get_graph().await.is_none());
+        assert!(cache.get_issues().await.is_none());
         assert!(!cache.is_fresh().await);
     }
 
@@ -269,9 +312,9 @@ mod tests {
     #[tokio::test]
     async fn get_graph_returns_cached_graph() {
         let cache = GraphCache::new(Duration::from_secs(60));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph.clone()).await;
+        cache.update(issues, ready_set, graph.clone()).await;
 
         let cached_graph = cache.get_graph().await;
         assert!(cached_graph.is_some());
@@ -287,6 +330,27 @@ mod tests {
         }
     }
 
+    // ── get_issues returns cached issues ───────────────────────────────
+
+    #[tokio::test]
+    async fn get_issues_returns_cached_issues() {
+        let cache = GraphCache::new(Duration::from_secs(60));
+        let (issues, graph, ready_set) = test_graph();
+
+        // Before update, get_issues returns None.
+        assert!(cache.get_issues().await.is_none());
+
+        cache.update(issues.clone(), ready_set, graph).await;
+
+        let cached = cache.get_issues().await.expect("cache should hold issues");
+        assert_eq!(cached.len(), issues.len());
+        for (got, want) in cached.iter().zip(issues.iter()) {
+            assert_eq!(got.qualified_id, want.qualified_id);
+            assert_eq!(got.number, want.number);
+            assert_eq!(got.state, want.state);
+        }
+    }
+
     // ── is_fresh tracks state correctly ────────────────────────────────
 
     #[tokio::test]
@@ -298,18 +362,18 @@ mod tests {
     #[tokio::test]
     async fn is_fresh_after_update() {
         let cache = GraphCache::new(Duration::from_secs(60));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph).await;
+        cache.update(issues, ready_set, graph).await;
         assert!(cache.is_fresh().await);
     }
 
     #[tokio::test]
     async fn is_fresh_after_invalidate() {
         let cache = GraphCache::new(Duration::from_secs(60));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph).await;
+        cache.update(issues, ready_set, graph).await;
         cache.invalidate().await;
         assert!(!cache.is_fresh().await);
     }
@@ -319,15 +383,16 @@ mod tests {
     #[tokio::test]
     async fn zero_ttl_is_never_fresh() {
         let cache = GraphCache::new(Duration::ZERO);
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph).await;
+        cache.update(issues, ready_set, graph).await;
 
         // With a zero TTL the strict `elapsed() < ttl` check can never
         // succeed — the cache is always stale immediately after population.
         assert!(!cache.is_fresh().await);
         assert!(cache.get_ready_set().await.is_none());
         assert!(cache.get_graph().await.is_none());
+        assert!(cache.get_issues().await.is_none());
     }
 
     // ── concurrent readers ─────────────────────────────────────────────
@@ -335,9 +400,9 @@ mod tests {
     #[tokio::test]
     async fn concurrent_readers_do_not_deadlock() {
         let cache = std::sync::Arc::new(GraphCache::new(Duration::from_secs(60)));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set.clone(), graph).await;
+        cache.update(issues, ready_set.clone(), graph).await;
 
         // Spawn 10 concurrent readers via tokio::join!
         let results = tokio::join!(
@@ -403,15 +468,18 @@ mod tests {
     #[tokio::test]
     async fn update_replaces_previous_entry() {
         let cache = GraphCache::new(Duration::from_secs(60));
-        let (graph, ready_set) = test_graph();
+        let (issues, graph, ready_set) = test_graph();
 
-        cache.update(ready_set, graph.clone()).await;
+        cache.update(issues, ready_set, graph.clone()).await;
 
-        // Update with a different ready set (empty).
+        // Update with a different issue set and empty ready set.
+        let new_issues: Vec<Issue> = vec![];
         let new_ready_set: Vec<IssueSummary> = vec![];
-        cache.update(new_ready_set.clone(), graph).await;
+        cache.update(new_issues, new_ready_set.clone(), graph).await;
 
         let cached = cache.get_ready_set().await.unwrap();
         assert!(cached.is_empty());
+        let cached_issues = cache.get_issues().await.unwrap();
+        assert!(cached_issues.is_empty());
     }
 }

--- a/crates/unblock-mcp/src/tools/list.rs
+++ b/crates/unblock-mcp/src/tools/list.rs
@@ -490,10 +490,12 @@ pub async fn handle_list(state: &ServerState, params: ListParams) -> Result<List
             // Step 3: refresh the cache as a useful side effect. The
             // operation is read-only from the contract perspective —
             // callers cannot tell from the response whether the cache
-            // was warm or cold.
+            // was warm or cold. `issues` is cloned because the local copy
+            // is still consumed below by `build_list_rows` for the list
+            // projection — the cache holds an independent snapshot.
             let graph = DependencyGraph::build(&issues, &edges);
             let ready_set = graph.compute_ready_set(&issues);
-            state.cache.update(ready_set, graph).await;
+            state.cache.update(issues.clone(), ready_set, graph).await;
             tracing::debug!("Cache refreshed by list handler");
             issues
         }

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -161,7 +161,7 @@ pub async fn rebuild_cache(state: &ServerState) {
         Ok((issues, edges)) => {
             let graph = DependencyGraph::build(&issues, &edges);
             let ready_set = graph.compute_ready_set(&issues);
-            state.cache.update(ready_set, graph).await;
+            state.cache.update(issues, ready_set, graph).await;
             tracing::debug!("Cache rebuilt after write tool execution");
         }
         Err(err) => {
@@ -241,7 +241,7 @@ mod tests {
         }];
         let graph = DependencyGraph::build(&issues, &edges);
         let ready_set = graph.compute_ready_set(&issues);
-        cache.update(ready_set, graph).await;
+        cache.update(issues, ready_set, graph).await;
     }
 
     /// Create a `ServerState` with a real cache but a client that points

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -44,6 +44,7 @@ pub mod reconcile;
 pub mod search;
 pub mod setup;
 pub mod show;
+pub mod stats;
 pub mod update;
 
 use std::future::Future;

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -362,7 +362,10 @@ pub async fn handle_prime(
     );
 
     // 5. Update cache with the fresh graph already fetched.
-    state.cache.update(ready_summaries, graph).await;
+    //    Categorisation above (step 4) already consumed `issues_vec` by
+    //    reference, and steps 6–8 only touch `categories`/`filtered_*`, so
+    //    the issues vec can be moved into the cache here without cloning.
+    state.cache.update(issues_vec, ready_summaries, graph).await;
     tracing::debug!("Cache updated with fresh graph from prime");
 
     // 6. Apply agent filter to relevant categories (PRD §6.3).
@@ -1484,7 +1487,7 @@ mod tests {
         ];
         let graph = DependencyGraph::build(&issues, &[]);
         let ready_set = graph.compute_ready_set(&issues);
-        state.cache.update(ready_set, graph).await;
+        state.cache.update(issues, ready_set, graph).await;
 
         assert!(
             state.cache.is_fresh().await,

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -193,8 +193,11 @@ pub async fn handle_reconcile(
     }
 
     // 5. Update cache with the fresh graph we already have.
-    //    Uses real 2-arg signature: cache.update(ready_summaries, graph).
-    state.cache.update(ready_summaries, graph).await;
+    //    The full issue snapshot is moved into the cache so subsequent
+    //    cache-aware reads (e.g. `stats`, spec §7.4) can aggregate without
+    //    a follow-up fetch. `issues_vec` is no longer used after this point
+    //    — `report`/`ReconcileOutput` only depend on `report`.
+    state.cache.update(issues_vec, ready_summaries, graph).await;
     tracing::debug!("Cache updated with fresh graph from reconcile");
 
     // 6. Return output.
@@ -602,7 +605,7 @@ mod tests {
         let ready_set = graph.compute_ready_set(&issues);
 
         // Update cache (same call the handler makes).
-        state.cache.update(ready_set, graph).await;
+        state.cache.update(issues, ready_set, graph).await;
 
         assert!(
             state.cache.is_fresh().await,

--- a/crates/unblock-mcp/src/tools/stats.rs
+++ b/crates/unblock-mcp/src/tools/stats.rs
@@ -1,0 +1,853 @@
+//! Stats tool — aggregate counts and metrics across the issue set.
+//!
+//! Per spec §7.4 this is a read-only tool that aggregates the open issue
+//! set (and, once [`unblock-a36`] lands, the closed set too) into a
+//! compact snapshot: totals by status, totals by priority, how many
+//! issues are blocked vs ready, how many cycles exist in the dependency
+//! graph, and per-agent throughput.
+//!
+//! ## Cache-aware read path (spec §7.4)
+//!
+//! The handler observes the spec's "API calls: 0 (cache hit) | 1+
+//! (rebuild)" contract:
+//!
+//! 1. If the cache is stale or empty, call
+//!    [`crate::tools::rebuild_cache`] to refresh every cached artefact
+//!    via a single `fetch_graph_data()` round-trip.
+//! 2. Read [`GraphCache::get_issues`] and [`GraphCache::get_graph`] —
+//!    both O(1) `Arc` clones — and aggregate entirely from cached
+//!    state. This is why [`GraphCache`] stores the full issue vector
+//!    (see the cache-extension commit for unblock-29p.8): without it,
+//!    stats would have to re-fetch on every call.
+//! 3. If the cache is still empty after a rebuild attempt (the network
+//!    call failed), propagate the underlying GitHub error via the
+//!    crate-internal `github_error_to_mcp` helper instead of returning
+//!    a degraded `stale = true` envelope. The spec's `StatsResult` has
+//!    no `stale` field — this mirrors [`search`](crate::tools::search),
+//!    and the R6 decision on the bead binds this choice.
+//!
+//! ## OPEN-only scope (unblock-a36 follow-up)
+//!
+//! `fetch_graph_data` only returns OPEN GitHub issues today (tracked
+//! separately by bead `unblock-a36`). That has two visible consequences
+//! for stats:
+//!
+//! - `by_status["closed"]` is always `0`.
+//! - Every [`AgentStats::completed`] counter is always `0`.
+//!
+//! Both fields are still populated (pre-seeded) in the response so
+//! callers can differentiate "unknown" from "no data". Once `unblock-a36`
+//! extends the fetch to include closed issues, stats picks up the new
+//! data with no code change.
+//!
+//! ## Aggregation semantics
+//!
+//! - **`total`** — number of issues after applying the optional
+//!   `milestone` filter.
+//! - **`by_status`** — count per [`Status`] variant, keyed by the
+//!   lowercase Projects V2 option slug (`ready`, `in_progress`,
+//!   `blocked`, `deferred`, `closed`). Every key is pre-seeded with `0`
+//!   so callers can read `map["ready"]` without null-checking.
+//! - **`by_priority`** — count per [`Priority`] variant, keyed by the
+//!   [`Display`](Priority) form (`"P0"`..`"P4"`). All five keys are
+//!   pre-seeded with `0`.
+//! - **`blocked_count`** — number of issues that are effectively
+//!   blocked, i.e. `status == Status::Blocked` OR have at least one
+//!   open blocker in the graph (per the R3 decision on the bead —
+//!   mirrors [`prime`](crate::tools::prime) categorisation semantics).
+//! - **`ready_count`** — `compute_ready_set(&issues).len()` after the
+//!   milestone filter is applied (per the R4 decision). This is the
+//!   count of issues that would appear in a fresh `ready` call scoped
+//!   to the same milestone.
+//! - **`cycle_count`** — `DependencyGraph::detect_all_cycles().len()`
+//!   over the **full** graph (per the R5 decision). The milestone
+//!   filter never scopes cycle detection because an edge can cross
+//!   milestones and the spec does not define a scoped cycle semantic.
+//! - **`agents`** — one [`AgentStats`] per distinct non-empty agent
+//!   value observed in the (optionally milestone-filtered) issue set.
+//!   `in_progress` counts issues whose `status == Status::InProgress`;
+//!   `completed` counts issues with `state == IssueState::Closed`
+//!   (always `0` today — see the OPEN-only scope note above).
+//!
+//! ## Validation
+//!
+//! The only parameter is `milestone: Option<String>`; there is no
+//! numeric limit, no required field, and empty / whitespace-only
+//! strings collapse to `None` via the crate-internal
+//! `normalize_filter` helper, matching every other filter-accepting
+//! read tool.
+//!
+//! [`unblock-a36`]: https://example.invalid/bd/unblock-a36
+//! [`GraphCache`]: unblock_core::cache::GraphCache
+//! [`GraphCache::get_issues`]: unblock_core::cache::GraphCache::get_issues
+//! [`GraphCache::get_graph`]: unblock_core::cache::GraphCache::get_graph
+
+use std::collections::HashMap;
+
+use rmcp::model::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::{info, instrument};
+use unblock_core::graph::DependencyGraph;
+use unblock_core::types::{Issue, IssueState, Priority, Status};
+
+use crate::errors::github_error_to_mcp;
+use crate::server::ServerState;
+
+/// Input parameters for the `stats` MCP tool.
+///
+/// Per spec §7.4. The `milestone` filter is applied before aggregation
+/// so `by_status`, `by_priority`, `ready_count`, and `agents` all reflect
+/// the scoped subset. `cycle_count` is intentionally computed on the
+/// full graph (see module docs, R5 decision).
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct StatsParams {
+    /// Exact-match milestone title filter. When omitted (or empty /
+    /// whitespace-only, which collapses to `None`), the response
+    /// aggregates across every open issue.
+    pub milestone: Option<String>,
+}
+
+/// Result returned by the `stats` MCP tool.
+///
+/// Per spec §7.4. Note the absence of a `stale` field: stats propagates
+/// fetch failures as an `ErrorData` rather than a degraded envelope
+/// (R6 decision).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct StatsResult {
+    /// Number of issues counted (after the optional milestone filter).
+    pub total: usize,
+    /// Count per [`Status`] variant, keyed by lowercase Projects V2
+    /// option slug (`ready`, `in_progress`, `blocked`, `deferred`,
+    /// `closed`). All five keys are always present — absent keys are
+    /// pre-seeded to `0`.
+    pub by_status: HashMap<String, usize>,
+    /// Count per [`Priority`] variant, keyed by the [`Display`](Priority)
+    /// form (`"P0"`..`"P4"`). All five keys are always present.
+    pub by_priority: HashMap<String, usize>,
+    /// Number of issues effectively blocked — either
+    /// `status == Status::Blocked` OR at least one open blocker in the
+    /// graph (R3 decision).
+    pub blocked_count: usize,
+    /// Number of issues that would appear in a `ready` call scoped to
+    /// the same milestone (R4 decision).
+    pub ready_count: usize,
+    /// Number of cycles in the **full** dependency graph (R5 decision).
+    /// The milestone filter never scopes cycle detection.
+    pub cycle_count: usize,
+    /// Per-agent throughput. One entry per distinct non-empty agent
+    /// value in the (optionally milestone-filtered) issue set.
+    pub agents: Vec<AgentStats>,
+}
+
+/// Per-agent throughput snapshot.
+///
+/// Per spec §7.4. `completed` is always `0` today because
+/// `fetch_graph_data` returns OPEN issues only (see module-level docs
+/// and `unblock-a36`).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AgentStats {
+    /// Agent name as stored on `Issue.agent`.
+    pub name: String,
+    /// Number of issues assigned to this agent with
+    /// `status == Status::InProgress`.
+    pub in_progress: usize,
+    /// Number of issues assigned to this agent with
+    /// `state == IssueState::Closed`. Always `0` today — see module docs.
+    pub completed: usize,
+}
+
+/// Lowercase Projects V2 slug for a [`Status`] variant.
+///
+/// Uses the same option names as the GraphQL `parse_status_field`
+/// parser in `unblock-github` (and the `projects.rs` setup helper),
+/// so the wire format is round-trip safe with the field values the
+/// server itself creates.
+fn status_slug(status: Status) -> &'static str {
+    match status {
+        Status::Ready => "ready",
+        Status::InProgress => "in_progress",
+        Status::Blocked => "blocked",
+        Status::Deferred => "deferred",
+        Status::Closed => "closed",
+    }
+}
+
+/// Return `true` when `issue` has at least one blocker that is still
+/// OPEN.
+///
+/// Mirrors `has_open_blockers` in
+/// [`prime`](crate::tools::prime) — outgoing edges in the dependency
+/// graph point from the blocked issue to its blockers, so we walk the
+/// outgoing neighbours and stop at the first one whose
+/// [`IssueState`] is [`Open`](IssueState::Open).
+///
+/// Issues absent from the graph (edges absent, no blockers recorded)
+/// are treated as unblocked.
+fn has_open_blockers(issue: &Issue, graph: &DependencyGraph) -> bool {
+    let Some(&node_idx) = graph.node_map().get(&issue.qualified_id) else {
+        return false;
+    };
+    let inner = graph.inner_graph();
+    let issue_state = graph.issue_state();
+    inner
+        .neighbors_directed(node_idx, petgraph::Direction::Outgoing)
+        .any(|neighbor_idx| {
+            let neighbor_qid = &inner[neighbor_idx];
+            issue_state
+                .get(neighbor_qid)
+                .is_some_and(|state| *state == IssueState::Open)
+        })
+}
+
+/// Pre-seed the `by_status` bucket with `0` for every [`Status`]
+/// variant so callers can read any key unconditionally.
+fn seed_status_buckets() -> HashMap<String, usize> {
+    let mut out = HashMap::with_capacity(5);
+    for status in [
+        Status::Ready,
+        Status::InProgress,
+        Status::Blocked,
+        Status::Deferred,
+        Status::Closed,
+    ] {
+        out.insert(status_slug(status).to_owned(), 0);
+    }
+    out
+}
+
+/// Pre-seed the `by_priority` bucket with `0` for every [`Priority`]
+/// variant so callers can read any key unconditionally.
+fn seed_priority_buckets() -> HashMap<String, usize> {
+    let mut out = HashMap::with_capacity(5);
+    for priority in [
+        Priority::P0,
+        Priority::P1,
+        Priority::P2,
+        Priority::P3,
+        Priority::P4,
+    ] {
+        out.insert(priority.to_string(), 0);
+    }
+    out
+}
+
+/// Aggregate a fully-resolved issue / graph snapshot into the spec
+/// [`StatsResult`] shape.
+///
+/// Pure function — takes pre-filtered issues (milestone already
+/// applied) plus the unfiltered graph. Returning a dedicated helper
+/// keeps [`handle_stats`] focused on the cache orchestration and makes
+/// the aggregation logic trivially unit-testable without touching the
+/// cache layer.
+fn aggregate_stats(filtered: &[&Issue], graph: &DependencyGraph) -> StatsResult {
+    let mut by_status = seed_status_buckets();
+    let mut by_priority = seed_priority_buckets();
+    let mut blocked_count: usize = 0;
+    // Map of agent name → (in_progress, completed).
+    let mut agent_map: HashMap<String, (usize, usize)> = HashMap::new();
+
+    for issue in filtered {
+        // by_status — lowercase slug keys match the Projects V2 option
+        // names the project is created with (unblock-github/src/projects.rs).
+        if let Some(bucket) = by_status.get_mut(status_slug(issue.status)) {
+            *bucket += 1;
+        }
+
+        // by_priority — "P0".."P4" Display form.
+        if let Some(bucket) = by_priority.get_mut(&issue.priority.to_string()) {
+            *bucket += 1;
+        }
+
+        // blocked_count — union of Status::Blocked OR open blockers in
+        // the graph (R3).
+        if issue.status == Status::Blocked || has_open_blockers(issue, graph) {
+            blocked_count += 1;
+        }
+
+        // Agents — one entry per distinct non-empty `Issue.agent`. Empty
+        // strings collapse to None the same way `normalize_filter` does
+        // elsewhere, so a trailing-space agent is not split from the
+        // same name without the space (defensive — agents today are
+        // assigned via claim which already writes trimmed values).
+        if let Some(agent) = issue
+            .agent
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            let slot = agent_map
+                .entry(agent.to_owned())
+                .or_insert((0_usize, 0_usize));
+            if issue.status == Status::InProgress {
+                slot.0 += 1;
+            }
+            if issue.state == IssueState::Closed {
+                slot.1 += 1;
+            }
+        }
+    }
+
+    // Ready set is computed on the filtered slice — R4: the ready_count
+    // surfaces what `ready(milestone=…)` would return. `compute_ready_set`
+    // needs `&[Issue]`, so project the `&Issue` refs back into a Vec of
+    // owned clones. This allocation is bounded by `total` and only runs
+    // on the cache-warm read path (once per stats call).
+    let filtered_owned: Vec<Issue> = filtered.iter().copied().cloned().collect();
+    let ready_count = graph.compute_ready_set(&filtered_owned).len();
+
+    // Cycle count is always full-graph (R5). Milestone does not scope
+    // cycle detection — the spec does not define a milestone-aware
+    // cycle semantic, and an edge can cross milestones.
+    let cycle_count = graph.detect_all_cycles().len();
+
+    // Stable agent order so test assertions (and clients) do not depend
+    // on HashMap iteration order.
+    let mut agents: Vec<AgentStats> = agent_map
+        .into_iter()
+        .map(|(name, (in_progress, completed))| AgentStats {
+            name,
+            in_progress,
+            completed,
+        })
+        .collect();
+    agents.sort_by(|a, b| a.name.cmp(&b.name));
+
+    StatsResult {
+        total: filtered.len(),
+        by_status,
+        by_priority,
+        blocked_count,
+        ready_count,
+        cycle_count,
+        agents,
+    }
+}
+
+/// Execute the `stats` tool handler.
+///
+/// See the module-level docs for the cache-aware contract and the
+/// aggregation semantics that R3/R4/R5/R6/R7 pin down.
+///
+/// # Flow
+///
+/// 1. If the cache is stale, lazily rebuild via
+///    [`crate::tools::rebuild_cache`] (single `fetch_graph_data()`).
+/// 2. Read the full issue vector and the dependency graph from the
+///    cache — both O(1) `Arc` clones. If either is still absent after
+///    the rebuild attempt, propagate a real GitHub error so the caller
+///    sees the underlying cause (R6).
+/// 3. Apply the optional `milestone` filter to produce the aggregation
+///    slice.
+/// 4. Delegate to the crate-internal `aggregate_stats` helper.
+///
+/// # Errors
+///
+/// Returns [`ErrorData`] when the cache cannot be warmed (e.g. GitHub
+/// network failure). The error is the same one the crate-internal
+/// `github_error_to_mcp` helper surfaces for a direct
+/// `fetch_graph_data()` call.
+#[instrument(
+    skip(state, params),
+    name = "handle_stats",
+    fields(
+        agent.kind = state.agent_kind_str(),
+        milestone = params.milestone.as_deref(),
+    ),
+)]
+pub async fn handle_stats(
+    state: &ServerState,
+    params: StatsParams,
+) -> Result<StatsResult, ErrorData> {
+    info!("Stats tool invoked");
+
+    // Step 1: warm the cache if needed. Zero work on the cache-hit path.
+    if !state.cache.is_fresh().await {
+        tracing::debug!("Stats cache is stale — triggering lazy rebuild");
+        crate::tools::rebuild_cache(state).await;
+    }
+
+    // Step 2: pull the full issue set and graph from cache. Both are
+    // O(1) Arc clones; the cache lock is released as soon as both
+    // handles are captured.
+    let issues_arc = state.cache.get_issues().await;
+    let graph_arc = state.cache.get_graph().await;
+
+    let (Some(issues), Some(graph)) = (issues_arc, graph_arc) else {
+        // The rebuild attempt above could not populate the cache (e.g.
+        // `fetch_graph_data` returned an error inside `rebuild_cache`).
+        // Re-issue the fetch locally so the caller receives the real
+        // underlying error rather than an empty-envelope response.
+        // `StatsResult` has no `stale` field, so error propagation is
+        // the only surface for failures (R6 decision).
+        tracing::warn!("Cache empty after rebuild — retrying fetch to surface the error");
+        let (issues_vec, edges_vec) = state
+            .github
+            .fetch_graph_data()
+            .await
+            .map_err(github_error_to_mcp)?;
+        // The retry unexpectedly succeeded — populate the cache so a
+        // follow-up call is warm, then aggregate against the freshly
+        // fetched vectors without re-reading the cache.
+        let graph_built = DependencyGraph::build(&issues_vec, &edges_vec);
+        let ready_set = graph_built.compute_ready_set(&issues_vec);
+        let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
+        let filtered = filter_by_milestone(&issues_vec, milestone);
+        let result = aggregate_stats(&filtered, &graph_built);
+        state.cache.update(issues_vec, ready_set, graph_built).await;
+        return Ok(result);
+    };
+
+    // Step 3: apply the milestone filter (R2 decision — `milestone` is
+    // normalised so empty/whitespace inputs collapse to None).
+    let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
+    let filtered = filter_by_milestone(issues.as_ref(), milestone);
+
+    // Step 4: aggregate.
+    Ok(aggregate_stats(&filtered, graph.as_ref()))
+}
+
+/// Filter an issue slice by exact-match milestone title.
+///
+/// When `milestone` is `None`, every issue is retained (zero-cost
+/// borrow-through via `Iterator::collect`). Extracted so both the
+/// happy path and the fetch-retry fallback share a single filter
+/// implementation.
+fn filter_by_milestone<'a>(issues: &'a [Issue], milestone: Option<&str>) -> Vec<&'a Issue> {
+    issues
+        .iter()
+        .filter(|issue| milestone.is_none_or(|m| issue.milestone.as_deref() == Some(m)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use unblock_core::types::{BlockingEdge, IssueType, QualifiedId};
+
+    use super::*;
+
+    // ── Test helpers ────────────────────────────────────────────────────
+
+    fn qid(number: u64) -> QualifiedId {
+        QualifiedId::new("acme", "widgets", number)
+    }
+
+    /// Minimal open [`Issue`] populated enough for aggregation tests.
+    fn stats_issue(
+        number: u64,
+        status: Status,
+        priority: Priority,
+        state: IssueState,
+        agent: Option<&str>,
+        milestone: Option<&str>,
+    ) -> Issue {
+        Issue {
+            qualified_id: qid(number),
+            number,
+            node_id: format!("NODE_{number}"),
+            title: format!("Issue #{number}"),
+            issue_type: Some(IssueType::Task),
+            status,
+            priority,
+            agent: agent.map(str::to_owned),
+            claimed_at: None,
+            pipeline_stage: None,
+            story_points: None,
+            defer_until: None,
+            labels: vec![],
+            milestone: milestone.map(str::to_owned),
+            assignees: vec![],
+            state,
+            body: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            url: format!("https://github.com/acme/widgets/issues/{number}"),
+            comments: vec![],
+            blocked_by: vec![],
+            blocking: vec![],
+            parent: None,
+            sub_issues: vec![],
+        }
+    }
+
+    // ── status_slug / seeding ───────────────────────────────────────────
+
+    #[test]
+    fn status_slug_maps_every_variant_to_lowercase() {
+        assert_eq!(status_slug(Status::Ready), "ready");
+        assert_eq!(status_slug(Status::InProgress), "in_progress");
+        assert_eq!(status_slug(Status::Blocked), "blocked");
+        assert_eq!(status_slug(Status::Deferred), "deferred");
+        assert_eq!(status_slug(Status::Closed), "closed");
+    }
+
+    #[test]
+    fn seed_status_buckets_contains_every_slug_at_zero() {
+        let seeded = seed_status_buckets();
+        assert_eq!(seeded.len(), 5);
+        for key in ["ready", "in_progress", "blocked", "deferred", "closed"] {
+            assert_eq!(
+                seeded.get(key),
+                Some(&0_usize),
+                "missing pre-seeded slug {key}",
+            );
+        }
+    }
+
+    #[test]
+    fn seed_priority_buckets_contains_every_priority_at_zero() {
+        let seeded = seed_priority_buckets();
+        assert_eq!(seeded.len(), 5);
+        for key in ["P0", "P1", "P2", "P3", "P4"] {
+            assert_eq!(
+                seeded.get(key),
+                Some(&0_usize),
+                "missing pre-seeded priority {key}",
+            );
+        }
+    }
+
+    // ── has_open_blockers ───────────────────────────────────────────────
+
+    #[test]
+    fn has_open_blockers_false_when_issue_not_in_graph() {
+        let g = DependencyGraph::build(&[], &[]);
+        let orphan = stats_issue(
+            42,
+            Status::Ready,
+            Priority::P2,
+            IssueState::Open,
+            None,
+            None,
+        );
+        assert!(!has_open_blockers(&orphan, &g));
+    }
+
+    #[test]
+    fn has_open_blockers_true_for_downstream_of_open_upstream() {
+        let upstream = stats_issue(1, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let downstream = stats_issue(2, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let issues = vec![upstream.clone(), downstream.clone()];
+        // Edge: downstream (2) source -> upstream (1) target. Matches
+        // the existing `BlockingEdge` convention in cache/rebuild tests.
+        let edges = vec![BlockingEdge {
+            source: qid(2),
+            target: qid(1),
+        }];
+        let g = DependencyGraph::build(&issues, &edges);
+        assert!(has_open_blockers(&downstream, &g));
+        assert!(!has_open_blockers(&upstream, &g));
+    }
+
+    #[test]
+    fn has_open_blockers_false_when_upstream_is_closed() {
+        let upstream = stats_issue(
+            1,
+            Status::Closed,
+            Priority::P2,
+            IssueState::Closed,
+            None,
+            None,
+        );
+        let downstream = stats_issue(2, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let issues = vec![upstream.clone(), downstream.clone()];
+        let edges = vec![BlockingEdge {
+            source: qid(2),
+            target: qid(1),
+        }];
+        let g = DependencyGraph::build(&issues, &edges);
+        // The upstream blocker is Closed — the downstream issue should
+        // look unblocked.
+        assert!(!has_open_blockers(&downstream, &g));
+    }
+
+    // ── aggregate_stats ─────────────────────────────────────────────────
+
+    #[test]
+    fn aggregate_stats_empty_input_yields_zeroed_envelope() {
+        let g = DependencyGraph::build(&[], &[]);
+        let result = aggregate_stats(&[], &g);
+        assert_eq!(result.total, 0);
+        assert_eq!(result.blocked_count, 0);
+        assert_eq!(result.ready_count, 0);
+        assert_eq!(result.cycle_count, 0);
+        assert!(result.agents.is_empty());
+        for key in ["ready", "in_progress", "blocked", "deferred", "closed"] {
+            assert_eq!(result.by_status.get(key), Some(&0_usize));
+        }
+        for key in ["P0", "P1", "P2", "P3", "P4"] {
+            assert_eq!(result.by_priority.get(key), Some(&0_usize));
+        }
+    }
+
+    #[test]
+    fn aggregate_stats_counts_one_per_variant() {
+        // One issue in each Status × Priority combination we care about.
+        let issues = vec![
+            stats_issue(1, Status::Ready, Priority::P0, IssueState::Open, None, None),
+            stats_issue(
+                2,
+                Status::InProgress,
+                Priority::P1,
+                IssueState::Open,
+                Some("alice"),
+                None,
+            ),
+            stats_issue(
+                3,
+                Status::Blocked,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                None,
+            ),
+            stats_issue(
+                4,
+                Status::Deferred,
+                Priority::P3,
+                IssueState::Open,
+                None,
+                None,
+            ),
+            // Note: state Open because fetch_graph_data is OPEN-only today.
+            stats_issue(5, Status::Ready, Priority::P4, IssueState::Open, None, None),
+        ];
+        let g = DependencyGraph::build(&issues, &[]);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+
+        assert_eq!(result.total, 5);
+        assert_eq!(result.by_status.get("ready"), Some(&2_usize));
+        assert_eq!(result.by_status.get("in_progress"), Some(&1_usize));
+        assert_eq!(result.by_status.get("blocked"), Some(&1_usize));
+        assert_eq!(result.by_status.get("deferred"), Some(&1_usize));
+        assert_eq!(result.by_status.get("closed"), Some(&0_usize));
+
+        for key in ["P0", "P1", "P2", "P3", "P4"] {
+            assert_eq!(result.by_priority.get(key), Some(&1_usize));
+        }
+    }
+
+    #[test]
+    fn aggregate_stats_blocked_count_unions_status_and_graph() {
+        // Issue 1 is Status::Blocked (no graph edge).
+        let a = stats_issue(
+            1,
+            Status::Blocked,
+            Priority::P2,
+            IssueState::Open,
+            None,
+            None,
+        );
+        // Issue 2 is Status::Ready but blocked-by issue 3 in the graph.
+        let b = stats_issue(2, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let c = stats_issue(3, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let issues = vec![a.clone(), b.clone(), c.clone()];
+        let edges = vec![BlockingEdge {
+            source: qid(2),
+            target: qid(3),
+        }];
+        let g = DependencyGraph::build(&issues, &edges);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+
+        // Both #1 (Status::Blocked) and #2 (has open blocker) count.
+        assert_eq!(result.blocked_count, 2);
+    }
+
+    #[test]
+    fn aggregate_stats_ready_count_matches_graph_compute_ready_set() {
+        let a = stats_issue(1, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let b = stats_issue(2, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let issues = vec![a.clone(), b.clone()];
+        // Issue 2 is blocked by issue 1, so only issue 1 is ready.
+        let edges = vec![BlockingEdge {
+            source: qid(2),
+            target: qid(1),
+        }];
+        let g = DependencyGraph::build(&issues, &edges);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+        assert_eq!(result.ready_count, 1);
+    }
+
+    #[test]
+    fn aggregate_stats_cycle_count_detects_mutual_blockers() {
+        let a = stats_issue(1, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let b = stats_issue(2, Status::Ready, Priority::P2, IssueState::Open, None, None);
+        let issues = vec![a.clone(), b.clone()];
+        let edges = vec![
+            BlockingEdge {
+                source: qid(1),
+                target: qid(2),
+            },
+            BlockingEdge {
+                source: qid(2),
+                target: qid(1),
+            },
+        ];
+        let g = DependencyGraph::build(&issues, &edges);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+        assert_eq!(result.cycle_count, 1, "one SCC of size 2 = one cycle");
+    }
+
+    #[test]
+    fn aggregate_stats_agents_grouped_by_name_with_in_progress_counts() {
+        let issues = vec![
+            stats_issue(
+                1,
+                Status::InProgress,
+                Priority::P0,
+                IssueState::Open,
+                Some("alice"),
+                None,
+            ),
+            stats_issue(
+                2,
+                Status::InProgress,
+                Priority::P1,
+                IssueState::Open,
+                Some("alice"),
+                None,
+            ),
+            stats_issue(
+                3,
+                Status::Ready,
+                Priority::P2,
+                IssueState::Open,
+                Some("alice"),
+                None,
+            ),
+            stats_issue(
+                4,
+                Status::InProgress,
+                Priority::P0,
+                IssueState::Open,
+                Some("bob"),
+                None,
+            ),
+            // Unassigned issue — should not contribute any AgentStats.
+            stats_issue(5, Status::Ready, Priority::P2, IssueState::Open, None, None),
+        ];
+        let g = DependencyGraph::build(&issues, &[]);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+
+        assert_eq!(result.agents.len(), 2);
+        // Sort is by name ascending (alice, bob).
+        assert_eq!(result.agents[0].name, "alice");
+        assert_eq!(result.agents[0].in_progress, 2);
+        assert_eq!(result.agents[0].completed, 0);
+        assert_eq!(result.agents[1].name, "bob");
+        assert_eq!(result.agents[1].in_progress, 1);
+        assert_eq!(result.agents[1].completed, 0);
+    }
+
+    #[test]
+    fn aggregate_stats_total_equals_sum_of_status_buckets() {
+        // Property: when no milestone filter applies, the sum of every
+        // status bucket must equal `total`.
+        let issues = vec![
+            stats_issue(1, Status::Ready, Priority::P2, IssueState::Open, None, None),
+            stats_issue(
+                2,
+                Status::InProgress,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                None,
+            ),
+            stats_issue(
+                3,
+                Status::Blocked,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                None,
+            ),
+            stats_issue(
+                4,
+                Status::Deferred,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                None,
+            ),
+        ];
+        let g = DependencyGraph::build(&issues, &[]);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+        let status_sum: usize = result.by_status.values().sum();
+        assert_eq!(status_sum, result.total);
+    }
+
+    #[test]
+    fn aggregate_stats_empty_agent_string_collapses_to_none() {
+        // A whitespace-only agent string should not create an entry.
+        let issues = vec![stats_issue(
+            1,
+            Status::InProgress,
+            Priority::P2,
+            IssueState::Open,
+            Some("   "),
+            None,
+        )];
+        let g = DependencyGraph::build(&issues, &[]);
+        let refs: Vec<&Issue> = issues.iter().collect();
+        let result = aggregate_stats(&refs, &g);
+        assert!(result.agents.is_empty());
+    }
+
+    // ── filter_by_milestone ─────────────────────────────────────────────
+
+    #[test]
+    fn filter_by_milestone_none_returns_everything() {
+        let issues = vec![
+            stats_issue(
+                1,
+                Status::Ready,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                Some("v1.0"),
+            ),
+            stats_issue(
+                2,
+                Status::Ready,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                Some("v2.0"),
+            ),
+        ];
+        assert_eq!(filter_by_milestone(&issues, None).len(), 2);
+    }
+
+    #[test]
+    fn filter_by_milestone_some_exact_match_only() {
+        let issues = vec![
+            stats_issue(
+                1,
+                Status::Ready,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                Some("v1.0"),
+            ),
+            stats_issue(
+                2,
+                Status::Ready,
+                Priority::P2,
+                IssueState::Open,
+                None,
+                Some("v2.0"),
+            ),
+            stats_issue(3, Status::Ready, Priority::P2, IssueState::Open, None, None),
+        ];
+        let filtered = filter_by_milestone(&issues, Some("v1.0"));
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].number, 1);
+    }
+}

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -590,7 +590,7 @@ async fn depends_aliased_configured_repo_source_cycle_detection() {
 
     let state = state_with_mock(Arc::clone(&mock));
     let cache = Arc::clone(&state.cache);
-    cache.update(ready_set, graph).await;
+    cache.update(issues, ready_set, graph).await;
 
     let server = UnblockServer::new(state);
 
@@ -708,7 +708,7 @@ async fn depends_aliased_configured_repo_target_cycle_detection() {
 
     let state = state_with_mock(Arc::clone(&mock));
     let cache = Arc::clone(&state.cache);
-    cache.update(ready_set, graph).await;
+    cache.update(issues, ready_set, graph).await;
 
     let server = UnblockServer::new(state);
 

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -1300,6 +1300,340 @@ async fn search_rejects_zero_limit_without_fetching() {
     );
 }
 
+// ── Stats tool: integration tests ─────────────────────────────────
+
+/// Build a customisable stats fixture `Issue` — one helper per field
+/// the stats aggregator distinguishes.
+#[allow(clippy::too_many_arguments)]
+fn stats_fixture_issue(
+    number: u64,
+    status: Status,
+    priority: Priority,
+    issue_state: IssueState,
+    agent: Option<&str>,
+    milestone: Option<&str>,
+) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new("acme", "widgets", number),
+        number,
+        node_id: format!("I_{number}"),
+        title: format!("Stats fixture #{number}"),
+        issue_type: Some(IssueType::Task),
+        status,
+        priority,
+        agent: agent.map(str::to_owned),
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: milestone.map(str::to_owned),
+        assignees: vec![],
+        state: issue_state,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/acme/widgets/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// End-to-end happy path: stats aggregates every bucket, blocked-count
+/// unions `Status::Blocked` with graph-open-blockers, ready-count
+/// matches `compute_ready_set`, cycle-count surfaces a 2-issue cycle,
+/// and per-agent throughput tracks `in_progress`. Verifies that after a
+/// cold start the cache was warmed (a single `fetch_graph_data()` call),
+/// and that the follow-up stats call hits the cache (still one call).
+#[tokio::test]
+#[allow(clippy::too_many_lines)] // Comprehensive end-to-end scenario.
+async fn stats_aggregates_every_bucket_and_warms_cache() {
+    use unblock_mcp::tools::stats::{StatsParams, handle_stats};
+
+    // Issue #1: Ready / P0 — ready.
+    // Issue #2: InProgress / P1 / agent=alice — in-progress, not ready.
+    // Issue #3: Blocked / P2 — Status::Blocked, bumps blocked_count.
+    // Issue #4: Deferred / P3 — deferred.
+    // Issue #5: Ready / P4 / blocked-by #1 in graph — bumps
+    //   blocked_count (open blocker), NOT ready.
+    // Issues #6 & #7: Ready / P2 — form a cycle (#6→#7, #7→#6) for
+    //   cycle_count. Because they mutually block, neither is ready.
+    // Issue #8: InProgress / P0 / agent=alice — second alice task.
+    // Issue #9: InProgress / P2 / agent=bob — bob in-progress.
+    let issues = vec![
+        stats_fixture_issue(1, Status::Ready, Priority::P0, IssueState::Open, None, None),
+        stats_fixture_issue(
+            2,
+            Status::InProgress,
+            Priority::P1,
+            IssueState::Open,
+            Some("alice"),
+            None,
+        ),
+        stats_fixture_issue(
+            3,
+            Status::Blocked,
+            Priority::P2,
+            IssueState::Open,
+            None,
+            None,
+        ),
+        stats_fixture_issue(
+            4,
+            Status::Deferred,
+            Priority::P3,
+            IssueState::Open,
+            None,
+            None,
+        ),
+        stats_fixture_issue(5, Status::Ready, Priority::P4, IssueState::Open, None, None),
+        stats_fixture_issue(6, Status::Ready, Priority::P2, IssueState::Open, None, None),
+        stats_fixture_issue(7, Status::Ready, Priority::P2, IssueState::Open, None, None),
+        stats_fixture_issue(
+            8,
+            Status::InProgress,
+            Priority::P0,
+            IssueState::Open,
+            Some("alice"),
+            None,
+        ),
+        stats_fixture_issue(
+            9,
+            Status::InProgress,
+            Priority::P2,
+            IssueState::Open,
+            Some("bob"),
+            None,
+        ),
+    ];
+    let edges = vec![
+        // Issue #5 blocked by issue #1 (open).
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 5),
+            target: QualifiedId::new("acme", "widgets", 1),
+        },
+        // Cycle: #6 <-> #7.
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 6),
+            target: QualifiedId::new("acme", "widgets", 7),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 7),
+            target: QualifiedId::new("acme", "widgets", 6),
+        },
+    ];
+
+    let mock = new_mock();
+    // Only the first (cold) call should trigger a fetch. The second
+    // call must be served entirely from the cache.
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    let state = state_with_mock(Arc::clone(&mock));
+
+    // ── Call 1 (cold): triggers the single rebuild fetch. ──
+    let result = handle_stats(&state, StatsParams { milestone: None })
+        .await
+        .expect("stats call should succeed on cold cache");
+
+    assert_eq!(result.total, 9);
+    // by_status — each bucket counted exactly.
+    assert_eq!(result.by_status.get("ready"), Some(&4_usize)); // #1, #5, #6, #7
+    assert_eq!(result.by_status.get("in_progress"), Some(&3_usize)); // #2, #8, #9
+    assert_eq!(result.by_status.get("blocked"), Some(&1_usize)); // #3
+    assert_eq!(result.by_status.get("deferred"), Some(&1_usize)); // #4
+    assert_eq!(result.by_status.get("closed"), Some(&0_usize)); // OPEN-only
+
+    // by_priority — one P0/P1/P3/P4, three P2s, plus another P0 (#8).
+    assert_eq!(result.by_priority.get("P0"), Some(&2_usize)); // #1, #8
+    assert_eq!(result.by_priority.get("P1"), Some(&1_usize));
+    assert_eq!(result.by_priority.get("P2"), Some(&4_usize)); // #3, #6, #7, #9
+    assert_eq!(result.by_priority.get("P3"), Some(&1_usize));
+    assert_eq!(result.by_priority.get("P4"), Some(&1_usize));
+
+    // blocked_count — #3 (Status::Blocked) + #5 (open blocker) + #6, #7
+    // (mutual blockers each see the other as an open blocker).
+    assert_eq!(result.blocked_count, 4);
+    // ready_count: per spec §3.3, `compute_ready_set` only filters
+    // InProgress / Deferred / Closed — Status::Blocked issues with no
+    // open blockers WILL appear in the ready set. So:
+    //   #1 — Ready / no blocker → ready.
+    //   #2/#8/#9 — InProgress (filtered).
+    //   #3 — Status::Blocked but no graph blocker → ready (per §3.3).
+    //   #4 — Deferred (filtered).
+    //   #5 — has open blocker (#1 is Open) → blocked.
+    //   #6/#7 — cycle partners, each blocked by the other → blocked.
+    // Expected ready set: {1, 3}.
+    assert_eq!(result.ready_count, 2);
+    assert_eq!(result.cycle_count, 1, "one SCC of size 2 = one cycle");
+
+    // agents — sorted alphabetically; alice has 2 in_progress; bob 1.
+    assert_eq!(result.agents.len(), 2);
+    assert_eq!(result.agents[0].name, "alice");
+    assert_eq!(result.agents[0].in_progress, 2);
+    assert_eq!(result.agents[0].completed, 0); // OPEN-only
+    assert_eq!(result.agents[1].name, "bob");
+    assert_eq!(result.agents[1].in_progress, 1);
+    assert_eq!(result.agents[1].completed, 0);
+
+    // Exactly one fetch should have occurred (cold-cache rebuild).
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "cold stats call rebuilds the cache once",
+    );
+
+    // ── Call 2 (warm): zero new fetch calls — cache hit path. ──
+    let result2 = handle_stats(&state, StatsParams { milestone: None })
+        .await
+        .expect("stats call should succeed on warm cache");
+    assert_eq!(result2.total, 9);
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "cache-hit stats call must not trigger any additional fetch (spec §7.4)",
+    );
+}
+
+/// `handle_stats` honours the `milestone` filter: `total`, `by_status`,
+/// `by_priority`, `blocked_count`, `ready_count`, and `agents` all
+/// reflect only the filtered subset. `cycle_count` remains full-graph
+/// (R5 decision) — a cycle entirely outside the milestone still counts.
+#[tokio::test]
+#[allow(clippy::too_many_lines)] // Comprehensive end-to-end scenario.
+async fn stats_milestone_filter_scopes_aggregation_but_not_cycles() {
+    use unblock_mcp::tools::stats::{StatsParams, handle_stats};
+
+    // Milestone v1.0:
+    //   #1 — Ready / P0 / no blocker.
+    //   #2 — InProgress / P2 / agent=alice.
+    // Milestone v2.0:
+    //   #3 — Ready / P1.
+    //   #4 — Ready / P1 (cycle partner with #5).
+    //   #5 — Ready / P1 (cycle partner with #4).
+    // No milestone:
+    //   #6 — Deferred / P3.
+    let issues = vec![
+        stats_fixture_issue(
+            1,
+            Status::Ready,
+            Priority::P0,
+            IssueState::Open,
+            None,
+            Some("v1.0"),
+        ),
+        stats_fixture_issue(
+            2,
+            Status::InProgress,
+            Priority::P2,
+            IssueState::Open,
+            Some("alice"),
+            Some("v1.0"),
+        ),
+        stats_fixture_issue(
+            3,
+            Status::Ready,
+            Priority::P1,
+            IssueState::Open,
+            None,
+            Some("v2.0"),
+        ),
+        stats_fixture_issue(
+            4,
+            Status::Ready,
+            Priority::P1,
+            IssueState::Open,
+            None,
+            Some("v2.0"),
+        ),
+        stats_fixture_issue(
+            5,
+            Status::Ready,
+            Priority::P1,
+            IssueState::Open,
+            None,
+            Some("v2.0"),
+        ),
+        stats_fixture_issue(
+            6,
+            Status::Deferred,
+            Priority::P3,
+            IssueState::Open,
+            None,
+            None,
+        ),
+    ];
+    // Cycle #4 <-> #5 — entirely inside milestone v2.0.
+    let edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 4),
+            target: QualifiedId::new("acme", "widgets", 5),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 5),
+            target: QualifiedId::new("acme", "widgets", 4),
+        },
+    ];
+
+    let mock = new_mock();
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    let state = state_with_mock(Arc::clone(&mock));
+
+    // ── Filter milestone = v1.0 ──
+    let v1 = handle_stats(
+        &state,
+        StatsParams {
+            milestone: Some("v1.0".to_owned()),
+        },
+    )
+    .await
+    .expect("stats call should succeed");
+    assert_eq!(v1.total, 2, "v1.0 has 2 issues");
+    assert_eq!(v1.by_status.get("ready"), Some(&1_usize)); // #1
+    assert_eq!(v1.by_status.get("in_progress"), Some(&1_usize)); // #2
+    assert_eq!(v1.by_status.get("blocked"), Some(&0_usize));
+    assert_eq!(v1.by_priority.get("P0"), Some(&1_usize));
+    assert_eq!(v1.by_priority.get("P2"), Some(&1_usize));
+    assert_eq!(v1.by_priority.get("P1"), Some(&0_usize));
+    assert_eq!(v1.blocked_count, 0, "no blockers inside v1.0");
+    assert_eq!(v1.ready_count, 1, "#1 is ready, #2 is InProgress");
+    assert_eq!(
+        v1.cycle_count, 1,
+        "cycle count is full-graph (R5) — v2.0's cycle still counts",
+    );
+    assert_eq!(v1.agents.len(), 1);
+    assert_eq!(v1.agents[0].name, "alice");
+    assert_eq!(v1.agents[0].in_progress, 1);
+
+    // ── Filter milestone = v2.0 ──
+    let v2 = handle_stats(
+        &state,
+        StatsParams {
+            milestone: Some("v2.0".to_owned()),
+        },
+    )
+    .await
+    .expect("stats call should succeed");
+    assert_eq!(v2.total, 3);
+    assert_eq!(v2.by_status.get("ready"), Some(&3_usize));
+    // blocked_count: #4 and #5 each have an open blocker (the other).
+    assert_eq!(v2.blocked_count, 2);
+    // ready_count: #3 has no blockers; #4 and #5 mutually block.
+    assert_eq!(v2.ready_count, 1);
+    assert_eq!(
+        v2.cycle_count, 1,
+        "cycle count is full-graph and surfaces the v2.0 cycle",
+    );
+    assert!(v2.agents.is_empty(), "no agents assigned inside v2.0");
+    // Exactly one fetch — the second stats call hit the cache.
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "milestone filter must be a post-filter, not a refetch",
+    );
+}
+
 // ── Create tool: integration tests ────────────────────────────────
 
 /// Create tool is registered in the server tool list.

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -235,7 +235,7 @@ async fn show_include_deps_false_skips_graph_traversal() {
     }];
     let graph = DependencyGraph::build(&issues, &edges);
     let ready_set = graph.compute_ready_set(&issues);
-    state.cache.update(ready_set, graph).await;
+    state.cache.update(issues, ready_set, graph).await;
     assert!(
         state.cache.get_graph().await.is_some(),
         "cache should be populated before invoking show",
@@ -377,7 +377,7 @@ async fn show_dependency_tree_for_blocking_relationships() {
     ];
     let graph = DependencyGraph::build(&issues, &edges);
     let ready_set = graph.compute_ready_set(&issues);
-    cache.update(ready_set, graph).await;
+    cache.update(issues, ready_set, graph).await;
 
     // With include_deps=true and a populated cache, the DependencyTree should have data.
     let dep_tree = cache
@@ -477,7 +477,7 @@ async fn ready_returns_only_open_unblocked_non_deferred_issues() {
     }];
     let graph = DependencyGraph::build(&issues, &edges);
     let ready_set = graph.compute_ready_set(&issues);
-    cache.update(ready_set.clone(), graph).await;
+    cache.update(issues, ready_set.clone(), graph).await;
 
     // Filter using ready tool logic.
     let params = unblock_mcp::tools::ready::ReadyParams {
@@ -509,7 +509,7 @@ async fn ready_second_call_returns_from_cache() {
     let edges = vec![];
     let graph = DependencyGraph::build(&issues, &edges);
     let ready_set = graph.compute_ready_set(&issues);
-    cache.update(ready_set, graph).await;
+    cache.update(issues, ready_set, graph).await;
 
     // First call.
     let first = cache.get_ready_set().await;
@@ -544,7 +544,7 @@ async fn ready_filter_by_priority() {
     let issues = vec![issue_1, issue_2, issue_3];
     let graph = DependencyGraph::build(&issues, &[]);
     let ready_set = graph.compute_ready_set(&issues);
-    cache.update(ready_set.clone(), graph).await;
+    cache.update(issues, ready_set.clone(), graph).await;
 
     let params = unblock_mcp::tools::ready::ReadyParams {
         limit: None,
@@ -578,7 +578,7 @@ async fn ready_filter_by_label() {
     let issues = vec![issue_1, issue_2, issue_3];
     let graph = DependencyGraph::build(&issues, &[]);
     let ready_set = graph.compute_ready_set(&issues);
-    cache.update(ready_set.clone(), graph).await;
+    cache.update(issues, ready_set.clone(), graph).await;
 
     let params = unblock_mcp::tools::ready::ReadyParams {
         limit: None,
@@ -1142,7 +1142,10 @@ async fn search_hits_github_and_maps_to_summary_without_touching_cache() {
     let cache_issues = vec![test_issue(999, IssueState::Open)];
     let graph = DependencyGraph::build(&cache_issues, &[]);
     let ready_set = graph.compute_ready_set(&cache_issues);
-    state.cache.update(ready_set.clone(), graph).await;
+    state
+        .cache
+        .update(cache_issues, ready_set.clone(), graph)
+        .await;
     assert!(
         state.cache.is_fresh().await,
         "cache should be fresh before search",

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -1093,6 +1093,7 @@ async fn list_rejects_limit_out_of_range_without_fetching() {
 /// Server.rs registration is owned by sibling bead unblock-29p.12 and
 /// is intentionally not exercised here.
 #[tokio::test]
+#[allow(clippy::too_many_lines)] // Comprehensive end-to-end scenario.
 async fn search_hits_github_and_maps_to_summary_without_touching_cache() {
     use unblock_core::types::IssueSummary;
     use unblock_mcp::tools::search::{SearchParams, handle_search};


### PR DESCRIPTION
Adds the spec §7.4 `stats` read tool: totals, status/priority buckets,
blocked / ready / cycle counts, and per-agent throughput. The handler
is cache-aware and honours the "API calls: 0 (cache hit)" contract
from §7.4 — aggregation runs entirely over the new
`GraphCache::get_issues()` and `get_graph()` accessors. Cold calls
trigger a single `rebuild_cache` fetch; warm calls never fetch.

Behavioural decisions (recorded on bead unblock-29p.8):

- R1 `AgentStats` shape follows spec: `{ name, in_progress, completed }`.
- R3 `blocked_count` counts the union of `Status::Blocked` OR open
  graph blockers — matches the `prime` tool's blocked category.
- R4 `ready_count` = `compute_ready_set(&filtered).len()` after the
  milestone filter, so it reflects what a milestone-scoped `ready`
  call would return.
- R5 `cycle_count` always uses the full graph, never the milestone
  subset. The spec does not define a milestone-scoped cycle semantic
  and edges can cross milestones.
- R6 no `stale` field on `StatsResult`: fetch failures propagate via
  `ErrorData` (mirroring `search`) rather than a degraded envelope.
- R2 / OPEN-only caveat: today `fetch_graph_data` only returns open
  issues, so `by_status["closed"]` and every `AgentStats.completed`
  are always 0. Both are still pre-seeded so callers can read keys
  unconditionally. Once unblock-a36 lands, stats picks up the new
  data with no code change.

Keys use the lowercase Projects V2 option slugs
(`ready`, `in_progress`, `blocked`, `deferred`, `closed`), matching
the GraphQL parser and the Projects setup helper; priority keys use
`Priority`'s `Display` form (`"P0"`..`"P4"`).

- `src/tools/stats.rs` — new module with `StatsParams`, `StatsResult`,
  `AgentStats`, `handle_stats`, the `aggregate_stats` core, and unit
  tests covering slug mapping, bucket pre-seeding, `has_open_blockers`,
  and every aggregation dimension.
- `src/tools/mod.rs` — register `pub mod stats;`.
- `tests/integration.rs` — two end-to-end tests via `MockGitHubClient`:
  one comprehensive fixture exercising every bucket + a 2-issue cycle
  + per-agent throughput + the warm-cache zero-fetch promise, and a
  milestone-filter test verifying that only aggregation (not
  `cycle_count`) is scoped.

Server registration and the tool router entry land separately in
bead unblock-29p.12.

