### PR TITLE
feat(mcp): adopt §11.4 cross_repo_refs in CloseResult

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1053,6 +1053,7 @@ impl UnblockServer {
 
         // Phase 2: Compute cascade from the freshly rebuilt cache.
         let mut unblocked = Vec::new();
+        let mut cross_repo_refs: Option<unblock_core::types::CrossRepoRefs> = None;
 
         if let Some(graph) = state.cache.get_graph().await {
             // compute_unblock_cascade's _all_issues param is currently unused —
@@ -1125,7 +1126,20 @@ impl UnblockServer {
                 }
             }
 
-            unblocked = cascade.iter().map(|q| q.number).collect();
+            // SPEC §8.2 flow step 9 / §11.4 row 4: partition the cascade
+            // into local dependents (projected to `unblocked: Vec<u64>`)
+            // vs cross-repo dependents (surfaced via `cross_repo_refs`).
+            // The Phase 3 loop above intentionally does NOT gate on
+            // (owner, repo) == (config.owner, config.repo) — cross-repo
+            // dependents ARE still cascade-updated; only the response
+            // shape differs here (SPEC §11.4 affected-tools table).
+            let (local_unblocked, cross_repo_accum) =
+                crate::tools::cross_repo::project_cascade(&cascade, client.owner(), client.repo());
+            unblocked = local_unblocked;
+            cross_repo_refs = crate::tools::cross_repo::build_cross_repo_refs_with_summary(
+                cross_repo_accum,
+                crate::tools::cross_repo::close_summary,
+            );
         } else {
             tracing::warn!("Cache not available after rebuild — cascade computation skipped");
         }
@@ -1133,6 +1147,7 @@ impl UnblockServer {
         Ok(Json(CloseResult {
             issue: issue_number,
             unblocked,
+            cross_repo_refs,
         }))
     }
 

--- a/crates/unblock-mcp/src/tools/close.rs
+++ b/crates/unblock-mcp/src/tools/close.rs
@@ -4,9 +4,19 @@
 //! fields (Status=Done), rebuilds the cache, then computes the unblock cascade.
 //! For each newly unblocked issue, updates its Projects V2 fields
 //! (Status=Backlog if not already `InProgress`) and posts an unblock comment.
+//!
+//! Cross-repo dependents (SPEC §11.4): when the cascade returned by
+//! [`compute_unblock_cascade`][`unblock_core::graph::DependencyGraph::compute_unblock_cascade`]
+//! touches a `QualifiedId` whose `(owner, repo)` differs from the configured
+//! repo, the dependent is STILL cascade-updated (same Status / comment path) —
+//! only the response shape differs. The bare-`u64` [`CloseResult::unblocked`]
+//! vector is scoped to the configured repo; cross-repo dependents are surfaced
+//! in [`CloseResult::cross_repo_refs`] (`Some` iff at least one cross-repo
+//! dependent participated in the cascade, per SPEC §14 Invariant 14(b)).
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use unblock_core::types::CrossRepoRefs;
 
 /// Input parameters for the `close` MCP tool.
 ///
@@ -25,13 +35,36 @@ pub struct CloseParams {
 ///
 /// Contains the closed issue number and the list of issue numbers that were
 /// fully unblocked by this close (the cascade).
+///
+/// Cross-repo cascade members (per SPEC §11.4) are surfaced separately in
+/// [`Self::cross_repo_refs`] rather than being flattened into
+/// [`Self::unblocked`] — bare `u64` cannot disambiguate across repositories.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct CloseResult {
     /// The closed issue number.
     pub issue: u64,
     /// Issue numbers that were fully unblocked by closing this issue.
+    ///
+    /// Scoped to the configured repo: only dependents whose
+    /// `(owner, repo) == (config.owner, config.repo)` appear here. Cross-repo
+    /// dependents that were cascade-updated are surfaced in
+    /// [`Self::cross_repo_refs`] per SPEC §11.4.
+    ///
     /// Only includes issues where ALL blockers are now closed.
     pub unblocked: Vec<u64>,
+    /// Cross-repo dependents that were cascade-updated but dropped from
+    /// the bare-`u64` projection of [`Self::unblocked`], per SPEC §11.4.
+    ///
+    /// `Some` iff at least one cascade member lived in a different
+    /// repository (i.e. its `(owner, repo)` differed from the configured
+    /// repo). `None` otherwise. Elided from the JSON envelope when
+    /// `None` via `#[serde(skip_serializing_if = "Option::is_none")]`.
+    ///
+    /// See SPEC §2.16 (shared type), §11.4 (cross-cutting contract), and
+    /// §14 Invariant 14(b) (response-shape determinism — `omitted` is
+    /// lexicographically sorted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross_repo_refs: Option<CrossRepoRefs>,
 }
 
 // TODO(unblock-45a.12): Add integration tests for close tool (cascade, co-blocking,

