### PR TITLE
feat(mcp): implement dep_cycles MCP tool with §11.4 cross-repo contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "criterion",
  "petgraph",
  "proptest",
+ "schemars",
  "serde",
  "serde_json",
  "snafu",

--- a/crates/unblock-core/Cargo.toml
+++ b/crates/unblock-core/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { workspace = true }
 snafu = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+schemars = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -800,6 +800,48 @@ fn non_empty_trimmed(s: &str) -> Option<String> {
     }
 }
 
+/// Cross-repo references that participated in a response computation but
+/// were dropped from the bare-`u64` projection of that response.
+///
+/// Shared response-side type governed by the cross-repo response contract
+/// in SPEC §11.4. Populated when a tool returns issue numbers scoped to
+/// the configured repo but the underlying graph traversal touched nodes
+/// in other repositories that cannot be expressed as bare `u64`.
+///
+/// # Invariant
+///
+/// The field is `Some` iff [`omitted`](Self::omitted) is non-empty. Tools
+/// MUST wrap this type in `Option<CrossRepoRefs>` with
+/// `#[serde(skip_serializing_if = "Option::is_none")]` so clients that do
+/// not inspect the field observe no JSON surface when no cross-repo node
+/// participated.
+///
+/// # Rendering
+///
+/// Each entry in [`omitted`](Self::omitted) uses [`QualifiedId::Display`]
+/// → `"owner/repo#number"`. The vector MUST be sorted lexicographically to
+/// preserve determinism (Invariant 5 / Invariant 14 in SPEC §14).
+///
+/// # Affected tools (SPEC §11.4)
+///
+/// `ready` (§7.1), `prime` (§7.3), `dep_cycles` (§7.7), `close` (§8.2).
+///
+/// [`QualifiedId::Display`]: QualifiedId#impl-Display-for-QualifiedId
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CrossRepoRefs {
+    /// Qualified refs omitted from the bare-`u64` projection of the
+    /// containing response, one per entry. Each entry uses
+    /// [`QualifiedId::Display`](QualifiedId) → `"owner/repo#number"`.
+    ///
+    /// Sorted lexicographically so identical graph state produces
+    /// identical responses (Invariant 5 / Invariant 14, SPEC §14).
+    pub omitted: Vec<String>,
+    /// Human-readable summary for agent consumption.
+    ///
+    /// Example: `"2 cross-repo cycle members omitted from ` + "`cycles`" + `"`.
+    pub summary: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1400,6 +1442,45 @@ Notes here.";
     fn issue_ref_parse_whitespace_trimmed() {
         let r: IssueRef = "  42  ".parse().unwrap();
         assert_eq!(r, IssueRef::Local(42));
+    }
+
+    // ── CrossRepoRefs (SPEC §2.16 / §11.4) ──────────────────────────────
+
+    #[test]
+    fn cross_repo_refs_serializes_expected_shape() {
+        let refs = CrossRepoRefs {
+            omitted: vec!["acme/widgets#42".to_owned(), "other/repo#9".to_owned()],
+            summary: Some("2 cross-repo cycle members omitted".to_owned()),
+        };
+        let json = serde_json::to_value(&refs).expect("CrossRepoRefs should serialize");
+        assert_eq!(json["omitted"].as_array().map(Vec::len), Some(2));
+        assert_eq!(json["omitted"][0], "acme/widgets#42");
+        assert_eq!(json["omitted"][1], "other/repo#9");
+        assert_eq!(json["summary"], "2 cross-repo cycle members omitted");
+    }
+
+    #[test]
+    fn cross_repo_refs_summary_none_serializes_as_null() {
+        let refs = CrossRepoRefs {
+            omitted: vec!["acme/widgets#1".to_owned()],
+            summary: None,
+        };
+        let json = serde_json::to_value(&refs).expect("CrossRepoRefs should serialize");
+        assert!(
+            json["summary"].is_null(),
+            "summary None serializes as JSON null: {json}"
+        );
+    }
+
+    #[test]
+    fn cross_repo_refs_round_trips_through_serde() {
+        let original = CrossRepoRefs {
+            omitted: vec!["a/b#1".to_owned(), "c/d#2".to_owned()],
+            summary: Some("two".to_owned()),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let back: CrossRepoRefs = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, back);
     }
 
     // ── Proptest ────────────────────────────────────────────────────────

--- a/crates/unblock-mcp/src/tools/dep_cycles.rs
+++ b/crates/unblock-mcp/src/tools/dep_cycles.rs
@@ -1,0 +1,631 @@
+//! `dep_cycles` tool — detect dependency cycles in the dependency graph.
+//!
+//! Per SPEC §7.7 this is a **read-only** tool that projects the output of
+//! [`DependencyGraph::detect_all_cycles`] (Tarjan's SCC algorithm, see
+//! SPEC §3.6) down to a JSON-friendly `Vec<Vec<u64>>` of issue numbers
+//! scoped to the configured repository, plus the `cross_repo_refs`
+//! envelope mandated by SPEC §11.4.
+//!
+//! ## Read-only — no write-tool scaffolding
+//!
+//! The tool does not mutate GitHub and does not invalidate the cache (see
+//! SPEC §4.4 invalidation matrix: `dep_cycles = No`). The handler therefore
+//! does **not** wrap the operation in the crate-internal
+//! `execute_write_tool` helper and does not fire the Projects V2 Status
+//! update ladder. It piggy-backs on [`crate::tools::rebuild_cache`] only
+//! when the cache is stale, exactly like [`crate::tools::stats`].
+//!
+//! ## Cache-aware read path (SPEC §7.7 "API calls: 0 (cache hit) | 1+
+//! (rebuild)")
+//!
+//! 1. If the cache is stale/empty, call [`crate::tools::rebuild_cache`]
+//!    to warm every cached artefact with a single `fetch_graph_data()`
+//!    round-trip.
+//! 2. Read [`GraphCache::get_graph`] — an O(1) `Arc` clone — and compute
+//!    cycles directly from the cached [`DependencyGraph`].
+//! 3. If the cache is still empty after the rebuild attempt (the network
+//!    call inside `rebuild_cache` failed), propagate the underlying
+//!    GitHub error via `github_error_to_mcp` after one local
+//!    [`fetch_graph_data`](unblock_github::GitHubApi::fetch_graph_data)
+//!    retry. The spec's [`DepCyclesResult`] has no `stale` field, so
+//!    surfacing the error is the only honest signal to the caller. This
+//!    mirrors [`stats`](crate::tools::stats) (R6) and the
+//!    [`dep_remove`](crate::tools::dep_remove) R3 posture.
+//!
+//! ## Cross-Repo Response Contract (SPEC §11.4)
+//!
+//! The graph engine's nodes are [`QualifiedId`] values (§2.1). Cycle
+//! detection therefore returns `Vec<Vec<QualifiedId>>` — each inner
+//! vector may contain a mix of local and cross-repo members. SPEC §7.7's
+//! [`DepCyclesResult::cycles`] is `Vec<Vec<u64>>`, which cannot express
+//! the `(owner, repo)` tuple of a cross-repo node. The handler therefore
+//! performs an *asymmetric* projection:
+//!
+//! - **Local members** (those whose `(owner, repo)` matches the
+//!   configured `(client.owner(), client.repo())`) are emitted as bare
+//!   `u64` issue numbers inside the `cycles` vector, preserving the
+//!   relative iteration order that Tarjan returned.
+//! - **Cross-repo members** are stripped from the inner vector and
+//!   instead accumulated into
+//!   [`CrossRepoRefs::omitted`](unblock_core::types::CrossRepoRefs)
+//!   using [`QualifiedId::Display`] (`"owner/repo#number"`), sorted
+//!   lexicographically to preserve determinism (Invariant 14, SPEC §14).
+//!
+//! A cycle whose local-projection length drops below 2 after stripping
+//! cross-repo members is STILL emitted as a (possibly-shorter)
+//! `Vec<u64>` — the agent must know the cycle exists even if the local
+//! projection is degraded. This is spelled out in SPEC §7.7 flow step 4b
+//! ("the bare-`u64` vector may therefore be shorter than the true cycle
+//! length") and echoed in plan Task 06.06 acceptance.
+//!
+//! ## Population rules (SPEC §11.4)
+//!
+//! [`DepCyclesResult::cross_repo_refs`] is `Some` iff at least one cycle
+//! in the detected set visited a cross-repo `QualifiedId` that was not
+//! emitted in the bare-`u64` projection. Otherwise it is `None` and the
+//! `#[serde(skip_serializing_if = "Option::is_none")]` attribute elides
+//! it from the JSON envelope entirely. The field is NEVER `Some` with an
+//! empty `omitted` vector.
+//!
+//! De-duplication: the same cross-repo `QualifiedId` may theoretically
+//! appear in two disjoint cycles. Its `QualifiedId::Display` form is
+//! emitted in `omitted` exactly once after de-duplication, which matches
+//! the strict reading of SPEC §11.4 ("nodes dropped from the
+//! bare-`u64` projection") and preserves the lexicographic-sort
+//! invariant trivially.
+//!
+//! ## Targeted `id` parameter (SPEC §7.7 params)
+//!
+//! The tool accepts `id: Option<u64>`. Per SPEC §7.7 the parameter is
+//! typed as `u64`, not [`IssueRef`], so cross-repo lookups are
+//! deliberately NOT supported here (consistent with [`claim`],
+//! [`close`], [`reopen`] scope in §5.6). The lookup resolves the bare
+//! number against `(client.owner(), client.repo())` and keeps only the
+//! SCCs whose member set contains the target node. This reuses
+//! [`DependencyGraph::detect_all_cycles`] directly — no new graph-engine
+//! API is introduced (see bead `unblock-29p.11` scope notes).
+//!
+//! The cross-repo projection (above) still applies on the filtered
+//! subset: a targeted query that lands on a mixed cycle returns the
+//! local projection of that cycle and the cross-repo members in
+//! `cross_repo_refs`.
+//!
+//! ## Server registration deferred to sibling bead
+//!
+//! The `#[tool]` registration on `UnblockServer` is **deliberately out
+//! of scope** for this module — it is tracked by sibling bead
+//! `unblock-29p.12`. This file exposes [`handle_dep_cycles`] and the
+//! data types [`DepCyclesParams`] / [`DepCyclesResult`] so the sibling
+//! bead can wire the router without touching cycle-detection logic.
+//!
+//! [`DependencyGraph::detect_all_cycles`]: unblock_core::graph::DependencyGraph::detect_all_cycles
+//! [`GraphCache::get_graph`]: unblock_core::cache::GraphCache::get_graph
+//! [`QualifiedId`]: unblock_core::types::QualifiedId
+//! [`QualifiedId::Display`]: unblock_core::types::QualifiedId#impl-Display-for-QualifiedId
+//! [`IssueRef`]: unblock_core::types::IssueRef
+//! [`claim`]: crate::tools::claim
+//! [`close`]: crate::tools::close
+//! [`reopen`]: crate::tools::reopen
+
+use rmcp::model::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::{info, instrument};
+use unblock_core::graph::DependencyGraph;
+use unblock_core::types::{CrossRepoRefs, QualifiedId};
+
+use crate::errors::github_error_to_mcp;
+use crate::server::ServerState;
+
+/// Input parameters for the `dep_cycles` MCP tool.
+///
+/// Per SPEC §7.7 the only parameter is `id: Option<u64>`. The bare-`u64`
+/// form is intentional: cross-repo targeted lookups are out of scope for
+/// this tool (§5.6 cross-repo scope table — read tools that accept an
+/// issue number accept local numbers only). When `id` is `None`, the
+/// handler returns cycles across the full configured-repo graph.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct DepCyclesParams {
+    /// Optional local issue number for a targeted cycle check. When
+    /// present, only cycles that contain the node
+    /// `(client.owner(), client.repo(), id)` are returned.
+    pub id: Option<u64>,
+}
+
+/// Result returned by the `dep_cycles` MCP tool.
+///
+/// Per SPEC §7.7. The `cycles` vector carries the local-only projection
+/// of each detected SCC (issue numbers in the configured repo); cycles
+/// that traversed at least one cross-repo `QualifiedId` surface the
+/// omitted members in [`cross_repo_refs`](Self::cross_repo_refs) per
+/// SPEC §11.4. A cycle whose local-projection length dropped below 2
+/// after stripping cross-repo members is STILL emitted so the agent
+/// knows the cycle exists — the missing members are in
+/// `cross_repo_refs`.
+///
+/// `count` mirrors `cycles.len()` at all times.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct DepCyclesResult {
+    /// Detected cycles, each projected to the bare-`u64` local
+    /// representation per SPEC §7.7. May be shorter than the true cycle
+    /// length when cross-repo members were stripped — see
+    /// [`cross_repo_refs`](Self::cross_repo_refs) and SPEC §11.4.
+    pub cycles: Vec<Vec<u64>>,
+    /// Number of cycles in [`cycles`](Self::cycles). Always equal to
+    /// `cycles.len()`.
+    pub count: usize,
+    /// Cross-repo `QualifiedId` cycle members dropped from the bare-`u64`
+    /// projection of [`cycles`](Self::cycles), per SPEC §11.4.
+    ///
+    /// `Some` iff at least one cycle visited a cross-repo node; `None`
+    /// otherwise. Elided from the JSON envelope when `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross_repo_refs: Option<CrossRepoRefs>,
+}
+
+/// Project a single cycle (`Vec<QualifiedId>`) onto its local and
+/// cross-repo partitions, feeding the cross-repo members into the shared
+/// `omitted` set.
+///
+/// The local projection preserves the relative iteration order that
+/// Tarjan returned (local-only subsequence of the original SCC). The
+/// cross-repo set is a `BTreeSet<String>` keyed by
+/// [`QualifiedId::Display`](QualifiedId#impl-Display-for-QualifiedId)
+/// (`"owner/repo#number"`) so de-duplication across cycles is free and
+/// the final `Vec<String>` emerges lexicographically sorted — the
+/// Invariant 14 determinism contract holds without an explicit
+/// `sort()` call.
+///
+/// Returns the local projection (may be empty if every member was
+/// cross-repo).
+fn project_cycle(
+    cycle: &[QualifiedId],
+    configured_owner: &str,
+    configured_repo: &str,
+    cross_repo_accum: &mut std::collections::BTreeSet<String>,
+) -> Vec<u64> {
+    let mut local = Vec::with_capacity(cycle.len());
+    for qid in cycle {
+        if qid.owner == configured_owner && qid.repo == configured_repo {
+            local.push(qid.number);
+        } else {
+            cross_repo_accum.insert(qid.to_string());
+        }
+    }
+    local
+}
+
+/// Build the optional [`CrossRepoRefs`] envelope from the accumulated
+/// cross-repo `QualifiedId` display strings.
+///
+/// Returns `None` when no cross-repo node was encountered (preserving
+/// SPEC §11.4's "`Some` iff `omitted` is non-empty" invariant) — callers
+/// can forward this directly into [`DepCyclesResult::cross_repo_refs`].
+fn build_cross_repo_refs(accum: std::collections::BTreeSet<String>) -> Option<CrossRepoRefs> {
+    if accum.is_empty() {
+        return None;
+    }
+    let omitted: Vec<String> = accum.into_iter().collect();
+    // The BTreeSet iteration already yields lexicographically sorted
+    // entries — no explicit sort call needed (Invariant 14).
+    let summary = Some(format!(
+        "{} cross-repo cycle {} omitted from `cycles`",
+        omitted.len(),
+        if omitted.len() == 1 {
+            "member"
+        } else {
+            "members"
+        },
+    ));
+    Some(CrossRepoRefs { omitted, summary })
+}
+
+/// Core projection helper: given the raw cycle set returned by
+/// [`DependencyGraph::detect_all_cycles`] (or its `id`-scoped
+/// restriction), perform the SPEC §7.7 / §11.4 projection and return the
+/// `(cycles, cross_repo_refs)` pair.
+///
+/// Pulled out of [`handle_dep_cycles`] so it can be covered by
+/// hermetic unit tests without constructing a [`ServerState`].
+fn project_all(
+    raw: &[Vec<QualifiedId>],
+    configured_owner: &str,
+    configured_repo: &str,
+) -> (Vec<Vec<u64>>, Option<CrossRepoRefs>) {
+    let mut cycles: Vec<Vec<u64>> = Vec::with_capacity(raw.len());
+    let mut cross_repo_accum: std::collections::BTreeSet<String> =
+        std::collections::BTreeSet::new();
+    for cycle in raw {
+        // SPEC §7.7 flow step 4b: emit every detected cycle, even the
+        // ones whose local-projection length is < 2 (mixed cycles where
+        // all but ≤1 member are cross-repo). The agent must know the
+        // cycle exists; the missing members land in `cross_repo_refs`.
+        let local = project_cycle(
+            cycle,
+            configured_owner,
+            configured_repo,
+            &mut cross_repo_accum,
+        );
+        cycles.push(local);
+    }
+    let cross_repo_refs = build_cross_repo_refs(cross_repo_accum);
+    (cycles, cross_repo_refs)
+}
+
+/// Keep only the SCCs that contain the supplied target node.
+///
+/// Matches the "targeted cycle check involving that node" wording in
+/// SPEC §7.7 flow step 2. Comparison is on full [`QualifiedId`] equality,
+/// so the caller is responsible for resolving the bare `id` against
+/// `(client.owner(), client.repo())` before calling.
+fn filter_cycles_containing<'a>(
+    raw: &'a [Vec<QualifiedId>],
+    target: &QualifiedId,
+) -> Vec<&'a Vec<QualifiedId>> {
+    raw.iter().filter(|scc| scc.contains(target)).collect()
+}
+
+/// Execute the `dep_cycles` tool handler.
+///
+/// See the module-level docs for the full contract. Flow (mirrors SPEC
+/// §7.7):
+///
+/// 1. Warm the cache if needed ([`crate::tools::rebuild_cache`]).
+/// 2. Read the cached [`DependencyGraph`]; fall back to a direct
+///    [`fetch_graph_data`](unblock_github::GitHubApi::fetch_graph_data)
+///    retry when the cache is still empty after the rebuild attempt.
+/// 3. Call [`DependencyGraph::detect_all_cycles`].
+/// 4. When `params.id` is `Some`, restrict to SCCs that contain the
+///    resolved [`QualifiedId`].
+/// 5. Project each cycle onto its local / cross-repo partitions per SPEC
+///    §11.4.
+/// 6. Return [`DepCyclesResult`] with `count = cycles.len()`.
+///
+/// # Errors
+///
+/// Returns [`ErrorData`] only when the cache cannot be warmed (e.g.
+/// GitHub network failure). The error surface matches the
+/// [`crate::tools::stats`] R6 posture — `DepCyclesResult` has no
+/// `stale` field, so failure must be signalled via the error channel.
+#[instrument(
+    skip(state, params),
+    name = "handle_dep_cycles",
+    fields(
+        agent.kind = state.agent_kind_str(),
+        id = params.id,
+    ),
+)]
+pub async fn handle_dep_cycles(
+    state: &ServerState,
+    params: DepCyclesParams,
+) -> Result<DepCyclesResult, ErrorData> {
+    info!("DepCycles tool invoked");
+
+    // Step 1: warm the cache if needed. Zero work on the cache-hit path.
+    if !state.cache.is_fresh().await {
+        tracing::debug!("DepCycles cache is stale — triggering lazy rebuild");
+        crate::tools::rebuild_cache(state).await;
+    }
+
+    // Step 2: pull the dependency graph from the cache. Fall back to a
+    // direct fetch when the rebuild did not populate the cache (network
+    // failure inside `rebuild_cache` swallows the error there, so we
+    // must re-issue here to surface the real cause — R3 posture,
+    // mirrors stats.rs).
+    let configured_owner = state.github.owner().to_owned();
+    let configured_repo = state.github.repo().to_owned();
+
+    let raw_cycles: Vec<Vec<QualifiedId>> = if let Some(graph) = state.cache.get_graph().await {
+        graph.detect_all_cycles()
+    } else {
+        tracing::warn!("DepCycles cache empty after rebuild — retrying fetch to surface the error");
+        let (issues_vec, edges_vec) = state
+            .github
+            .fetch_graph_data()
+            .await
+            .map_err(github_error_to_mcp)?;
+        // The retry unexpectedly succeeded — populate the cache so a
+        // follow-up call is warm, then compute cycles against the
+        // freshly built graph without re-reading the cache.
+        let graph_built = DependencyGraph::build(&issues_vec, &edges_vec);
+        let ready_set = graph_built.compute_ready_set(&issues_vec);
+        let cycles = graph_built.detect_all_cycles();
+        state.cache.update(issues_vec, ready_set, graph_built).await;
+        cycles
+    };
+
+    // Step 3: apply the optional `id` filter. The parameter is a local
+    // issue number (SPEC §7.7 types it as `u64`, not `IssueRef`), so
+    // resolve it against `(configured_owner, configured_repo)` before
+    // comparing.
+    let filtered_refs: Vec<&Vec<QualifiedId>> = if let Some(id) = params.id {
+        let target = QualifiedId::new(configured_owner.clone(), configured_repo.clone(), id);
+        filter_cycles_containing(&raw_cycles, &target)
+    } else {
+        raw_cycles.iter().collect()
+    };
+
+    // Step 4: project each cycle into its (local, cross-repo) partitions
+    // per SPEC §11.4. Clone the filtered slices into owned vectors so the
+    // projection helper can consume an owned slice without lifetime
+    // gymnastics — the cost is bounded by the total cycle node count,
+    // which is small in practice (Tarjan returns disjoint SCCs).
+    let filtered_owned: Vec<Vec<QualifiedId>> = filtered_refs.into_iter().cloned().collect();
+    let (cycles, cross_repo_refs) =
+        project_all(&filtered_owned, &configured_owner, &configured_repo);
+
+    let count = cycles.len();
+    Ok(DepCyclesResult {
+        cycles,
+        count,
+        cross_repo_refs,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qid(owner: &str, repo: &str, number: u64) -> QualifiedId {
+        QualifiedId::new(owner, repo, number)
+    }
+
+    // ── project_cycle ────────────────────────────────────────────────
+
+    #[test]
+    fn project_cycle_local_only_emits_all_numbers_and_no_cross_repo() {
+        let cycle = vec![qid("acme", "widgets", 6), qid("acme", "widgets", 7)];
+        let mut accum = std::collections::BTreeSet::new();
+        let local = project_cycle(&cycle, "acme", "widgets", &mut accum);
+        // Order preserved as Tarjan returned it.
+        assert_eq!(local, vec![6, 7]);
+        assert!(accum.is_empty());
+    }
+
+    #[test]
+    fn project_cycle_mixed_partitions_local_and_cross_repo() {
+        // Mixed cycle: one local (acme/widgets#6), one cross-repo
+        // (other/repo#99). The local projection drops the cross-repo
+        // node; the cross-repo member lands in the accumulator.
+        let cycle = vec![qid("acme", "widgets", 6), qid("other", "repo", 99)];
+        let mut accum = std::collections::BTreeSet::new();
+        let local = project_cycle(&cycle, "acme", "widgets", &mut accum);
+        assert_eq!(local, vec![6]);
+        assert_eq!(accum.len(), 1);
+        assert!(accum.contains("other/repo#99"));
+    }
+
+    #[test]
+    fn project_cycle_cross_repo_only_emits_empty_local_and_accumulates() {
+        let cycle = vec![qid("other", "repo", 1), qid("third", "party", 2)];
+        let mut accum = std::collections::BTreeSet::new();
+        let local = project_cycle(&cycle, "acme", "widgets", &mut accum);
+        assert!(
+            local.is_empty(),
+            "no local members → empty local projection"
+        );
+        assert_eq!(accum.len(), 2);
+        assert!(accum.contains("other/repo#1"));
+        assert!(accum.contains("third/party#2"));
+    }
+
+    #[test]
+    fn project_cycle_deduplicates_same_cross_repo_across_calls() {
+        // Two disjoint cycles both touching `other/repo#42`: the
+        // BTreeSet collapses the duplicate to a single entry.
+        let a = vec![qid("acme", "widgets", 1), qid("other", "repo", 42)];
+        let b = vec![qid("acme", "widgets", 2), qid("other", "repo", 42)];
+        let mut accum = std::collections::BTreeSet::new();
+        let _ = project_cycle(&a, "acme", "widgets", &mut accum);
+        let _ = project_cycle(&b, "acme", "widgets", &mut accum);
+        assert_eq!(
+            accum.len(),
+            1,
+            "same cross-repo QualifiedId must be deduped"
+        );
+        assert!(accum.contains("other/repo#42"));
+    }
+
+    // ── build_cross_repo_refs ───────────────────────────────────────
+
+    #[test]
+    fn build_cross_repo_refs_empty_accum_returns_none() {
+        let accum = std::collections::BTreeSet::new();
+        assert!(build_cross_repo_refs(accum).is_none());
+    }
+
+    #[test]
+    fn build_cross_repo_refs_single_member_singular_summary() {
+        let mut accum = std::collections::BTreeSet::new();
+        accum.insert("other/repo#7".to_owned());
+        let refs = build_cross_repo_refs(accum).expect("Some");
+        assert_eq!(refs.omitted, vec!["other/repo#7".to_owned()]);
+        let summary = refs.summary.as_deref().expect("summary set");
+        assert!(summary.starts_with("1 "), "singular form: {summary}");
+        assert!(summary.contains("member"), "singular noun: {summary}");
+        assert!(
+            !summary.contains("members"),
+            "singular noun only: {summary}"
+        );
+    }
+
+    #[test]
+    fn build_cross_repo_refs_plural_sorted_lexicographically() {
+        let mut accum = std::collections::BTreeSet::new();
+        accum.insert("zeta/repo#3".to_owned());
+        accum.insert("alpha/repo#1".to_owned());
+        accum.insert("mid/repo#2".to_owned());
+        let refs = build_cross_repo_refs(accum).expect("Some");
+        assert_eq!(
+            refs.omitted,
+            vec![
+                "alpha/repo#1".to_owned(),
+                "mid/repo#2".to_owned(),
+                "zeta/repo#3".to_owned(),
+            ],
+            "Invariant 14: omitted sorted lexicographically"
+        );
+        let summary = refs.summary.as_deref().expect("summary set");
+        assert!(summary.contains("3 "));
+        assert!(summary.contains("members"), "plural noun: {summary}");
+    }
+
+    // ── project_all ──────────────────────────────────────────────────
+
+    #[test]
+    fn project_all_acyclic_returns_empty_cycles_and_no_cross_repo() {
+        let raw: Vec<Vec<QualifiedId>> = vec![];
+        let (cycles, refs) = project_all(&raw, "acme", "widgets");
+        assert!(cycles.is_empty());
+        assert!(refs.is_none());
+    }
+
+    #[test]
+    fn project_all_local_only_cycle_emits_cycles_and_none_refs() {
+        let raw = vec![vec![qid("acme", "widgets", 6), qid("acme", "widgets", 7)]];
+        let (cycles, refs) = project_all(&raw, "acme", "widgets");
+        assert_eq!(cycles.len(), 1);
+        // Relative order preserved as Tarjan returned it.
+        assert_eq!(cycles[0], vec![6, 7]);
+        assert!(refs.is_none(), "no cross-repo node → refs None");
+    }
+
+    #[test]
+    fn project_all_mixed_cycle_populates_refs_and_shortened_projection() {
+        // Single cycle of length 3: two local + one cross-repo. The
+        // cross-repo member is stripped; `cycles` emits only the local
+        // two.
+        let raw = vec![vec![
+            qid("acme", "widgets", 1),
+            qid("other", "repo", 99),
+            qid("acme", "widgets", 2),
+        ]];
+        let (cycles, refs) = project_all(&raw, "acme", "widgets");
+        assert_eq!(cycles.len(), 1);
+        assert_eq!(
+            cycles[0],
+            vec![1, 2],
+            "cross-repo stripped, locals retained in order"
+        );
+        let refs = refs.expect("cross-repo node → refs Some");
+        assert_eq!(refs.omitted, vec!["other/repo#99".to_owned()]);
+    }
+
+    #[test]
+    fn project_all_cross_repo_majority_still_emits_short_cycle() {
+        // SPEC §7.7 flow step 4b: a cycle whose local-projection length
+        // drops below 2 is STILL emitted so the agent knows the cycle
+        // exists.
+        let raw = vec![vec![
+            qid("acme", "widgets", 1),
+            qid("other", "repo", 99),
+            qid("third", "party", 100),
+        ]];
+        let (cycles, refs) = project_all(&raw, "acme", "widgets");
+        assert_eq!(cycles.len(), 1, "cycle preserved even with 1 local member");
+        assert_eq!(cycles[0], vec![1]);
+        let refs = refs.expect("cross-repo members → refs Some");
+        assert_eq!(
+            refs.omitted,
+            vec!["other/repo#99".to_owned(), "third/party#100".to_owned()],
+        );
+    }
+
+    #[test]
+    fn project_all_all_cross_repo_cycle_emits_empty_vec_but_preserves_refs() {
+        // A cycle with zero local members still appears in `cycles`
+        // (as an empty Vec<u64>) per flow step 4b — the cycle exists.
+        let raw = vec![vec![qid("other", "repo", 1), qid("third", "party", 2)]];
+        let (cycles, refs) = project_all(&raw, "acme", "widgets");
+        assert_eq!(cycles.len(), 1);
+        assert!(cycles[0].is_empty());
+        let refs = refs.expect("cross-repo-only cycle → refs Some");
+        assert_eq!(refs.omitted.len(), 2);
+    }
+
+    // ── filter_cycles_containing ─────────────────────────────────────
+
+    #[test]
+    fn filter_cycles_containing_matches_target_in_scc() {
+        let c1 = vec![qid("acme", "widgets", 1), qid("acme", "widgets", 2)];
+        let c2 = vec![qid("acme", "widgets", 3), qid("acme", "widgets", 4)];
+        let raw = vec![c1.clone(), c2.clone()];
+        let target = qid("acme", "widgets", 3);
+        let hits = filter_cycles_containing(&raw, &target);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(*hits[0], c2);
+    }
+
+    #[test]
+    fn filter_cycles_containing_returns_empty_when_absent() {
+        let raw = vec![vec![qid("acme", "widgets", 1), qid("acme", "widgets", 2)]];
+        let target = qid("acme", "widgets", 999);
+        let hits = filter_cycles_containing(&raw, &target);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn filter_cycles_containing_scopes_by_owner_repo_not_just_number() {
+        // A cycle containing `other/repo#42` must NOT match a target
+        // resolved to `acme/widgets#42`. The bare `id` parameter is
+        // scoped to the configured repo (SPEC §7.7 R8).
+        let raw = vec![vec![qid("other", "repo", 42), qid("other", "repo", 43)]];
+        let target = qid("acme", "widgets", 42);
+        let hits = filter_cycles_containing(&raw, &target);
+        assert!(
+            hits.is_empty(),
+            "`id` target scoped to configured repo — must not leak cross-repo SCC match",
+        );
+    }
+
+    // ── DepCyclesResult serialization shape ─────────────────────────
+
+    #[test]
+    fn dep_cycles_result_serializes_expected_local_shape() {
+        let res = DepCyclesResult {
+            cycles: vec![vec![6, 7]],
+            count: 1,
+            cross_repo_refs: None,
+        };
+        let json = serde_json::to_value(&res).expect("serialize");
+        assert_eq!(json["count"], 1);
+        assert_eq!(json["cycles"][0][0], 6);
+        assert_eq!(json["cycles"][0][1], 7);
+        assert!(
+            json.get("cross_repo_refs").is_none(),
+            "None `cross_repo_refs` MUST be elided via skip_serializing_if: {json}"
+        );
+    }
+
+    #[test]
+    fn dep_cycles_result_serializes_cross_repo_refs_when_some() {
+        let res = DepCyclesResult {
+            cycles: vec![vec![6]],
+            count: 1,
+            cross_repo_refs: Some(CrossRepoRefs {
+                omitted: vec!["other/repo#99".to_owned()],
+                summary: Some("1 cross-repo cycle member omitted from `cycles`".to_owned()),
+            }),
+        };
+        let json = serde_json::to_value(&res).expect("serialize");
+        assert_eq!(json["cross_repo_refs"]["omitted"][0], "other/repo#99");
+        assert_eq!(
+            json["cross_repo_refs"]["summary"],
+            "1 cross-repo cycle member omitted from `cycles`"
+        );
+    }
+
+    #[test]
+    fn dep_cycles_result_count_mirrors_cycles_len_invariant() {
+        // Trivial structural guard — the handler MUST set
+        // `count = cycles.len()`. We construct a direct instance here;
+        // the integration tests cover the handler pathway.
+        let cycles = vec![vec![1, 2], vec![3, 4, 5]];
+        let res = DepCyclesResult {
+            count: cycles.len(),
+            cycles,
+            cross_repo_refs: None,
+        };
+        assert_eq!(res.count, res.cycles.len());
+    }
+}

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -35,6 +35,7 @@ pub mod claim;
 pub mod close;
 pub mod comment;
 pub mod create;
+pub mod dep_cycles;
 pub mod dep_remove;
 pub mod depends;
 pub mod init;

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -3283,3 +3283,365 @@ async fn reconcile_with_injected_drift_and_fix() {
         repaired_report.drift_found
     );
 }
+
+// ── DepCycles tool: integration tests (SPEC §7.7, §11.4) ──────────────
+
+/// Build a fixture issue under the `MockGitHubClient` coordinates
+/// (`acme/widgets`) for `dep_cycles` tests. Every optional field is set
+/// to a minimal value — `dep_cycles` only consumes the graph topology,
+/// not the per-issue fields.
+fn dep_cycles_fixture_issue(number: u64) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new("acme", "widgets", number),
+        number,
+        node_id: format!("I_{number}"),
+        title: format!("DepCycles fixture #{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Ready,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/acme/widgets/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Build a cross-repo fixture issue for `dep_cycles` mixed-cycle tests.
+/// The resulting `QualifiedId` points OUTSIDE the configured
+/// `acme/widgets` repo so the cross-repo projection can strip it.
+fn dep_cycles_cross_repo_fixture(
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new(owner, repo, number),
+        number,
+        node_id: format!("I_{owner}_{repo}_{number}"),
+        title: format!("DepCycles cross-repo fixture {owner}/{repo}#{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Ready,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/{owner}/{repo}/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Acceptance (a): local-only cycle — `cross_repo_refs == None`, bare
+/// `cycles` populated, cache warmed exactly once across two calls.
+///
+/// Fixture: four issues, #6 ↔ #7 form a 2-node cycle, #1 / #8 are
+/// unrelated acyclic nodes. Per SPEC §7.7 the handler must:
+/// - detect one cycle of length 2,
+/// - project to `Vec<Vec<u64>>` with the local numbers {6, 7},
+/// - leave `cross_repo_refs == None` (skip-serialising to no JSON key),
+/// - serve the second call from the warm cache (no additional fetch).
+#[tokio::test]
+async fn dep_cycles_returns_all_local_cycles_from_warm_cache() {
+    use unblock_mcp::tools::dep_cycles::{DepCyclesParams, handle_dep_cycles};
+
+    let issues = vec![
+        dep_cycles_fixture_issue(1),
+        dep_cycles_fixture_issue(6),
+        dep_cycles_fixture_issue(7),
+        dep_cycles_fixture_issue(8),
+    ];
+    let edges = vec![
+        // Cycle: #6 ↔ #7.
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 6),
+            target: QualifiedId::new("acme", "widgets", 7),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 7),
+            target: QualifiedId::new("acme", "widgets", 6),
+        },
+    ];
+
+    let mock = new_mock();
+    // Only the first (cold) call should trigger a fetch. The second
+    // call must be served entirely from the cache (spec §7.7 contract:
+    // "API calls: 0 (cache hit) | 1+ (rebuild)").
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    let state = state_with_mock(Arc::clone(&mock));
+
+    // ── Call 1 (cold): triggers the single rebuild fetch. ──
+    let result = handle_dep_cycles(&state, DepCyclesParams { id: None })
+        .await
+        .expect("dep_cycles should succeed on cold cache");
+
+    assert_eq!(result.count, 1, "one SCC of size 2 = one cycle");
+    assert_eq!(result.cycles.len(), 1, "count mirrors cycles.len()");
+    // Tarjan SCC order is not contractually stable across petgraph
+    // versions — assert on the member SET, not positional order.
+    let cycle_set: std::collections::HashSet<u64> = result.cycles[0].iter().copied().collect();
+    assert_eq!(
+        cycle_set,
+        std::collections::HashSet::from([6_u64, 7]),
+        "local cycle must contain issue numbers 6 and 7",
+    );
+    // Acceptance (a): local-only cycle produces cross_repo_refs == None.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "SPEC §11.4: local-only cycle → cross_repo_refs None; got: {:?}",
+        result.cross_repo_refs,
+    );
+    // The skip_serializing_if attribute must elide the key entirely.
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert!(
+        json.get("cross_repo_refs").is_none(),
+        "None cross_repo_refs must be elided from JSON: {json}"
+    );
+
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "cold dep_cycles call rebuilds the cache once",
+    );
+
+    // ── Call 2 (warm): zero new fetch calls — cache hit path. ──
+    let result2 = handle_dep_cycles(&state, DepCyclesParams { id: None })
+        .await
+        .expect("dep_cycles should succeed on warm cache");
+    assert_eq!(result2.count, 1);
+    assert!(result2.cross_repo_refs.is_none());
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "warm dep_cycles call must not trigger any additional fetch (SPEC §7.7)",
+    );
+}
+
+/// Acceptance (b): mixed cycle — the configured-repo projection is
+/// shortened and `cross_repo_refs` surfaces the omitted members in
+/// lexicographic order with a non-empty summary.
+///
+/// Fixture: one SCC spanning three nodes —
+/// `acme/widgets#1 → zeta/repo#9 → acme/widgets#2 → acme/widgets#1`.
+/// The cycle contains two local members (#1, #2) and one cross-repo
+/// node (`zeta/repo#9`). Per SPEC §11.4:
+/// - `cycles` must contain the local members as `Vec<u64>` (possibly
+///   shorter than the true cycle length),
+/// - `cross_repo_refs.omitted` must contain `"zeta/repo#9"`,
+/// - `cross_repo_refs.summary` must be populated (agent-facing text).
+#[tokio::test]
+async fn dep_cycles_mixed_cycle_populates_cross_repo_refs() {
+    use unblock_mcp::tools::dep_cycles::{DepCyclesParams, handle_dep_cycles};
+
+    let issues = vec![
+        dep_cycles_fixture_issue(1),
+        dep_cycles_fixture_issue(2),
+        // Two cross-repo nodes pulled into the cycle so the
+        // determinism contract (lex-sorted `omitted`) is observable.
+        dep_cycles_cross_repo_fixture("alpha", "upstream", 42),
+        dep_cycles_cross_repo_fixture("zeta", "repo", 9),
+    ];
+    // 4-node cycle:
+    //   #1 → alpha/upstream#42 → zeta/repo#9 → #2 → #1
+    // After stripping cross-repo members, the local projection is {1, 2}.
+    // `alpha/upstream#42` sorts before `zeta/repo#9` lexicographically.
+    let edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 1),
+            target: QualifiedId::new("alpha", "upstream", 42),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("alpha", "upstream", 42),
+            target: QualifiedId::new("zeta", "repo", 9),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("zeta", "repo", 9),
+            target: QualifiedId::new("acme", "widgets", 2),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 2),
+            target: QualifiedId::new("acme", "widgets", 1),
+        },
+    ];
+
+    let mock = new_mock();
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    let state = state_with_mock(Arc::clone(&mock));
+
+    let result = handle_dep_cycles(&state, DepCyclesParams { id: None })
+        .await
+        .expect("dep_cycles should succeed on cold cache");
+
+    // Exactly one cycle.
+    assert_eq!(result.count, 1);
+    assert_eq!(result.cycles.len(), 1);
+    // Acceptance (b): local projection contains the local members.
+    // Tarjan SCC order is not stable — assert on SET membership.
+    let local_set: std::collections::HashSet<u64> = result.cycles[0].iter().copied().collect();
+    assert_eq!(
+        local_set,
+        std::collections::HashSet::from([1_u64, 2]),
+        "mixed cycle must emit only local members in the bare-u64 projection; got: {:?}",
+        result.cycles[0],
+    );
+    // SPEC §7.7 flow step 4b: the bare-u64 projection MAY be shorter
+    // than the true cycle length. True cycle length here is 4; the
+    // projection is length 2.
+    assert!(
+        result.cycles[0].len() < 4,
+        "local projection must be shorter than true cycle length (SPEC §7.7 flow 4b)",
+    );
+
+    // Acceptance (b): cross_repo_refs is Some with the cross-repo
+    // members in lexicographic order.
+    let refs = result
+        .cross_repo_refs
+        .as_ref()
+        .expect("SPEC §11.4: mixed cycle → cross_repo_refs Some");
+    assert_eq!(
+        refs.omitted,
+        vec!["alpha/upstream#42".to_owned(), "zeta/repo#9".to_owned(),],
+        "Invariant 14: omitted MUST be sorted lexicographically",
+    );
+    let summary = refs
+        .summary
+        .as_deref()
+        .expect("SPEC §11.4: summary populated for non-empty omitted");
+    assert!(
+        summary.contains("cross-repo"),
+        "summary must describe cross-repo omission: {summary}",
+    );
+    assert!(
+        summary.contains("cycles"),
+        "summary must reference the `cycles` projection: {summary}",
+    );
+
+    // JSON serialisation includes the cross_repo_refs envelope.
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert_eq!(
+        json["cross_repo_refs"]["omitted"][0], "alpha/upstream#42",
+        "JSON envelope surfaces the sorted omitted list",
+    );
+    assert_eq!(json["cross_repo_refs"]["omitted"][1], "zeta/repo#9");
+
+    // Exactly one fetch call for the cold rebuild.
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+/// Acceptance (c): targeted `id` filter — two disjoint cycles in the
+/// graph, an `id` parameter picks exactly one.
+///
+/// Fixture: two independent 2-node cycles (#10 ↔ #11 and #20 ↔ #21).
+/// With `id = Some(10)` the handler must return only the {#10, #11}
+/// cycle, not the {#20, #21} cycle. With `id = Some(20)` the reverse.
+/// With `id = Some(999)` (absent from every cycle) the handler returns
+/// an empty `cycles` vector and `count == 0`.
+#[tokio::test]
+async fn dep_cycles_targeted_id_filters_to_scc() {
+    use unblock_mcp::tools::dep_cycles::{DepCyclesParams, handle_dep_cycles};
+
+    let issues = vec![
+        dep_cycles_fixture_issue(10),
+        dep_cycles_fixture_issue(11),
+        dep_cycles_fixture_issue(20),
+        dep_cycles_fixture_issue(21),
+    ];
+    let edges = vec![
+        // Cycle A: #10 ↔ #11.
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 11),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 11),
+            target: QualifiedId::new("acme", "widgets", 10),
+        },
+        // Cycle B: #20 ↔ #21.
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 20),
+            target: QualifiedId::new("acme", "widgets", 21),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 21),
+            target: QualifiedId::new("acme", "widgets", 20),
+        },
+    ];
+
+    let mock = new_mock();
+    // One push is enough — all three calls below share the same warm
+    // cache after the first fetch.
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    let state = state_with_mock(Arc::clone(&mock));
+
+    // ── id = 10: matches cycle A only. ──
+    let r10 = handle_dep_cycles(&state, DepCyclesParams { id: Some(10) })
+        .await
+        .expect("dep_cycles(id=10) should succeed");
+    assert_eq!(r10.count, 1, "id=10 matches exactly one cycle");
+    let set10: std::collections::HashSet<u64> = r10.cycles[0].iter().copied().collect();
+    assert_eq!(
+        set10,
+        std::collections::HashSet::from([10_u64, 11]),
+        "id=10 → cycle A {{#10, #11}}",
+    );
+    assert!(r10.cross_repo_refs.is_none());
+
+    // ── id = 20: matches cycle B only. ──
+    let r20 = handle_dep_cycles(&state, DepCyclesParams { id: Some(20) })
+        .await
+        .expect("dep_cycles(id=20) should succeed");
+    assert_eq!(r20.count, 1, "id=20 matches exactly one cycle");
+    let set20: std::collections::HashSet<u64> = r20.cycles[0].iter().copied().collect();
+    assert_eq!(
+        set20,
+        std::collections::HashSet::from([20_u64, 21]),
+        "id=20 → cycle B {{#20, #21}}",
+    );
+    assert!(r20.cross_repo_refs.is_none());
+
+    // ── id = 999: matches no cycle. ──
+    let r999 = handle_dep_cycles(&state, DepCyclesParams { id: Some(999) })
+        .await
+        .expect("dep_cycles(id=999) should succeed (no match is not an error)");
+    assert_eq!(r999.count, 0);
+    assert!(r999.cycles.is_empty());
+    assert!(r999.cross_repo_refs.is_none());
+
+    // ── id = None: returns BOTH cycles. ──
+    let r_all = handle_dep_cycles(&state, DepCyclesParams { id: None })
+        .await
+        .expect("dep_cycles(id=None) should succeed");
+    assert_eq!(r_all.count, 2, "id=None → full graph produces both cycles");
+
+    // All four calls shared a single fetch (warm-cache after the first).
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "SPEC §7.7 cache contract: one fetch across four calls",
+    );
+}


