### PR TITLE
 feat(core): scope ready set to configured repository (SPEC §14 Invariant 14(a))

### DIFF
--- a/crates/unblock-core/benches/cache_bench.rs
+++ b/crates/unblock-core/benches/cache_bench.rs
@@ -104,7 +104,9 @@ fn build_populated_cache(rt: &Runtime, n: usize) -> Arc<GraphCache> {
     let issues = generate_issues(n);
     let edges = generate_edges(n);
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    // Fixture lives in ("bench", "repo") per generate_issues/generate_edges —
+    // pass the same coords so SPEC §3.3 Filter 3 admits the issues.
+    let ready_set = graph.compute_ready_set(&issues, "bench", "repo");
     let cache = Arc::new(GraphCache::new(Duration::from_secs(300)));
     rt.block_on(cache.update(issues, ready_set, graph));
     cache

--- a/crates/unblock-core/src/cache.rs
+++ b/crates/unblock-core/src/cache.rs
@@ -199,9 +199,15 @@ mod tests {
 
     use crate::types::QualifiedId;
 
+    /// Owner/repo used by cache test fixtures. Must match the values passed
+    /// to `compute_ready_set` so SPEC §3.3 Filter 3 (§14 Invariant 14(a))
+    /// admits the local issues.
+    const TEST_OWNER: &str = "test";
+    const TEST_REPO: &str = "repo";
+
     /// Helper to create a `QualifiedId` for tests.
     fn qid(number: u64) -> QualifiedId {
-        QualifiedId::new("test", "repo", number)
+        QualifiedId::new(TEST_OWNER, TEST_REPO, number)
     }
 
     /// Build a minimal `Issue` for testing.
@@ -246,7 +252,7 @@ mod tests {
             target: qid(2),
         }];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready_set = graph.compute_ready_set(&issues);
+        let ready_set = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         (issues, graph, ready_set)
     }
 

--- a/crates/unblock-core/src/graph.rs
+++ b/crates/unblock-core/src/graph.rs
@@ -1820,6 +1820,102 @@ mod tests {
                     );
                 }
             }
+
+            /// SPEC §13.3 #7 / §14 Invariant 14(a) (unblock-eos.4 / D6.a /
+            /// GAP-14.b): for any input mixing configured-repo and
+            /// cross-repo source issues, `compute_ready_set` returns zero
+            /// elements whose `qualified_id.(owner, repo)` differs from
+            /// the configured `(owner, repo)`. Drives the unblock-eos.4
+            /// graph-engine scrub.
+            ///
+            /// Strategy: generate N issues with random states, priorities,
+            /// and a parallel `is_cross_repo` vector. Issues flagged
+            /// cross-repo live in `("owner-b", "repo-b")`; the rest live
+            /// in `("owner-a", "repo-a")`. Call
+            /// `compute_ready_set(&issues, "owner-a", "repo-a")` and
+            /// assert every returned summary has `owner == "owner-a"` and
+            /// `repo == "repo-a"`.
+            #[test]
+            fn ready_set_source_scoped_to_configured_repo(
+                num_issues in 1_u64..40,
+                issue_states in proptest::collection::vec(arb_issue_state(), 1..40),
+                issue_priorities in proptest::collection::vec(arb_priority(), 1..40),
+                issue_statuses in proptest::collection::vec(arb_status(), 1..40),
+                is_cross_repo in proptest::collection::vec(any::<bool>(), 1..40),
+                edges in proptest::collection::vec((1_u64..40, 1_u64..40, any::<bool>(), any::<bool>()), 0..80),
+            ) {
+                let owner_a = "owner-a";
+                let repo_a = "repo-a";
+                let owner_b = "owner-b";
+                let repo_b = "repo-b";
+
+                // Generate issues with random state/priority/status and
+                // random repo membership.
+                let issues: Vec<Issue> = (1..=num_issues)
+                    .map(|n| {
+                        let idx = usize::try_from(n - 1).expect("issue number fits in usize");
+                        let state = issue_states.get(idx).copied().unwrap_or(IssueState::Open);
+                        let priority = issue_priorities.get(idx).copied().unwrap_or(Priority::P2);
+                        let status = issue_statuses.get(idx).copied().unwrap_or(Status::Ready);
+                        let cross = is_cross_repo.get(idx).copied().unwrap_or(false);
+                        let (owner, repo) = if cross {
+                            (owner_b, repo_b)
+                        } else {
+                            (owner_a, repo_a)
+                        };
+                        let mut issue = make_issue_repo(owner, repo, n, state, priority);
+                        issue.status = status;
+                        issue
+                    })
+                    .collect();
+
+                // Build blocking edges that may point within or across
+                // repos — Filter 3 runs BEFORE Filter 4, so cross-repo
+                // source issues are dropped regardless of blocker state.
+                let blocking_edges: Vec<BlockingEdge> = edges
+                    .into_iter()
+                    .filter(|(s, t, _, _)| *s != *t && *s <= num_issues && *t <= num_issues)
+                    .map(|(s, t, src_cross, tgt_cross)| {
+                        let (src_owner, src_repo) = if src_cross { (owner_b, repo_b) } else { (owner_a, repo_a) };
+                        let (tgt_owner, tgt_repo) = if tgt_cross { (owner_b, repo_b) } else { (owner_a, repo_a) };
+                        BlockingEdge {
+                            source: qid_repo(src_owner, src_repo, s),
+                            target: qid_repo(tgt_owner, tgt_repo, t),
+                        }
+                    })
+                    .collect();
+
+                let graph = DependencyGraph::build(&issues, &blocking_edges);
+                let ready = graph.compute_ready_set(&issues, owner_a, repo_a);
+
+                // Invariant 14(a): every ready entry lives in the
+                // configured (owner_a, repo_a).
+                for summary in &ready {
+                    prop_assert_eq!(
+                        summary.qualified_id.owner.as_str(),
+                        owner_a,
+                        "Ready summary {} has non-configured owner (expected {})",
+                        summary.qualified_id,
+                        owner_a
+                    );
+                    prop_assert_eq!(
+                        summary.qualified_id.repo.as_str(),
+                        repo_a,
+                        "Ready summary {} has non-configured repo (expected {})",
+                        summary.qualified_id,
+                        repo_a
+                    );
+                    prop_assert!(
+                        summary.qualified_id.owner != owner_b
+                            || summary.qualified_id.repo != repo_b,
+                        "Cross-repo source {} leaked into ready set \
+                         configured to {}/{}",
+                        summary.qualified_id,
+                        owner_a,
+                        repo_a
+                    );
+                }
+            }
         }
     }
 

--- a/crates/unblock-core/src/graph.rs
+++ b/crates/unblock-core/src/graph.rs
@@ -2,7 +2,8 @@
 //!
 //! Provides `DependencyGraph` with operations:
 //! - `build()` — construct graph from issues and blocking edges
-//! - `compute_ready_set()` — find issues with no active blockers
+//! - `compute_ready_set()` — find issues with no active blockers that live in
+//!   the configured `(owner, repo)` (SPEC §3.3 Filter 3 / §14 Invariant 14(a))
 //! - `compute_unblock_cascade()` — determine what unblocks when an issue closes
 //! - `would_create_cycle()` — check before adding a dependency
 //! - `detect_all_cycles()` — find all circular dependencies via Tarjan's SCC
@@ -122,36 +123,59 @@ impl DependencyGraph {
         }
     }
 
-    /// Compute the set of issues that are ready to work on.
+    /// Compute the set of issues that are ready to work on for the configured
+    /// `(owner, repo)`.
     ///