--- a/crates/unblock-mcp/src/tools/cross_repo.rs
+++ b/crates/unblock-mcp/src/tools/cross_repo.rs
@@ -1,14 +1,15 @@
 //! Shared primitives for SPEC §11.4 "Cross-Repo Response Contract"
 //! projection.
 //!
-//! Prior to this module, `ready.rs`, `dep_cycles.rs`, and (now) `prime.rs`
-//! each held local copies of the projection logic:
+//! Prior to this module, `ready.rs`, `dep_cycles.rs`, `prime.rs`, and
+//! (now) the `close` handler each held local copies of the projection
+//! logic:
 //!
 //! 1. Walk the source collection (cycles for `dep_cycles` / `prime`; open
-//!    issues with blockers for `ready`) and partition references into
-//!    **local** (keep the bare `u64` number in the response) vs
-//!    **cross-repo** (collect the `owner/repo#number` display string for
-//!    the §11.4 trailer).
+//!    issues with blockers for `ready`; the unblock cascade for `close`)
+//!    and partition references into **local** (keep the bare `u64`
+//!    number in the response) vs **cross-repo** (collect the
+//!    `owner/repo#number` display string for the §11.4 trailer).
 //! 2. Collect cross-repo references into a [`BTreeSet<String>`] keyed by
 //!    [`QualifiedId::Display`](unblock_core::types::QualifiedId) — the
 //!    `BTreeSet` gives us SPEC §14 Invariant 14 (a) determinism (dedup + lex
@@ -20,10 +21,10 @@
 //!
 //! The canonical primitives live here. Callers bring their own
 //! sum­mary-grammar closure so the tool-specific phrasing in SPEC §11.4 is
-//! preserved byte-for-byte — parity across all three tools is a user
+//! preserved byte-for-byte — parity across all four tools is a user
 //! non-negotiable and the summary strings are part of the public response
-//! envelope. See [`cycles_summary`] and [`ready_summary`] for the exact
-//! phrasing.
+//! envelope. See [`cycles_summary`], [`ready_summary`], and
+//! [`close_summary`] for the exact phrasing.
 //!
 //! # Non-goals
 //!
@@ -50,7 +51,7 @@
 //! - SPEC §14 Invariant 14 — response determinism.
 //! - ARCH §5.5 — cross-repo node keying via `QualifiedId`.
 //! - Beads `unblock-eos.2` (this extraction), `unblock-eos.7` (prime
-//!   adoption).
+//!   adoption), `unblock-iov` (close adoption).
 
 use std::collections::BTreeSet;
 
@@ -118,6 +119,43 @@ pub(crate) fn project_all_cycles(
         cycles.push(local);
     }
     (cycles, cross_repo_accum)