### PR DESCRIPTION
## Summary

Implements `dep_cycles` MCP tool per SPEC §7.7, consuming the cross-repo response contract landed in §11.4 (#179). Detects all dependency cycles in the graph, projects them down to local `u64` issue numbers scoped to the configured repo, and surfaces cross-repo cycle members through `cross_repo_refs: Option<CrossRepoRefs>`.

Bead: `unblock-29p.11` (parent epic `unblock-29p`).

### What changed

- **`unblock-core`** — adds the shared `CrossRepoRefs { omitted: Vec<String>, summary: Option<String> }` response-side type at `crates/unblock-core/src/types.rs` per SPEC §2.16, with a new `schemars` dependency on core for `JsonSchema` support.
- **`unblock-mcp`** — new `tools::dep_cycles` module with:
  - `DepCyclesParams { id: Option<u64> }` — optional targeted filter to a single SCC containing the local issue number.
  - `DepCyclesResult { cycles, count, cross_repo_refs }` — `cross_repo_refs` is `#[serde(skip_serializing_if = "Option::is_none")]` so purely-local runs elide the envelope.
  - Read-only handler (no `execute_write_tool`): lazy cache rebuild, direct `fetch_graph_data` retry on empty cache (mirrors stats.rs R6 503 path).
  - Cross-repo accumulator uses `BTreeSet<String>` — free dedup + lex-sorted iteration satisfies §14 Invariant 14.
  - Cycles with < 2 local members are still emitted per §7.7 step 4b (their cross-repo members contribute to `omitted`).
- **Server registration deliberately deferred** to sibling bead `unblock-29p.12`.

### Acceptance criteria (plan Task 06.06)

- (a) Local-only cycle integration test: `cross_repo_refs == None`, envelope elided from JSON output.
- (b) Mixed cycle integration test: `cross_repo_refs == Some` with lex-sorted `omitted`; bare `u64` projection can be shorter than true cycle length.
- (c) Targeted `id` filter honours `params.id: Option<u64>` (SCC-scoped, local-only).
- (d) Integration tests use `MockGitHubClient`.
- (e) Quality gate green: fmt / clippy / test / doc all clean.
- (f) Module `//!` docs explain §11.4 integration and server-registration deferral.

### SPEC sections implemented

- §2.16 — `CrossRepoRefs` shared type (placement: `unblock-core/src/types.rs`).
- §7.7 — `dep_cycles` tool semantics (lazy rebuild, projection, optional id filter).
- §11.4 — Cross-repo response contract (`cross_repo_refs: Option<CrossRepoRefs>`, elided when `None`).
- §14 Invariant 14 — `omitted` is lex-sorted and deduplicated.

### Commits

- `1ceccc9` feat(core): add CrossRepoRefs shared response-side type (`API:` footer)
- `97cedea` feat(mcp): add dep_cycles MCP tool handler module
- `f2097f2` test(mcp): add integration tests for dep_cycles MCP tool

## Test plan

- [x] `cargo fmt --check --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — 198 + 121 + 250 pass
- [x] `cargo test -p unblock-mcp --test integration dep_cycles` — 3 new tests pass
- [x] `cargo doc --no-deps --workspace` — clean
- [x] R7 discipline: all cycle-order assertions use `HashSet<u64>` (Tarjan SCC order is not contractually stable across petgraph versions)
- [ ] Human review of §11.4 contract shape and `cross_repo_refs` summary wording

### Out of scope (sibling beads)

- Server registration of the tool → `unblock-29p.12`
- Retro-fit of §11.4 into `ready` / `prime` / `close` → separate sub-epic `unblock-eos` children

Closes bead: `unblock-29p.11` (to be closed after review + merge).