-    /// An issue is considered ready if:
-    /// 1. Its GitHub state is [`IssueState::Open`]
-    /// 2. It has no outgoing edges to issues that are still [`IssueState::Open`]
-    ///    (i.e., all of its blockers are closed)
+    /// An issue is considered ready iff all of the following hold:
+    /// 1. Its GitHub state is [`IssueState::Open`] (Filter 1).
+    /// 2. Its [`Status`] is not one of the preserved states
+    ///    [`Status::InProgress`], [`Status::Deferred`], or [`Status::Closed`]
+    ///    (Filter 2).
+    /// 3. Its `qualified_id.(owner, repo)` equals `(configured_owner, configured_repo)`
+    ///    (Filter 3 — source scoping, SPEC §3.3 / §14 Invariant 14(a)).
+    /// 4. It has no outgoing edges to issues that are still [`IssueState::Open`]
+    ///    (i.e. all of its blockers are closed — Filter 4).
+    ///
+    /// **Source scoping (Filter 3, unblock-eos.4 / D6.a / GAP-14.b).**
+    /// `compute_ready_set` is the single chokepoint that enforces
+    /// `ready_set ⊆ { i | i.qualified_id.(owner, repo) == (configured_owner, configured_repo) }`.
+    /// Every downstream consumer of the ready set (cached `ready_set` in
+    /// `GraphCache`, the `ready` tool in §7.1, `prime` categorisation in §7.3,
+    /// `update_status_fields` in §10) inherits this guarantee without
+    /// re-checking. Cross-repo source issues are dropped by Filter 3
+    /// regardless of blocker state — they are NEVER members of the local
+    /// ready-set projection. Filter 3 is applied BEFORE Filter 4 so the
+    /// cross-repo blocker traversal is never performed for a cross-repo
+    /// source.
     ///
     /// **Note:** `defer_until` filtering is intentionally not applied here.
-    /// Per ARCH section 6.2, defer-until is a post-filter at the MCP tool layer, not
-    /// in the graph engine. The graph engine remains date-free.
+    /// Per ARCH section 6.2, defer-until is a post-filter at the MCP tool
+    /// layer, not in the graph engine. The graph engine remains date-free.
     ///
-    /// **Contract:** The `issues` slice should match the issues used to build the
-    /// graph. The blocker evaluation uses the graph's internal state snapshot (built
-    /// at construction time), while open-issue filtering uses the passed-in slice.
-    /// Passing a different set of issues than what was used in `build()` may produce
-    /// inconsistent results.
+    /// **Contract:** The `issues` slice should match the issues used to build
+    /// the graph. The blocker evaluation uses the graph's internal state
+    /// snapshot (built at construction time), while open-issue filtering uses
+    /// the passed-in slice. Passing a different set of issues than what was
+    /// used in `build()` may produce inconsistent results.
     ///
-    /// Results are sorted by priority ascending (P0 first), then by `created_at`
-    /// ascending (oldest first) as a tiebreaker.
+    /// Results are sorted by priority ascending (P0 first), then by
+    /// `created_at` ascending (oldest first) as a tiebreaker.
     #[must_use]