+}
+
+/// Project the unblock cascade (`Vec<QualifiedId>`) onto its local and
+/// cross-repo partitions.
+///
+/// Used by the `close` MCP tool per SPEC §8.2 flow step 9: local
+/// dependents are projected to bare `u64` numbers for
+/// `CloseResult.unblocked`; cross-repo dependents populate the
+/// [`CrossRepoRefs`] envelope per SPEC §11.4 (row 4 of the affected-tools
+/// table).
+///
+/// The local projection preserves the iteration order of `cascade`
+/// (petgraph Incoming-neighbour order, the same order the caller already
+/// iterated in Phase 3 of the close handler). The cross-repo set is a
+/// [`BTreeSet<String>`] keyed by
+/// [`QualifiedId::Display`](QualifiedId#impl-Display-for-QualifiedId)
+/// (`"owner/repo#number"`) so de-duplication is free and the final
+/// `Vec<String>` emerges lexicographically sorted — SPEC §14 Invariant
+/// 14 (b) determinism contract holds without an explicit `sort()` call.
+///
+/// Returns the local projection (may be empty if every cascade member
+/// was cross-repo) plus the cross-repo accumulator.
+pub(crate) fn project_cascade(
+    cascade: &[QualifiedId],
+    configured_owner: &str,
+    configured_repo: &str,
+) -> (Vec<u64>, BTreeSet<String>) {
+    let mut local: Vec<u64> = Vec::with_capacity(cascade.len());
+    let mut cross_repo_accum: BTreeSet<String> = BTreeSet::new();
+    for qid in cascade {
+        if qid.owner == configured_owner && qid.repo == configured_repo {
+            local.push(qid.number);
+        } else {
+            cross_repo_accum.insert(qid.to_string());
+        }
+    }
+    (local, cross_repo_accum)
 }
 
 /// Build the optional [`CrossRepoRefs`] envelope from the accumulated
@@ -197,6 +235,28 @@ pub(crate) fn ready_summary(n: usize) -> String {
     format!(
         "{n} cross-repo {noun} excluded local issue(s) from ready set",
         noun = if n == 1 { "blocker" } else { "blockers" },
+    )
+}
+
+/// Format the **close-cascade** italic summary per SPEC §11.4 (row 4
+/// of the affected-tools table at §11.4, phrasing per §8.2 line 1262).
+///
+/// Exact string (byte-for-byte — do not paraphrase):
+///
+/// - `n == 1` → ``"1 cross-repo dependent cascade-updated but omitted from `unblocked`"``
+/// - `n >= 2` → ``"{n} cross-repo dependents cascade-updated but omitted from `unblocked`"``
+///
+/// Used by `close` (JSON `cross_repo_refs.summary` field). The grammar
+/// mirrors [`cycles_summary`] / [`ready_summary`]: singular/plural noun
+/// (`dependent` / `dependents`) keyed off the count. Cross-repo
+/// dependents ARE still cascade-updated in Phase 3 of the close handler
+/// — the summary reports what the response projection omitted, not what
+/// the mutation skipped.
+#[must_use]
+pub(crate) fn close_summary(n: usize) -> String {
+    format!(
+        "{n} cross-repo {noun} cascade-updated but omitted from `unblocked`",
+        noun = if n == 1 { "dependent" } else { "dependents" },
     )
 }
 
@@ -365,6 +425,76 @@ mod tests {
         assert_eq!(
             ready_summary(7),
             "7 cross-repo blockers excluded local issue(s) from ready set"
+        );
+    }
+
+    // ── project_cascade ────────────────────────────────────────────────
+
+    #[test]
+    fn project_cascade_all_local_returns_local_numbers_no_cross_repo() {
+        let cascade = vec![qid("acme", "widgets", 10), qid("acme", "widgets", 11)];
+        let (local, accum) = project_cascade(&cascade, "acme", "widgets");
+        assert_eq!(local, vec![10, 11]);
+        assert!(accum.is_empty());
+    }
+
+    #[test]
+    fn project_cascade_all_cross_repo_returns_empty_local_populates_accum() {
+        let cascade = vec![qid("other", "repo", 99), qid("third", "repo", 1)];
+        let (local, accum) = project_cascade(&cascade, "acme", "widgets");
+        assert!(local.is_empty());
+        // BTreeSet gives lex order for free.
+        let collected: Vec<String> = accum.into_iter().collect();
+        assert_eq!(collected, vec!["other/repo#99", "third/repo#1"]);
+    }
+
+    #[test]
+    fn project_cascade_mixed_splits_local_from_cross_repo() {
+        let cascade = vec![
+            qid("acme", "widgets", 10),
+            qid("other", "repo", 99),
+            qid("acme", "widgets", 11),
+            qid("alpha", "upstream", 42),
+        ];
+        let (local, accum) = project_cascade(&cascade, "acme", "widgets");
+        // Cascade iteration order is preserved for locals.
+        assert_eq!(local, vec![10, 11]);
+        // BTreeSet iteration = lex order.
+        let collected: Vec<String> = accum.into_iter().collect();
+        assert_eq!(collected, vec!["alpha/upstream#42", "other/repo#99"]);
+    }
+
+    #[test]
+    fn project_cascade_dedups_repeated_cross_repo_nodes_via_btreeset() {
+        let cascade = vec![
+            qid("other", "repo", 99),
+            qid("other", "repo", 99),
+            qid("other", "repo", 99),
+        ];
+        let (_local, accum) = project_cascade(&cascade, "acme", "widgets");
+        assert_eq!(accum.len(), 1);
+        assert!(accum.contains("other/repo#99"));
+    }
+
+    // ── close_summary — SPEC §11.4 / §8.2 phrasing parity ──────────────
+
+    #[test]
+    fn close_summary_singular_matches_spec() {
+        assert_eq!(
+            close_summary(1),
+            "1 cross-repo dependent cascade-updated but omitted from `unblocked`"
+        );
+    }
+
+    #[test]
+    fn close_summary_plural_matches_spec() {
+        assert_eq!(
+            close_summary(2),
+            "2 cross-repo dependents cascade-updated but omitted from `unblocked`"
+        );
+        assert_eq!(
+            close_summary(5),
+            "5 cross-repo dependents cascade-updated but omitted from `unblocked`"
         );
     }
 }

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -390,6 +390,17 @@ async fn close_dispatches_through_dyn_vtable() {
 
     assert_eq!(result.issue, 8);
     assert!(result.unblocked.is_empty());
+    // SPEC §11.4 / §14 Invariant 14(b): all-local fixture → None, elided from JSON.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "all-local fixture must not populate cross_repo_refs; got: {:?}",
+        result.cross_repo_refs,
+    );
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert!(
+        json.get("cross_repo_refs").is_none(),
+        "None cross_repo_refs must be elided from JSON: {json}"
+    );
     assert_eq!(mock.calls().fetch_issue(), 1);
     assert_eq!(mock.calls().close_issue(), 1);
     assert_eq!(mock.calls().fetch_graph_data(), 1);
@@ -424,6 +435,17 @@ async fn close_with_empty_reason_skips_comment() {
         mock.calls().add_comment(),
         0,
         "empty/whitespace reason must not post a comment"
+    );
+    // SPEC §11.4 / §14 Invariant 14(b): all-local fixture → None, elided from JSON.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "all-local fixture must not populate cross_repo_refs; got: {:?}",
+        result.cross_repo_refs,
+    );
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert!(
+        json.get("cross_repo_refs").is_none(),
+        "None cross_repo_refs must be elided from JSON: {json}"
     );
 }
 

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -4181,3 +4181,338 @@ async fn prime_markdown_omits_cross_repo_section_when_all_cycles_are_local() {
         "no singular/plural summary must leak when trailer is absent: {md}"
     );
 }