-    pub fn compute_ready_set(&self, issues: &[Issue]) -> Vec<IssueSummary> {
+    pub fn compute_ready_set(
+        &self,
+        issues: &[Issue],
+        configured_owner: &str,
+        configured_repo: &str,
+    ) -> Vec<IssueSummary> {
         let mut ready: Vec<IssueSummary> = Vec::new();
 
         for issue in issues {
-            // Only consider open issues.
+            // Filter 1: must be open in GitHub.
             if issue.state != IssueState::Open {
                 continue;
             }
 
-            // Skip preserved states per spec §3.3.
+            // Filter 2: skip preserved states per spec §3.3.
             // InProgress, Deferred, and Closed are set by agent/human and must
             // not be overwritten by the graph engine.
             //
@@ -166,7 +190,22 @@ impl DependencyGraph {
                 continue;
             }
 
-            // Check if this issue has any open blockers.
+            // Filter 3: source issue MUST live in the configured (owner, repo).
+            // Cross-repo source issues are never members of the local
+            // ready-set projection (§11.4, §14 Invariant 14(a)). Applied
+            // BEFORE Filter 4 so the cross-repo blocker traversal is never
+            // performed for a cross-repo source. Introduced by
+            // unblock-eos.4 (Direction 1).
+            if issue.qualified_id.owner != configured_owner
+                || issue.qualified_id.repo != configured_repo
+            {
+                continue;
+            }
+
+            // Filter 4: check all blockers via graph. Cross-repo blockers
+            // ARE honoured here — an open cross-repo blocker keeps the local
+            // source out of the ready set, and the tool layer surfaces the
+            // dropped blocker via §11.4 `cross_repo_refs`.
             // Outgoing edges point to blockers.
             let is_blocked = if let Some(&node_idx) = self.node_map.get(&issue.qualified_id) {
                 self.graph
@@ -662,7 +701,7 @@ mod tests {
             make_issue(2, IssueState::Open, Priority::P1),
         ];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         assert_eq!(ready.len(), 2);
         // P1 (issue 2) should come first due to priority sorting.
         assert_eq!(ready[0].number, 2);
@@ -676,7 +715,7 @@ mod tests {
             make_issue(2, IssueState::Closed, Priority::P1),
         ];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].number, 1);
     }
@@ -691,7 +730,7 @@ mod tests {
         ];
         let edges = vec![edge(1, 2)];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -714,7 +753,7 @@ mod tests {
         ];
         let edges = vec![edge(1, 2)];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -735,7 +774,7 @@ mod tests {
         ];
         let edges = vec![edge(1, 2), edge(1, 3)];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -751,7 +790,7 @@ mod tests {
     #[test]
     fn ready_set_empty_inputs() {
         let graph = DependencyGraph::build(&[], &[]);
-        let ready = graph.compute_ready_set(&[]);
+        let ready = graph.compute_ready_set(&[], TEST_OWNER, TEST_REPO);
         assert!(ready.is_empty());
     }
 
@@ -765,7 +804,7 @@ mod tests {
             make_issue_at(3, IssueState::Open, Priority::P0, now),
         ];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         assert_eq!(ready.len(), 3);
         // P0 first.
@@ -781,7 +820,7 @@ mod tests {
         let issue1 = make_issue(1, IssueState::Open, Priority::P2);
         let issue2 = make_issue(2, IssueState::Open, Priority::P1);
         let graph = DependencyGraph::build(std::slice::from_ref(&issue1), &[]);
-        let ready = graph.compute_ready_set(&[issue1, issue2]);
+        let ready = graph.compute_ready_set(&[issue1, issue2], TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -801,7 +840,7 @@ mod tests {
         ];
         let edges = vec![edge(1, 2), edge(2, 3)];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].number, 3);
@@ -815,7 +854,7 @@ mod tests {
         let open_ready = make_issue(2, IssueState::Open, Priority::P2);
         let issues = vec![in_progress, open_ready];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -836,7 +875,7 @@ mod tests {
         let open_ready = make_issue(2, IssueState::Open, Priority::P2);
         let issues = vec![deferred, open_ready];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -858,7 +897,7 @@ mod tests {
         let open_ready = make_issue(2, IssueState::Open, Priority::P2);
         let issues = vec![stale_closed, open_ready];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -878,7 +917,7 @@ mod tests {
         // Issue 1 is blocked by issue 2, but issue 2 is closed.
         let edges = vec![edge(1, 2)];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         let ready_numbers: Vec<u64> = ready.iter().map(|s| s.number).collect();
         assert!(
@@ -892,7 +931,7 @@ mod tests {
         // Status::Ready issues that are open and unblocked should be included.
         let issues = vec![make_issue(1, IssueState::Open, Priority::P1)];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].number, 1);
@@ -1398,8 +1437,27 @@ mod tests {
 
     #[test]
     fn cross_repo_ready_set_with_mixed_repos() {
-        // Issue acme/widgets#1 is blocked by acme/gadgets#1.
-        // acme/gadgets#1 is open, so acme/widgets#1 should NOT be ready.
+        // Regression target for unblock-eos.4 / D6.a / GAP-14.b (SPEC §14
+        // Invariant 14(a)): the ready set MUST be scoped to the configured
+        // `(owner, repo)` at the graph engine via §3.3 Filter 3.
+        //
+        // Fixture:
+        // - Local source `acme/widgets#1` (configured repo) is blocked by the
+        //   cross-repo node `acme/gadgets#1` (same owner, different repo).
+        // - `acme/gadgets#1` is itself an OPEN issue in the input slice.
+        //
+        // Expected behaviour after eos.4:
+        // - Filter 3 drops `acme/gadgets#1` regardless of its (unblocked)
+        //   blocker state — cross-repo sources are never members of the
+        //   ready-set projection.
+        // - `acme/widgets#1` survives Filter 3 but is excluded by Filter 4
+        //   because its blocker `acme/gadgets#1` is still open.
+        // - Net ready set: empty.
+        //
+        // Pre-eos.4 behaviour admitted `acme/gadgets#1` into the ready set
+        // because the engine did not apply source-scoping. This test pins
+        // the post-eos.4 invariant and is preserved (not deleted) per bead
+        // AC #4 / plan GAP-14.b migration note #3.
         let issue_a = make_issue_repo("acme", "widgets", 1, IssueState::Open, Priority::P1);
         let issue_b = make_issue_repo("acme", "gadgets", 1, IssueState::Open, Priority::P2);
         let issues = vec![issue_a, issue_b];
@@ -1408,9 +1466,20 @@ mod tests {
             target: qid_repo("acme", "gadgets", 1),
         }];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
-        assert_eq!(ready.len(), 1);
-        assert_eq!(ready[0].qualified_id, qid_repo("acme", "gadgets", 1));
+        let ready = graph.compute_ready_set(&issues, "acme", "widgets");
+        assert!(
+            ready.is_empty(),
+            "Ready set must be empty: acme/gadgets#1 is dropped by Filter 3 \
+             (cross-repo source) and acme/widgets#1 is dropped by Filter 4 \
+             (still blocked by open acme/gadgets#1). Got: {ready:?}"
+        );
+        assert!(
+            !ready
+                .iter()
+                .any(|s| s.qualified_id.owner == "acme" && s.qualified_id.repo == "gadgets"),
+            "Cross-repo source acme/gadgets#1 must never reach the ready set \
+             under SPEC §14 Invariant 14(a)"
+        );
     }
 
     // ── Proptest ──────────────────────────────────────────────────────────
@@ -1476,7 +1545,7 @@ mod tests {
                     .collect();
 
                 let graph = DependencyGraph::build(&issues, &blocking_edges);
-                let ready = graph.compute_ready_set(&issues);
+                let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
                 // Invariant 1: no issue in the ready set has an open blocker.
                 for summary in &ready {
@@ -1710,8 +1779,10 @@ mod tests {
                     graph.graph.node_count()
                 );
 
-                // Invariant: ready set issues are all Open.
-                let ready = graph.compute_ready_set(&all_issues);
+                // Invariant: ready set issues are all Open AND scoped to the
+                // configured repo (repo_a). This is unblock-eos.4 / §14
+                // Invariant 14(a) — cross-repo sources must never leak.
+                let ready = graph.compute_ready_set(&all_issues, repo_a_owner, repo_a_name);
                 for summary in &ready {
                     let original = all_issues.iter().find(|i| i.qualified_id == summary.qualified_id);
                     if let Some(issue) = original {
@@ -1722,6 +1793,31 @@ mod tests {
                             summary.qualified_id
                         );
                     }
+                    // §14 Invariant 14(a): no cross-repo (org-b/repo-b) issue
+                    // can appear in the ready set configured to repo_a.
+                    prop_assert!(
+                        summary.qualified_id.owner != repo_b_owner
+                            || summary.qualified_id.repo != repo_b_name,
+                        "Cross-repo source {} leaked into ready set \
+                         configured to {}/{}",
+                        summary.qualified_id,
+                        repo_a_owner,
+                        repo_a_name
+                    );
+                    prop_assert_eq!(
+                        summary.qualified_id.owner.as_str(),
+                        repo_a_owner,
+                        "Ready issue {} has non-configured owner, expected {}",
+                        summary.qualified_id,
+                        repo_a_owner
+                    );
+                    prop_assert_eq!(
+                        summary.qualified_id.repo.as_str(),
+                        repo_a_name,
+                        "Ready issue {} has non-configured repo, expected {}",
+                        summary.qualified_id,
+                        repo_a_name
+                    );
                 }
             }
         }

--- a/crates/unblock-core/src/reconcile.rs
+++ b/crates/unblock-core/src/reconcile.rs
@@ -560,9 +560,18 @@ mod tests {
     }
 
     /// Compute the ready set as a `HashSet<QualifiedId>` from the graph.
-    fn ready_set(graph: &DependencyGraph, issues: &[Issue]) -> HashSet<QualifiedId> {
+    ///
+    /// Takes the configured `(owner, repo)` pair so SPEC §3.3 Filter 3
+    /// (§14 Invariant 14(a)) admits the local issues — reconcile tests use
+    /// a single repo per fixture (`acme/widgets` or `acme/test`).
+    fn ready_set(
+        graph: &DependencyGraph,
+        issues: &[Issue],
+        configured_owner: &str,
+        configured_repo: &str,
+    ) -> HashSet<QualifiedId> {
         graph
-            .compute_ready_set(issues)
+            .compute_ready_set(issues, configured_owner, configured_repo)
             .into_iter()
             .map(|s| s.qualified_id)
             .collect()
@@ -581,7 +590,7 @@ mod tests {
         let issues_vec = vec![issue1, issue2];
         let edges = vec![edge(&q2, &q1)]; // #2 is blocked by #1
         let graph = DependencyGraph::build(&issues_vec, &edges);
-        let computed_ready = ready_set(&graph, &issues_vec);
+        let computed_ready = ready_set(&graph, &issues_vec, "acme", "widgets");
         let by_id = issue_map(&issues_vec);
 
         let engine = ReconcileEngine::new(24);
@@ -604,7 +613,7 @@ mod tests {
 
         let issues_vec = vec![issue1, issue2];
         let graph = DependencyGraph::build(&issues_vec, &[]);
-        let computed_ready = ready_set(&graph, &issues_vec);
+        let computed_ready = ready_set(&graph, &issues_vec, "acme", "widgets");
         let by_id = issue_map(&issues_vec);
 
         let engine = ReconcileEngine::new(24);
@@ -630,7 +639,7 @@ mod tests {
         let issues_vec = vec![issue1, issue2, issue3];
         let edges = vec![edge(&q1, &q2), edge(&q2, &q3), edge(&q3, &q1)];
         let graph = DependencyGraph::build(&issues_vec, &edges);
-        let computed_ready = ready_set(&graph, &issues_vec);
+        let computed_ready = ready_set(&graph, &issues_vec, "acme", "widgets");
         let by_id = issue_map(&issues_vec);
 
         let engine = ReconcileEngine::new(24);
@@ -655,7 +664,7 @@ mod tests {
 
         let issues_vec = vec![issue1];
         let graph = DependencyGraph::build(&issues_vec, &[]);
-        let computed_ready = ready_set(&graph, &issues_vec);
+        let computed_ready = ready_set(&graph, &issues_vec, "acme", "widgets");
         let by_id = issue_map(&issues_vec);
 
         let engine = ReconcileEngine::new(24);
@@ -676,7 +685,7 @@ mod tests {
 
         let issues_vec = vec![issue1];
         let graph = DependencyGraph::build(&issues_vec, &[]);
-        let computed_ready = ready_set(&graph, &issues_vec);
+        let computed_ready = ready_set(&graph, &issues_vec, "acme", "widgets");
         let by_id = issue_map(&issues_vec);
 
         let engine = ReconcileEngine::new(24);
@@ -760,7 +769,7 @@ mod tests {
             edge(&q6, &q5), // #6 blocked by #5 (closed — so #6 is Ready)
         ];
         let graph = DependencyGraph::build(&issues_vec, &edges);
-        let computed_ready = ready_set(&graph, &issues_vec);
+        let computed_ready = ready_set(&graph, &issues_vec, "acme", "widgets");
         let by_id = issue_map(&issues_vec);
 
         let engine = ReconcileEngine::new(24);
@@ -858,7 +867,7 @@ mod tests {
 
                 // 4. Build graph and compute ready set.
                 let graph = DependencyGraph::build(&issues, &safe_edges);
-                let computed_ready = ready_set(&graph, &issues);
+                let computed_ready = ready_set(&graph, &issues, "acme", "test");
 
                 // 5. Set each issue's Status to match what the graph says.
                 for issue in &mut issues {
@@ -874,7 +883,7 @@ mod tests {
                 // Rebuild graph with corrected Status values (graph itself
                 // doesn't use Status, but we need the same structure).
                 let graph = DependencyGraph::build(&issues, &safe_edges);
-                let computed_ready = ready_set(&graph, &issues);
+                let computed_ready = ready_set(&graph, &issues, "acme", "test");
                 let by_id = issue_map(&issues);
 
                 // 6. Analyse and assert clean.

--- a/crates/unblock-mcp/src/tools/dep_cycles.rs
+++ b/crates/unblock-mcp/src/tools/dep_cycles.rs
@@ -328,7 +328,11 @@ pub async fn handle_dep_cycles(
         // follow-up call is warm, then compute cycles against the
         // freshly built graph without re-reading the cache.
         let graph_built = DependencyGraph::build(&issues_vec, &edges_vec);
-        let ready_set = graph_built.compute_ready_set(&issues_vec);
+        // SPEC §3.3 Filter 3 / §14 Invariant 14(a): scope the cached ready
+        // set to the configured (owner, repo) so downstream consumers
+        // inherit the local-only guarantee by construction.
+        let ready_set =
+            graph_built.compute_ready_set(&issues_vec, &configured_owner, &configured_repo);
         let cycles = graph_built.detect_all_cycles();
         state.cache.update(issues_vec, ready_set, graph_built).await;
         cycles

--- a/crates/unblock-mcp/src/tools/list.rs
+++ b/crates/unblock-mcp/src/tools/list.rs
@@ -494,7 +494,11 @@ pub async fn handle_list(state: &ServerState, params: ListParams) -> Result<List
             // is still consumed below by `build_list_rows` for the list
             // projection — the cache holds an independent snapshot.
             let graph = DependencyGraph::build(&issues, &edges);
-            let ready_set = graph.compute_ready_set(&issues);
+            // SPEC §3.3 Filter 3 / §14 Invariant 14(a): scope the cached
+            // ready set to the configured (owner, repo) so subsequent
+            // `ready`/`prime` reads inherit the local-only guarantee.
+            let ready_set =
+                graph.compute_ready_set(&issues, state.github.owner(), state.github.repo());
             state.cache.update(issues.clone(), ready_set, graph).await;
             tracing::debug!("Cache refreshed by list handler");
             issues

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -164,7 +164,14 @@ pub async fn rebuild_cache(state: &ServerState) {
     match state.github.fetch_graph_data().await {
         Ok((issues, edges)) => {
             let graph = DependencyGraph::build(&issues, &edges);
-            let ready_set = graph.compute_ready_set(&issues);
+            // SPEC §3.3 Filter 3 / §14 Invariant 14(a): the cached ready set
+            // is guaranteed local-only by construction when the engine is
+            // passed the configured (owner, repo). This is the canonical
+            // chokepoint — downstream consumers (ready, prime,
+            // update_status_fields) inherit the guarantee without
+            // re-checking. (unblock-eos.4 / D6.a / GAP-14.b)
+            let ready_set =
+                graph.compute_ready_set(&issues, state.github.owner(), state.github.repo());
             state.cache.update(issues, ready_set, graph).await;
             tracing::debug!("Cache rebuilt after write tool execution");
         }
@@ -244,7 +251,9 @@ mod tests {
             target: qid(1),
         }];
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready_set = graph.compute_ready_set(&issues);
+        // Fixture lives in ("test", "repo") — match the configured coords
+        // so SPEC §3.3 Filter 3 admits the issues.
+        let ready_set = graph.compute_ready_set(&issues, "test", "repo");
         cache.update(issues, ready_set, graph).await;
     }
 

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -756,9 +756,15 @@ mod tests {
 
     // ── Test helpers ───────────────────────────────────────────────────
 
+    /// Owner/repo used by prime test fixtures. Must match the values passed
+    /// to `compute_ready_set` so SPEC §3.3 Filter 3 (§14 Invariant 14(a))
+    /// admits the local issues.
+    const TEST_OWNER: &str = "test-owner";
+    const TEST_REPO: &str = "test-repo";
+
     /// Helper to create a `QualifiedId` for tests.
     fn qid(number: u64) -> QualifiedId {
-        QualifiedId::new("test-owner", "test-repo", number)
+        QualifiedId::new(TEST_OWNER, TEST_REPO, number)
     }
 
     /// Build a minimal `Issue` for testing.
@@ -820,7 +826,7 @@ mod tests {
     #[test]
     fn categorise_empty_issues_returns_empty() {
         let graph = DependencyGraph::build(&[], &[]);
-        let ready = graph.compute_ready_set(&[]);
+        let ready = graph.compute_ready_set(&[], TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&[], &graph, &ready, 24, Utc::now());
 
         assert!(result.in_progress.is_empty());
@@ -839,7 +845,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(result.in_progress.len(), 1);
@@ -859,7 +865,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(result.in_progress.len(), 1);
@@ -881,7 +887,7 @@ mod tests {
         }];
 
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // Issue #1 is ready (no blockers), issue #2 is blocked.
@@ -910,7 +916,7 @@ mod tests {
         ];
 
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let issue_map: HashMap<&QualifiedId, &Issue> =
             issues.iter().map(|i| (&i.qualified_id, i)).collect();
         let hotspots = compute_hotspots(&graph, &issue_map);
@@ -993,7 +999,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert!(result.in_progress.is_empty());
@@ -1013,7 +1019,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert!(
@@ -1032,7 +1038,7 @@ mod tests {
 
         let issues = vec![issue1, issue2];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(result.completed.len(), 2);
@@ -1054,7 +1060,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         // With default 24h window: excluded.
         let result_24 = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
@@ -1084,7 +1090,7 @@ mod tests {
         }];
 
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert!(
@@ -1102,7 +1108,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(result.in_progress.len(), 1);
@@ -1129,7 +1135,7 @@ mod tests {
 
         let issues = vec![issue1, issue2];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(result.in_progress.len(), 2);
@@ -1149,7 +1155,7 @@ mod tests {
 
         let issues = vec![issue1, issue2];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(result.stale.len(), 2);
@@ -1447,7 +1453,7 @@ mod tests {
         }];
 
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // #1 is ready (#3 is InProgress so excluded from ready list).
@@ -1490,7 +1496,7 @@ mod tests {
             test_issue(2, IssueState::Open, Status::Ready),
         ];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready_set = graph.compute_ready_set(&issues);
+        let ready_set = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         state.cache.update(issues, ready_set, graph).await;
 
         assert!(
@@ -1512,7 +1518,7 @@ mod tests {
         }
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         assert_eq!(
@@ -1571,7 +1577,7 @@ mod tests {
         let issues = vec![issue1, issue2];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         let (ip, _r, _b, _s) = apply_agent_filter(&result, None);
@@ -1589,7 +1595,7 @@ mod tests {
         let issues = vec![issue1, issue2];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         let (ip, _, _, _) = apply_agent_filter(&result, Some("agent-x"));
@@ -1605,7 +1611,7 @@ mod tests {
         let issues = vec![issue1, issue2];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         let (_, r, _, _) = apply_agent_filter(&result, Some("agent-x"));
@@ -1635,7 +1641,7 @@ mod tests {
         ];
 
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         let (_, _, b, _) = apply_agent_filter(&result, Some("agent-x"));
@@ -1653,7 +1659,7 @@ mod tests {
         let issues = vec![issue1, issue2];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         let (_, _, _, s) = apply_agent_filter(&result, Some("agent-x"));
@@ -1668,7 +1674,7 @@ mod tests {
         let issues = vec![issue];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // Completed has no agent field — it should always appear regardless
@@ -1695,7 +1701,7 @@ mod tests {
         }];
 
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // Hotspot #1 is agent-x, but even filtering for agent-y should not
@@ -1723,7 +1729,7 @@ mod tests {
         let issues = vec![issue1, issue2, issue3, issue4];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let categories = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // Simulate the filtering handle_prime does.
@@ -1780,7 +1786,7 @@ mod tests {
         let issues = vec![issue1, issue2];
 
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready = graph.compute_ready_set(&issues);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
         // Simulate what handle_prime does: normalize then filter.

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -347,8 +347,12 @@ pub async fn handle_prime(
         .map_err(github_error_to_mcp)?;
 
     // 3. Build graph and compute ready set.
+    // SPEC §3.3 Filter 3 / §14 Invariant 14(a): engine scopes source issues
+    // to the configured (owner, repo) before the blocker filter runs. The
+    // categorisation below and the cache store inherit that guarantee.
     let graph = DependencyGraph::build(&issues_vec, &edges);
-    let ready_summaries = graph.compute_ready_set(&issues_vec);
+    let ready_summaries =
+        graph.compute_ready_set(&issues_vec, state.github.owner(), state.github.repo());
 
     let now = Utc::now();
 

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -459,9 +459,15 @@ mod tests {
 
     // ── Test helpers ───────────────────────────────────────────────────
 
+    /// Owner/repo used by reconcile test fixtures. Must match the values
+    /// passed to `compute_ready_set` so SPEC §3.3 Filter 3
+    /// (§14 Invariant 14(a)) admits the local issues.
+    const TEST_OWNER: &str = "test-owner";
+    const TEST_REPO: &str = "test-repo";
+
     /// Helper to create a `QualifiedId` for tests.
     fn qid(number: u64) -> QualifiedId {
-        QualifiedId::new("test-owner", "test-repo", number)
+        QualifiedId::new(TEST_OWNER, TEST_REPO, number)
     }
 
     /// Build a minimal `Issue` for testing.
@@ -607,7 +613,7 @@ mod tests {
             test_issue(2, IssueState::Open, Status::Ready),
         ];
         let graph = DependencyGraph::build(&issues, &[]);
-        let ready_set = graph.compute_ready_set(&issues);
+        let ready_set = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
 
         // Update cache (same call the handler makes).
         state.cache.update(issues, ready_set, graph).await;
@@ -733,7 +739,7 @@ mod tests {
 
         // Build graph and compute ready set (steps 2-3 of handler).
         let graph = DependencyGraph::build(&issues_vec, &edges);
-        let ready_summaries = graph.compute_ready_set(&issues_vec);
+        let ready_summaries = graph.compute_ready_set(&issues_vec, TEST_OWNER, TEST_REPO);
         let computed_ready: HashSet<QualifiedId> = ready_summaries
             .iter()
             .map(|s| s.qualified_id.clone())
@@ -806,7 +812,7 @@ mod tests {
 
         // Build graph with no edges and compute ready set.
         let graph = DependencyGraph::build(&issues_vec, &[]);
-        let ready_summaries = graph.compute_ready_set(&issues_vec);
+        let ready_summaries = graph.compute_ready_set(&issues_vec, TEST_OWNER, TEST_REPO);
         let computed_ready: HashSet<QualifiedId> = ready_summaries
             .iter()
             .map(|s| s.qualified_id.clone())

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -175,8 +175,13 @@ pub async fn handle_reconcile(
         .collect();
 
     // 2. Build graph and compute ready set.
+    // SPEC §3.3 Filter 3 / §14 Invariant 14(a): scope sources to the
+    // configured (owner, repo) so the drift report's computed_ready set
+    // only considers configured-repo issues. The reconcile engine reads
+    // cross-repo nodes separately when chasing cycles and orphaned edges.
     let graph = DependencyGraph::build(&issues_vec, &edges);
-    let ready_summaries = graph.compute_ready_set(&issues_vec);
+    let ready_summaries =
+        graph.compute_ready_set(&issues_vec, state.github.owner(), state.github.repo());
     let computed_ready: HashSet<QualifiedId> = ready_summaries
         .iter()
         .map(|s| s.qualified_id.clone())

--- a/crates/unblock-mcp/src/tools/stats.rs
+++ b/crates/unblock-mcp/src/tools/stats.rs
@@ -461,8 +461,14 @@ mod tests {
 
     // ── Test helpers ────────────────────────────────────────────────────
 
+    /// Owner/repo used by stats test fixtures. Must match the values passed
+    /// to `aggregate_stats` so SPEC §3.3 Filter 3 (§14 Invariant 14(a))
+    /// admits the local issues.
+    const TEST_OWNER: &str = "acme";
+    const TEST_REPO: &str = "widgets";
+
     fn qid(number: u64) -> QualifiedId {
-        QualifiedId::new("acme", "widgets", number)
+        QualifiedId::new(TEST_OWNER, TEST_REPO, number)
     }
 
     /// Minimal open [`Issue`] populated enough for aggregation tests.
@@ -599,7 +605,7 @@ mod tests {
     #[test]
     fn aggregate_stats_empty_input_yields_zeroed_envelope() {
         let g = DependencyGraph::build(&[], &[]);
-        let result = aggregate_stats(&[], &g);
+        let result = aggregate_stats(&[], &g, TEST_OWNER, TEST_REPO);
         assert_eq!(result.total, 0);
         assert_eq!(result.blocked_count, 0);
         assert_eq!(result.ready_count, 0);
@@ -647,7 +653,7 @@ mod tests {
         ];
         let g = DependencyGraph::build(&issues, &[]);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
 
         assert_eq!(result.total, 5);
         assert_eq!(result.by_status.get("ready"), Some(&2_usize));
@@ -682,7 +688,7 @@ mod tests {
         }];
         let g = DependencyGraph::build(&issues, &edges);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
 
         // Both #1 (Status::Blocked) and #2 (has open blocker) count.
         assert_eq!(result.blocked_count, 2);
@@ -700,7 +706,7 @@ mod tests {
         }];
         let g = DependencyGraph::build(&issues, &edges);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
         assert_eq!(result.ready_count, 1);
     }
 
@@ -721,7 +727,7 @@ mod tests {
         ];
         let g = DependencyGraph::build(&issues, &edges);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
         assert_eq!(result.cycle_count, 1, "one SCC of size 2 = one cycle");
     }
 
@@ -765,7 +771,7 @@ mod tests {
         ];
         let g = DependencyGraph::build(&issues, &[]);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
 
         assert_eq!(result.agents.len(), 2);
         // Sort is by name ascending (alice, bob).
@@ -810,7 +816,7 @@ mod tests {
         ];
         let g = DependencyGraph::build(&issues, &[]);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
         let status_sum: usize = result.by_status.values().sum();
         assert_eq!(status_sum, result.total);
     }
@@ -828,7 +834,7 @@ mod tests {
         )];
         let g = DependencyGraph::build(&issues, &[]);
         let refs: Vec<&Issue> = issues.iter().collect();
-        let result = aggregate_stats(&refs, &g);
+        let result = aggregate_stats(&refs, &g, TEST_OWNER, TEST_REPO);
         assert!(result.agents.is_empty());
     }
 

--- a/crates/unblock-mcp/src/tools/stats.rs
+++ b/crates/unblock-mcp/src/tools/stats.rs
@@ -406,11 +406,8 @@ pub async fn handle_stats(
         // SPEC §3.3 Filter 3 / §14 Invariant 14(a): pass configured coords
         // so the cached ready set is local-only and `ready_count` in the
         // stats envelope matches what `ready(milestone=…)` would return.
-        let ready_set = graph_built.compute_ready_set(
-            &issues_vec,
-            state.github.owner(),
-            state.github.repo(),
-        );
+        let ready_set =
+            graph_built.compute_ready_set(&issues_vec, state.github.owner(), state.github.repo());
         let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
         let filtered = filter_by_milestone(&issues_vec, milestone);
         let result = aggregate_stats(

--- a/crates/unblock-mcp/src/tools/stats.rs
+++ b/crates/unblock-mcp/src/tools/stats.rs
@@ -240,7 +240,18 @@ fn seed_priority_buckets() -> HashMap<String, usize> {
 /// keeps [`handle_stats`] focused on the cache orchestration and makes
 /// the aggregation logic trivially unit-testable without touching the
 /// cache layer.
-fn aggregate_stats(filtered: &[&Issue], graph: &DependencyGraph) -> StatsResult {
+///
+/// `configured_owner` / `configured_repo` are forwarded to
+/// [`DependencyGraph::compute_ready_set`] so SPEC §3.3 Filter 3
+/// (§14 Invariant 14(a)) scopes `ready_count` to the configured
+/// repository. Every caller already holds these from
+/// [`crate::server::ServerState::github`].
+fn aggregate_stats(
+    filtered: &[&Issue],
+    graph: &DependencyGraph,
+    configured_owner: &str,
+    configured_repo: &str,
+) -> StatsResult {
     let mut by_status = seed_status_buckets();
     let mut by_priority = seed_priority_buckets();
     let mut blocked_count: usize = 0;
@@ -294,7 +305,9 @@ fn aggregate_stats(filtered: &[&Issue], graph: &DependencyGraph) -> StatsResult 
     // owned clones. This allocation is bounded by `total` and only runs
     // on the cache-warm read path (once per stats call).
     let filtered_owned: Vec<Issue> = filtered.iter().copied().cloned().collect();
-    let ready_count = graph.compute_ready_set(&filtered_owned).len();
+    let ready_count = graph
+        .compute_ready_set(&filtered_owned, configured_owner, configured_repo)
+        .len();
 
     // Cycle count is always full-graph (R5). Milestone does not scope
     // cycle detection — the spec does not define a milestone-aware
@@ -390,10 +403,22 @@ pub async fn handle_stats(
         // follow-up call is warm, then aggregate against the freshly
         // fetched vectors without re-reading the cache.
         let graph_built = DependencyGraph::build(&issues_vec, &edges_vec);
-        let ready_set = graph_built.compute_ready_set(&issues_vec);
+        // SPEC §3.3 Filter 3 / §14 Invariant 14(a): pass configured coords
+        // so the cached ready set is local-only and `ready_count` in the
+        // stats envelope matches what `ready(milestone=…)` would return.
+        let ready_set = graph_built.compute_ready_set(
+            &issues_vec,
+            state.github.owner(),
+            state.github.repo(),
+        );
         let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
         let filtered = filter_by_milestone(&issues_vec, milestone);
-        let result = aggregate_stats(&filtered, &graph_built);
+        let result = aggregate_stats(
+            &filtered,
+            &graph_built,
+            state.github.owner(),
+            state.github.repo(),
+        );
         state.cache.update(issues_vec, ready_set, graph_built).await;
         return Ok(result);
     };
@@ -403,8 +428,15 @@ pub async fn handle_stats(
     let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
     let filtered = filter_by_milestone(issues.as_ref(), milestone);
 
-    // Step 4: aggregate.
-    Ok(aggregate_stats(&filtered, graph.as_ref()))
+    // Step 4: aggregate. SPEC §3.3 Filter 3 / §14 Invariant 14(a) —
+    // `aggregate_stats` threads configured coords into the embedded
+    // `compute_ready_set` call.
+    Ok(aggregate_stats(
+        &filtered,
+        graph.as_ref(),
+        state.github.owner(),
+        state.github.repo(),
+    ))
 }
 
 /// Filter an issue slice by exact-match milestone title.

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -586,7 +586,7 @@ async fn depends_aliased_configured_repo_source_cycle_detection() {
         target: QualifiedId::new("acme", "widgets", 3),
     }];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "acme", "widgets");
 
     let state = state_with_mock(Arc::clone(&mock));
     let cache = Arc::clone(&state.cache);
@@ -704,7 +704,7 @@ async fn depends_aliased_configured_repo_target_cycle_detection() {
         target: QualifiedId::new("acme", "widgets", 3),
     }];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "acme", "widgets");
 
     let state = state_with_mock(Arc::clone(&mock));
     let cache = Arc::clone(&state.cache);

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -957,8 +957,7 @@ async fn ready_cross_repo_open_blocker_populates_cross_repo_refs() {
     // `ReadyIssueSummary` drops `qualified_id`; check the fixture-derived
     // url to pin the entry to the configured (acme, widgets) repo.
     assert!(
-        result.issues[0].url.contains("acme/widgets")
-            || result.issues[0].url.is_empty(),
+        result.issues[0].url.contains("acme/widgets") || result.issues[0].url.is_empty(),
         "Ready entry must live in the configured (acme, widgets) repo; got url={}",
         result.issues[0].url,
     );
@@ -1059,10 +1058,8 @@ async fn ready_mixed_repo_sources_excluded_per_invariant_14a() {
     // (configured-repo uses 1–3, cross-repo uses 50–52), so any leak of a
     // cross-repo source into the envelope is detectable as a forbidden
     // number OR via the url prefix. We check both.
-    let numbers: std::collections::HashSet<u64> =
-        result.issues.iter().map(|i| i.number).collect();
-    let forbidden: std::collections::HashSet<u64> =
-        std::collections::HashSet::from([50, 51, 52]);
+    let numbers: std::collections::HashSet<u64> = result.issues.iter().map(|i| i.number).collect();
+    let forbidden: std::collections::HashSet<u64> = std::collections::HashSet::from([50, 51, 52]);
     assert!(
         numbers.is_disjoint(&forbidden),
         "SPEC §14 Invariant 14(a): cross-repo source numbers {:?} leaked \

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -923,21 +923,44 @@ async fn ready_cross_repo_open_blocker_populates_cross_repo_refs() {
         .await
         .expect("handle_ready should succeed on cold cache");
 
-    // Load-bearing assertion: local issue #1 was silently held out of the
-    // ready set by its cross-repo blocker (SPEC §7.1 flow step 9 /
-    // §3.3 step 6). This is the condition that triggers the §11.4 refs.
-    let local_numbers: std::collections::HashSet<u64> =
-        result.issues.iter().map(|i| i.number).collect();
-    assert!(
-        !local_numbers.contains(&1),
-        "SPEC §3.3 step 6: #1 MUST be filtered out by its cross-repo OPEN blocker; got: {:?}",
+    // Load-bearing assertion: only #2 survives.
+    //
+    // - #1 is a local source held out of the ready set by its open
+    //   cross-repo blocker other/repo#99 (SPEC §3.3 Filter 4).
+    // - other/repo#99 is a cross-repo source, so it is dropped by
+    //   SPEC §3.3 Filter 3 (§14 Invariant 14(a), unblock-eos.4 / D6.a /
+    //   GAP-14.b) BEFORE the blocker traversal — it can never reach the
+    //   ready set.
+    // - #2 has no blocker and lives in the configured repo, so it is the
+    //   only surviving entry.
+    //
+    // Pre-eos.4 the graph engine admitted other/repo#99 into the ready
+    // set; tool-layer post-filters may have dropped it but that was never
+    // the invariant. Post-eos.4, a strict count check pins the new
+    // invariant at the edge of the tool handler.
+    assert_eq!(
+        result.count, 1,
+        "SPEC §14 Invariant 14(a): only #2 (configured-repo, unblocked) must appear; got: {:?}",
         result.issues,
     );
-    // #2 has no blocker so it IS in the ready set.
-    assert!(
-        local_numbers.contains(&2),
-        "#2 has no blocker and must remain in the ready set; got: {:?}",
+    assert_eq!(
+        result.issues.len(),
+        1,
+        "result.issues must match result.count; got: {:?}",
         result.issues,
+    );
+    assert_eq!(
+        result.issues[0].number, 2,
+        "Ready entry must be local #2 (cross-repo #99 scrubbed by Filter 3, local #1 blocked); got: {:?}",
+        result.issues,
+    );
+    // `ReadyIssueSummary` drops `qualified_id`; check the fixture-derived
+    // url to pin the entry to the configured (acme, widgets) repo.
+    assert!(
+        result.issues[0].url.contains("acme/widgets")
+            || result.issues[0].url.is_empty(),
+        "Ready entry must live in the configured (acme, widgets) repo; got url={}",
+        result.issues[0].url,
     );
     assert!(!result.stale);
 
@@ -974,6 +997,113 @@ async fn ready_cross_repo_open_blocker_populates_cross_repo_refs() {
             .is_some_and(|s| s.contains("cross-repo")),
         "JSON envelope carries the summary: {json}",
     );
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+/// SPEC §14 Invariant 14(a) / Plan Task 04.05 addendum / unblock-eos.5 AC #6:
+/// when `fetch_graph_data` returns a mix of configured-repo and cross-repo
+/// OPEN issues (with NO blocking edges between them), `ReadyResult.issues`
+/// MUST contain ONLY configured-repo source issues. The graph engine's
+/// Filter 3 is the single chokepoint that enforces this — the `ready` tool
+/// handler does NOT re-check.
+///
+/// Fixture:
+/// - Configured repo (acme/widgets): three OPEN unblocked issues (#1, #2, #3).
+/// - Cross-repo (other/repo): three OPEN issues (#50, #51, #52) with no edges.
+///
+/// Expected behaviour:
+/// - `result.count == 3` (only the configured-repo issues survive).
+/// - No entry in `result.issues` has `qualified_id.(owner, repo) != (acme, widgets)`.
+/// - `result.cross_repo_refs` is `None` — no cross-repo BLOCKER participated
+///   in filtering (the cross-repo nodes are sources, scrubbed by Filter 3;
+///   per SPEC §11.4 the `ready` row surfaces cross-repo BLOCKERS only).
+#[tokio::test]
+async fn ready_mixed_repo_sources_excluded_per_invariant_14a() {
+    use unblock_mcp::tools::ready::{ReadyParams, handle_ready};
+
+    let issues = vec![
+        // Configured-repo OPEN issues — all unblocked.
+        ready_fixture_issue(1),
+        ready_fixture_issue(2),
+        ready_fixture_issue(3),
+        // Cross-repo OPEN issues — not blockers of anything local.
+        ready_cross_repo_fixture("other", "repo", 50),
+        ready_cross_repo_fixture("other", "repo", 51),
+        ready_cross_repo_fixture("other", "repo", 52),
+    ];
+    // Intentionally NO edges: no cross-repo blocker participates in
+    // filtering, so `cross_repo_refs` must be None.
+    let edges: Vec<BlockingEdge> = vec![];
+
+    let mock = new_mock();
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    let state = state_with_mock(Arc::clone(&mock));
+
+    let params = ReadyParams {
+        limit: None,
+        issue_type: None,
+        priority: None,
+        milestone: None,
+        agent: None,
+        label: None,
+        include_claimed: None,
+    };
+    let result = handle_ready(&state, params)
+        .await
+        .expect("handle_ready should succeed on cold cache");
+
+    // AC #6 core: no cross-repo source leaks into `issues`.
+    //
+    // The MCP projection `ReadyIssueSummary` collapses `QualifiedId` into
+    // `number` + `url`; the two fixture families use disjoint number ranges
+    // (configured-repo uses 1–3, cross-repo uses 50–52), so any leak of a
+    // cross-repo source into the envelope is detectable as a forbidden
+    // number OR via the url prefix. We check both.
+    let numbers: std::collections::HashSet<u64> =
+        result.issues.iter().map(|i| i.number).collect();
+    let forbidden: std::collections::HashSet<u64> =
+        std::collections::HashSet::from([50, 51, 52]);
+    assert!(
+        numbers.is_disjoint(&forbidden),
+        "SPEC §14 Invariant 14(a): cross-repo source numbers {:?} leaked \
+         into ReadyResult.issues; got numbers: {:?}",
+        forbidden.intersection(&numbers).collect::<Vec<_>>(),
+        numbers,
+    );
+    for summary in &result.issues {
+        assert!(
+            summary.url.contains("acme/widgets") || summary.url.is_empty(),
+            "SPEC §14 Invariant 14(a): issue url must point at the \
+             configured (acme, widgets) repo; got url={} number={}",
+            summary.url,
+            summary.number,
+        );
+    }
+
+    // `count` must equal the configured-repo subset (three entries), not
+    // the full 6-issue input.
+    assert_eq!(
+        result.count, 3,
+        "Filter 3 must drop every other/repo#N issue; got: {:?}",
+        result.issues,
+    );
+    assert_eq!(result.issues.len(), 3);
+
+    assert_eq!(
+        numbers,
+        std::collections::HashSet::from([1, 2, 3]),
+        "Only configured-repo issues #1, #2, #3 may appear",
+    );
+
+    // No cross-repo blocker participated in filtering, so §11.4 contract
+    // requires `cross_repo_refs` to be `None`.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "SPEC §11.4: cross_repo_refs must be None when no cross-repo blocker \
+         held a local issue out of the ready set; got: {:?}",
+        result.cross_repo_refs,
+    );
+    assert!(!result.stale);
     assert_eq!(mock.calls().fetch_graph_data(), 1);
 }
 

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -234,7 +234,7 @@ async fn show_include_deps_false_skips_graph_traversal() {
         target: QualifiedId::new("acme", "widgets", 1),
     }];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "acme", "widgets");
     state.cache.update(issues, ready_set, graph).await;
     assert!(
         state.cache.get_graph().await.is_some(),
@@ -376,7 +376,7 @@ async fn show_dependency_tree_for_blocking_relationships() {
         },
     ];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
     cache.update(issues, ready_set, graph).await;
 
     // With include_deps=true and a populated cache, the DependencyTree should have data.
@@ -476,7 +476,7 @@ async fn ready_returns_only_open_unblocked_non_deferred_issues() {
         target: qid(1),
     }];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
     cache.update(issues, ready_set.clone(), graph).await;
 
     // Filter using ready tool logic.
@@ -508,7 +508,7 @@ async fn ready_second_call_returns_from_cache() {
     ];
     let edges = vec![];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
     cache.update(issues, ready_set, graph).await;
 
     // First call.
@@ -543,7 +543,7 @@ async fn ready_filter_by_priority() {
 
     let issues = vec![issue_1, issue_2, issue_3];
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
     cache.update(issues, ready_set.clone(), graph).await;
 
     let params = unblock_mcp::tools::ready::ReadyParams {
@@ -577,7 +577,7 @@ async fn ready_filter_by_label() {
 
     let issues = vec![issue_1, issue_2, issue_3];
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
     cache.update(issues, ready_set.clone(), graph).await;
 
     let params = unblock_mcp::tools::ready::ReadyParams {
@@ -603,7 +603,7 @@ async fn ready_deferred_excluded() {
 
     let issues = vec![issue_1];
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
 
     let params = unblock_mcp::tools::ready::ReadyParams {
         limit: None,
@@ -630,7 +630,7 @@ async fn ready_include_claimed_includes_in_progress() {
 
     let issues = vec![issue_1, issue_2];
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
 
     // compute_ready_set now excludes InProgress per spec §3.3.
     assert_eq!(
@@ -694,7 +694,7 @@ async fn ready_sort_order() {
 
     let issues = vec![issue_a, issue_b, issue_c];
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
 
     let params = unblock_mcp::tools::ready::ReadyParams {
         limit: None,
@@ -720,7 +720,7 @@ async fn ready_sort_order() {
 async fn ready_limit_respected() {
     let issues: Vec<_> = (1..=20).map(|n| test_issue(n, IssueState::Open)).collect();
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "test", "repo");
 
     let params = unblock_mcp::tools::ready::ReadyParams {
         limit: Some(3),
@@ -1365,7 +1365,7 @@ async fn search_hits_github_and_maps_to_summary_without_touching_cache() {
     // any stray read/write by the search handler.
     let cache_issues = vec![test_issue(999, IssueState::Open)];
     let graph = DependencyGraph::build(&cache_issues, &[]);
-    let ready_set = graph.compute_ready_set(&cache_issues);
+    let ready_set = graph.compute_ready_set(&cache_issues, "test", "repo");
     state
         .cache
         .update(cache_issues, ready_set.clone(), graph)
@@ -2269,7 +2269,7 @@ async fn dep_remove_local_edge_transitions_source_to_ready() {
     }];
     let pre_issues = vec![pre_source, pre_target];
     let pre_graph = DependencyGraph::build(&pre_issues, &pre_edges);
-    let pre_ready_set = pre_graph.compute_ready_set(&pre_issues);
+    let pre_ready_set = pre_graph.compute_ready_set(&pre_issues, "acme", "widgets");
     state
         .cache
         .update(pre_issues, pre_ready_set, pre_graph)
@@ -2401,7 +2401,7 @@ async fn dep_remove_warm_cache_missing_edge_rejects_without_mutation() {
     // Warm cache with #42 and #99 but NO edge between them.
     let issues = vec![dep_remove_fixture_issue(42), dep_remove_fixture_issue(99)];
     let graph = DependencyGraph::build(&issues, &[]);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "acme", "widgets");
     state.cache.update(issues, ready_set, graph).await;
 
     let err = handle_dep_remove(
@@ -2457,7 +2457,7 @@ async fn dep_remove_surfaces_error_when_post_mutation_rebuild_fails() {
         target: QualifiedId::new("acme", "widgets", 99),
     }];
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    let ready_set = graph.compute_ready_set(&issues, "acme", "widgets");
     state.cache.update(issues, ready_set, graph).await;
 
     let err = handle_dep_remove(
@@ -3456,7 +3456,7 @@ async fn reconcile_with_injected_drift_and_fix() {
     }];
     let graph = DependencyGraph::build(&issues_vec, &edges);
     let computed_ready: HashSet<QualifiedId> = graph
-        .compute_ready_set(&issues_vec)
+        .compute_ready_set(&issues_vec, "acme", "test")
         .into_iter()
         .map(|s| s.qualified_id)
         .collect();
@@ -3484,7 +3484,7 @@ async fn reconcile_with_injected_drift_and_fix() {
     };
     let repaired_graph = DependencyGraph::build(&corrected_issues, &edges);
     let repaired_ready: HashSet<QualifiedId> = repaired_graph
-        .compute_ready_set(&corrected_issues)
+        .compute_ready_set(&corrected_issues, "acme", "test")
         .into_iter()
         .map(|s| s.qualified_id)
         .collect();


### PR DESCRIPTION
Implements unblock-eos.4 Direction 1 (D6.a / GAP-14.b): the graph engine
now enforces ready-set source scoping at the single chokepoint.
`DependencyGraph::compute_ready_set` takes the configured
`(owner, repo)` coordinates and applies SPEC §3.3 Filter 3 — which drops
cross-repo source issues BEFORE the blocker traversal (Filter 4) —
regardless of blocker state. Every downstream consumer (cached
`ready_set`, `ready` tool, `prime`, `update_status_fields`) inherits
§14 Invariant 14(a) without re-checking.

Changes:
- graph.rs: new signature `compute_ready_set(&issues, owner, repo)`,
  new Filter 3 between preserved-Status check and blocker traversal,
  doc comment rewritten to cover Filter 3 semantics + edge cases, and
  module-level rustdoc updated.
- graph.rs tests: 13 single-repo tests pass TEST_OWNER/TEST_REPO. The
  `cross_repo_ready_set_with_mixed_repos` regression-target test is
  PRESERVED (not deleted) and its assertion FLIPPED — configured with
  `("acme", "widgets")`, both source issues are now dropped (cross-repo
  source by Filter 3, local source by Filter 4 on an open cross-repo
  blocker).
- graph.rs proptests: `ready_set_never_contains_issue_with_open_blocker`
  passes TEST_OWNER/TEST_REPO. `cross_repo_same_numbers_distinct_in_graph`
  scopes its ready-set call to repo_a and gains per-iteration assertions
  that no `org-b/repo-b` issue leaks (implicit coverage of §13.3 https://github.com/websublime/unblock/pull/7
  pending the dedicated property test in a later commit).
- cache.rs: promotes `"test"/"repo"` to `TEST_OWNER`/`TEST_REPO` consts
  and threads them into `test_graph()`.
- reconcile.rs: `ready_set` helper gains `(owner, repo)` parameters so
  unit tests can pass `"acme"/"widgets"` and the proptest can pass
  `"acme"/"test"`.
- cache_bench.rs: bench fixture threads `"bench"/"repo"` into the call.

BREAKING CHANGE: DependencyGraph::compute_ready_set now requires
(configured_owner, configured_repo) parameters. Callers must pass the
configured repository coordinates so the graph engine can enforce
SPEC §14 Invariant 14(a). Cross-repo source issues are now filtered
out of the ready set at the engine level (previously: tool-layer
responsibility that was not honoured). See unblock-eos.4 / SPEC §3.3.