+
+// ── close tool: §11.4 cross-repo response contract integration tests ──
+//
+// Hermetic `MockGitHubClient` tests for SPEC §8.2 + §11.4 row 4 +
+// §14 Invariant 14(b). Mirror `dep_cycles_returns_all_local_cycles_from_warm_cache`
+// (None branch) and `dep_cycles_mixed_cycle_populates_cross_repo_refs`
+// (Some branch). See bead `unblock-iov`.
+
+/// Build a fixture issue under the `MockGitHubClient` coordinates
+/// (`acme/widgets`) for `close` cascade tests. Every optional field is
+/// set to a minimal value — the `close` handler only consumes the graph
+/// topology (via `compute_unblock_cascade`) plus the closed issue's
+/// `node_id`.
+fn close_fixture_issue(number: u64) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new("acme", "widgets", number),
+        number,
+        node_id: format!("I_close_{number}"),
+        title: format!("Close fixture #{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Ready,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/acme/widgets/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Build a cross-repo fixture issue for `close` mixed-cascade tests.
+/// The resulting `QualifiedId` points OUTSIDE the configured
+/// `acme/widgets` repo so the §11.4 partition can strip it from
+/// `unblocked` and surface it in `cross_repo_refs.omitted`.
+fn close_cross_repo_fixture(owner: &str, repo: &str, number: u64) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new(owner, repo, number),
+        number,
+        node_id: format!("I_close_{owner}_{repo}_{number}"),
+        title: format!("Close cross-repo fixture {owner}/{repo}#{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Ready,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/{owner}/{repo}/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Acceptance (a): all local cascade — `cross_repo_refs == None`,
+/// bare `unblocked` carries both local dependents, JSON elides the key.
+///
+/// Fixture: local blocker #8 has local dependents #10 and #11
+/// (edges: #10 → #8, #11 → #8 — "#10 is blocked by #8", "#11 is
+/// blocked by #8"). Closing #8 cascades both.
+///
+/// Per SPEC §11.4 / §14 Invariant 14(b): all-local cascade → field
+/// is `None` and the JSON envelope omits `cross_repo_refs` entirely.
+#[tokio::test]
+async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
+    use rmcp::handler::server::wrapper::{Json, Parameters};
+    use unblock_mcp::server::UnblockServer;
+    use unblock_mcp::tools::close::CloseParams;
+
+    let issues = vec![
+        close_fixture_issue(8),
+        close_fixture_issue(10),
+        close_fixture_issue(11),
+    ];
+    // Edges: #10 → #8, #11 → #8. Closing #8 unblocks both.
+    let edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 11),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+    ];
+
+    let mock = new_mock();
+    // Phase 1: fetch #8, close #8, rebuild.
+    mock.push_fetch_issue(Ok(close_fixture_issue(8)));
+    mock.push_close_issue(Ok(()));
+    // Phase 1 field ladder: push None to skip Projects V2 updates.
+    mock.push_field_ids(None);
+    // Rebuild pushes the POST-close graph. We keep #8 in the fetch
+    // response so `compute_unblock_cascade` can resolve it as a node
+    // (the mock is a stub — in production fetch_graph_data would
+    // exclude the closed issue, but that path is orthogonal to this
+    // bead's scope).
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    // Phase 3 loop runs 2×. Each iteration calls add_comment then
+    // field_ids. We push add_comment Ok twice and let field_ids
+    // default to None (queue empty ⇒ None) so the inner project-field
+    // ladder is skipped.
+    mock.push_add_comment(Ok("comment_id".to_owned()));
+    mock.push_add_comment(Ok("comment_id".to_owned()));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await
+        .expect("close should succeed on all-local cascade");
+
+    assert_eq!(result.issue, 8);
+    // petgraph Incoming-neighbour iteration order is NOT contractually
+    // stable — assert on set membership, not positional order.
+    let unblocked_set: std::collections::HashSet<u64> = result.unblocked.iter().copied().collect();
+    assert_eq!(
+        unblocked_set,
+        std::collections::HashSet::from([10_u64, 11]),
+        "all-local cascade must emit both local dependents in `unblocked`; got: {:?}",
+        result.unblocked,
+    );
+    // Acceptance (a): all-local cascade produces cross_repo_refs == None.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "SPEC §11.4: all-local cascade → cross_repo_refs None; got: {:?}",
+        result.cross_repo_refs,
+    );
+    // The skip_serializing_if attribute must elide the key entirely.
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert!(
+        json.get("cross_repo_refs").is_none(),
+        "None cross_repo_refs must be elided from JSON: {json}"
+    );
+
+    // Both cascade members received an unblock comment.
+    assert_eq!(mock.calls().add_comment(), 2);
+    assert_eq!(mock.calls().close_issue(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+/// Acceptance (b): mixed cascade — one local dependent + two cross-repo
+/// dependents. The configured-repo projection `unblocked` carries only
+/// the local member; `cross_repo_refs` surfaces the cross-repo members
+/// in lexicographic order with the singular/plural summary phrasing
+/// mandated by SPEC §11.4 row 4 (`close_summary`).
+///
+/// Fixture: local blocker #8 has:
+/// - one local dependent #10,
+/// - one cross-repo dependent `other/repo#99`,
+/// - one cross-repo dependent `alpha/upstream#42`.
+///
+/// Edges: `#10 → #8`, `other/repo#99 → #8`, `alpha/upstream#42 → #8`.
+/// Closing #8 cascades all three. `unblocked` should contain `[10]`
+/// (local set), `cross_repo_refs.omitted` should be
+/// `["alpha/upstream#42", "other/repo#99"]` (lex-sorted per
+/// Invariant 14(b) determinism).
+#[tokio::test]
+async fn close_cross_repo_dependent_populates_cross_repo_refs() {
+    use rmcp::handler::server::wrapper::{Json, Parameters};
+    use unblock_mcp::server::UnblockServer;
+    use unblock_mcp::tools::close::CloseParams;
+
+    let issues = vec![
+        close_fixture_issue(8),
+        close_fixture_issue(10),
+        close_cross_repo_fixture("other", "repo", 99),
+        close_cross_repo_fixture("alpha", "upstream", 42),
+    ];
+    let edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("other", "repo", 99),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("alpha", "upstream", 42),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+    ];
+
+    let mock = new_mock();
+    mock.push_fetch_issue(Ok(close_fixture_issue(8)));
+    mock.push_close_issue(Ok(()));
+    mock.push_field_ids(None); // Phase 1: skip project-field ladder.
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    // Phase 3 loop runs 3× (#10, other/repo#99, alpha/upstream#42).
+    // Each iteration posts an add_comment; field_ids defaults to None
+    // when the queue is empty, so the inner project-field ladder is
+    // skipped — no further pushes required.
+    //
+    // RISK #2 (close handler is not cross-repo-aware for side effects):
+    // `client.add_comment(99)` actually targets `acme/widgets#99`
+    // in production. The mock just records the call count here, so
+    // this operational limitation is invisible to the test — matches
+    // the bead's scope note.
+    mock.push_add_comment(Ok("c1".to_owned()));
+    mock.push_add_comment(Ok("c2".to_owned()));
+    mock.push_add_comment(Ok("c3".to_owned()));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await
+        .expect("close should succeed on mixed cascade");
+
+    assert_eq!(result.issue, 8);
+    // Only the local dependent appears in `unblocked`.
+    assert_eq!(
+        result.unblocked,
+        vec![10_u64],
+        "SPEC §8.2 flow step 9: local partition only; got: {:?}",
+        result.unblocked,
+    );
+
+    // Acceptance (b): cross_repo_refs is Some with lex-sorted omitted.
+    let refs = result
+        .cross_repo_refs
+        .as_ref()
+        .expect("SPEC §11.4: mixed cascade → cross_repo_refs Some");
+    assert_eq!(
+        refs.omitted,
+        vec!["alpha/upstream#42".to_owned(), "other/repo#99".to_owned(),],
+        "Invariant 14(b): omitted MUST be sorted lexicographically",
+    );
+    // Exact summary phrasing (byte-for-byte per SPEC §11.4 row 4).
+    assert_eq!(
+        refs.summary.as_deref(),
+        Some("2 cross-repo dependents cascade-updated but omitted from `unblocked`"),
+        "SPEC §11.4 / §8.2 line 1262: plural phrasing must match byte-for-byte",
+    );
+
+    // JSON serialisation includes the cross_repo_refs envelope.
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert_eq!(
+        json["cross_repo_refs"]["omitted"][0], "alpha/upstream#42",
+        "JSON envelope surfaces the lex-sorted omitted list",
+    );
+    assert_eq!(json["cross_repo_refs"]["omitted"][1], "other/repo#99");
+    // unblocked carries only the local member.
+    assert_eq!(json["unblocked"].as_array().map(Vec::len), Some(1));
+
+    // All three cascade members received an unblock comment (SPEC §8.2
+    // flow step 6: cross-repo dependents ARE still cascade-updated).
+    assert_eq!(mock.calls().add_comment(), 3);
+    assert_eq!(mock.calls().close_issue(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+}
+
+/// Acceptance (c): singular-form summary — a single cross-repo
+/// dependent triggers the singular `"1 cross-repo dependent …"`
+/// phrasing per SPEC §11.4 row 4 (`close_summary` — mirrors the
+/// `cycles_summary` / `ready_summary` singular/plural noun grammar).
+#[tokio::test]
+async fn close_single_cross_repo_dependent_uses_singular_summary() {
+    use rmcp::handler::server::wrapper::{Json, Parameters};
+    use unblock_mcp::server::UnblockServer;
+    use unblock_mcp::tools::close::CloseParams;
+
+    let issues = vec![
+        close_fixture_issue(8),
+        close_cross_repo_fixture("other", "repo", 99),
+    ];
+    let edges = vec![BlockingEdge {
+        source: QualifiedId::new("other", "repo", 99),
+        target: QualifiedId::new("acme", "widgets", 8),
+    }];
+
+    let mock = new_mock();
+    mock.push_fetch_issue(Ok(close_fixture_issue(8)));
+    mock.push_close_issue(Ok(()));
+    mock.push_field_ids(None);
+    mock.push_fetch_graph_data(Ok((issues, edges)));
+    mock.push_add_comment(Ok("c1".to_owned()));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await
+        .expect("close should succeed on single-cross-repo cascade");
+
+    assert_eq!(result.issue, 8);
+    // No local dependents — `unblocked` is empty.
+    assert!(
+        result.unblocked.is_empty(),
+        "all-cross-repo cascade → empty unblocked; got: {:?}",
+        result.unblocked,
+    );
+
+    let refs = result
+        .cross_repo_refs
+        .as_ref()
+        .expect("single cross-repo cascade → cross_repo_refs Some");
+    assert_eq!(refs.omitted, vec!["other/repo#99".to_owned()]);
+    // Singular grammar per SPEC §11.4 row 4 / §8.2 line 1262.
+    assert_eq!(
+        refs.summary.as_deref(),
+        Some("1 cross-repo dependent cascade-updated but omitted from `unblocked`"),
+        "SPEC §11.4: singular phrasing must match byte-for-byte",
+    );
+}


### PR DESCRIPTION
Retro-fit the `close` tool response to honor SPEC §11.4 "Cross-Repo Response Contract" row 4. Cross-repo dependents produced by the pre-close cascade (§3.4) are now partitioned out of the bare-`u64` `unblocked` vector and surfaced via the shared `cross_repo_refs: Option<CrossRepoRefs>` envelope, lex-sorted per §14 Invariant 14(b).

Cross-repo dependents ARE still cascade-updated in Phase 3 of the handler (same comment + Status=ready path) — only the response shape differs per SPEC §11.4 row 4 / §8.2 flow step 9.

Changes:
- `unblock-mcp/src/tools/cross_repo.rs`: add `project_cascade` (Vec<QualifiedId> → (Vec<u64>, BTreeSet<String>)) and `close_summary` (singular/plural grammar per §8.2 line 1262, byte-for-byte).
- `unblock-mcp/src/tools/close.rs`: add `cross_repo_refs: Option<CrossRepoRefs>` to `CloseResult` with `#[serde(skip_serializing_if = "Option::is_none")]`; doc-comment the configured-repo scoping on `unblocked`.
- `unblock-mcp/src/server.rs` close handler: partition the cascade via `project_cascade` + `build_cross_repo_refs_with_summary` with `close_summary`. Phase 3 side-effects loop is intentionally unchanged (RISK #2 in the bead investigation).
- Tests: 6 new unit tests in `cross_repo.rs` (4× project_cascade, 2× close_summary); 3 new integration tests in `integration.rs` (None branch, mixed plural branch, single-cross-repo singular branch); updated 2 dyn_dispatch close tests to assert the new field elides when None.

Closes `unblock-iov`; satisfies DoD 11(b) for the close row.

API: CloseResult gains cross_repo_refs: Option<CrossRepoRefs>