### PR TITLE
feat(github): add cross-repo-aware add_comment primitives for close c…

### DIFF
--- a/crates/unblock-github/src/api.rs
+++ b/crates/unblock-github/src/api.rs
@@ -179,6 +179,33 @@ pub trait GitHubApi: Send + Sync {
     /// Adds a comment to an issue; returns the comment node id.
     async fn add_comment(&self, number: u64, body: String) -> Result<String, Error>;
 
+    /// Adds a comment to an issue in the specified `owner/repo`.
+    ///
+    /// Cross-repo counterpart of [`add_comment`](Self::add_comment). The
+    /// target repository is supplied by the caller instead of being read
+    /// from the trait object's configured `(owner, repo)`. Used by the
+    /// `close` cascade (spec §8.2 step 6 / §11.4 row 4) to deliver unblock
+    /// comments to foreign dependents when the configured token has write
+    /// scope on the target repo.
+    async fn add_comment_in_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        body: String,
+    ) -> Result<String, Error>;
+
+    /// Adds a comment to an issue identified by an [`IssueRef`].
+    ///
+    /// Dispatches [`Local`](IssueRef::Local) refs to
+    /// [`add_comment`](Self::add_comment) and
+    /// [`CrossRepo`](IssueRef::CrossRepo) refs to
+    /// [`add_comment_in_repo`](Self::add_comment_in_repo). Mirrors
+    /// [`fetch_issue_ref`](Self::fetch_issue_ref) and is the primitive
+    /// behind the cross-repo close-cascade contract (spec §5.6 / §8.2
+    /// step 6 / §11.4 row 4).
+    async fn add_comment_ref(&self, issue_ref: &IssueRef, body: String) -> Result<String, Error>;
+
     /// Replaces the body of an issue.
     async fn update_issue_body(&self, number: u64, body: String) -> Result<(), Error>;
 
@@ -424,6 +451,20 @@ impl GitHubApi for GitHubClient {
 
     async fn add_comment(&self, number: u64, body: String) -> Result<String, Error> {
         GitHubClient::add_comment(self, number, body).await
+    }
+
+    async fn add_comment_in_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        body: String,
+    ) -> Result<String, Error> {
+        GitHubClient::add_comment_in_repo(self, owner, repo, number, body).await
+    }
+
+    async fn add_comment_ref(&self, issue_ref: &IssueRef, body: String) -> Result<String, Error> {
+        GitHubClient::add_comment_ref(self, issue_ref, body).await
     }
 
     async fn update_issue_body(&self, number: u64, body: String) -> Result<(), Error> {

--- a/crates/unblock-github/src/mock.rs
+++ b/crates/unblock-github/src/mock.rs
@@ -95,6 +95,8 @@ pub struct CallCounts {
     reopen_issue: AtomicUsize,
     search_issues: AtomicUsize,
     add_comment: AtomicUsize,
+    add_comment_in_repo: AtomicUsize,
+    add_comment_ref: AtomicUsize,
     update_issue_body: AtomicUsize,
     add_labels_to_issue: AtomicUsize,
     remove_label_from_issue: AtomicUsize,
@@ -149,6 +151,8 @@ impl CallCounts {
         reopen_issue,
         search_issues,
         add_comment,
+        add_comment_in_repo,
+        add_comment_ref,
         update_issue_body,
         add_labels_to_issue,
         remove_label_from_issue,
@@ -198,6 +202,8 @@ impl CallCounts {
             reopen_issue,
             search_issues,
             add_comment,
+            add_comment_in_repo,
+            add_comment_ref,
             update_issue_body,
             add_labels_to_issue,
             remove_label_from_issue,
@@ -254,6 +260,13 @@ pub struct Stubs {
     reopen_issue: Mutex<VecDeque<Result<(), Error>>>,
     search_issues: Mutex<VecDeque<Result<Vec<IssueSummary>, Error>>>,
     add_comment: Mutex<VecDeque<Result<String, Error>>>,
+    add_comment_in_repo: Mutex<VecDeque<Result<String, Error>>>,
+    add_comment_ref: Mutex<VecDeque<Result<String, Error>>>,
+    /// Argument-aware log for `add_comment_ref` invocations — stores every
+    /// [`IssueRef`] the mock saw, in call order. Tests use this to assert
+    /// that the close cascade dispatched against the qualified refs,
+    /// covering SPEC §8.2 step 6 / §11.4 row 4.
+    add_comment_ref_calls: Mutex<Vec<IssueRef>>,
     update_issue_body: Mutex<VecDeque<Result<(), Error>>>,
     add_labels_to_issue: Mutex<VecDeque<Result<(), Error>>>,
     remove_label_from_issue: Mutex<VecDeque<Result<(), Error>>>,
@@ -319,6 +332,28 @@ impl MockGitHubClient {
     #[must_use]
     pub fn calls(&self) -> &CallCounts {
         &self.calls
+    }
+
+    /// Returns a snapshot of every [`IssueRef`] passed to
+    /// [`add_comment_ref`](GitHubApi::add_comment_ref), in call order.
+    ///
+    /// Unlike the bare counter on [`CallCounts`], this lets tests assert
+    /// that the close-cascade Phase-3 loop (spec §8.2 step 6) dispatched
+    /// the comment against the correct qualified ref — required to cover
+    /// the SPEC §11.4 row 4 contract.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the internal log `Mutex` is poisoned, which can
+    /// only happen if a previous test thread panicked while holding the
+    /// lock — never in normal use.
+    #[must_use]
+    pub fn add_comment_ref_calls(&self) -> Vec<IssueRef> {
+        self.stubs
+            .add_comment_ref_calls
+            .lock()
+            .expect("mock call-log mutex poisoned")
+            .clone()
     }
 }
 
@@ -403,6 +438,8 @@ push_result!(close_issue, push_close_issue, ());
 push_result!(reopen_issue, push_reopen_issue, ());
 push_result!(search_issues, push_search_issues, Vec<IssueSummary>);
 push_result!(add_comment, push_add_comment, String);
+push_result!(add_comment_in_repo, push_add_comment_in_repo, String);
+push_result!(add_comment_ref, push_add_comment_ref, String);
 push_result!(update_issue_body, push_update_issue_body, ());
 push_result!(add_labels_to_issue, push_add_labels_to_issue, ());
 push_result!(remove_label_from_issue, push_remove_label_from_issue, ());
@@ -602,6 +639,32 @@ impl GitHubApi for MockGitHubClient {
     async fn add_comment(&self, _number: u64, _body: String) -> Result<String, Error> {
         self.calls.add_comment.fetch_add(1, Ordering::SeqCst);
         pop_or_unstubbed(&self.stubs.add_comment, "add_comment")
+    }
+
+    async fn add_comment_in_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+        _body: String,
+    ) -> Result<String, Error> {
+        self.calls
+            .add_comment_in_repo
+            .fetch_add(1, Ordering::SeqCst);
+        pop_or_unstubbed(&self.stubs.add_comment_in_repo, "add_comment_in_repo")
+    }
+
+    async fn add_comment_ref(&self, issue_ref: &IssueRef, _body: String) -> Result<String, Error> {
+        self.calls.add_comment_ref.fetch_add(1, Ordering::SeqCst);
+        // Record the qualified ref for argument-aware assertions (see
+        // `MockGitHubClient::add_comment_ref_calls`). The clone keeps the
+        // log independent of the caller's borrow scope.
+        self.stubs
+            .add_comment_ref_calls
+            .lock()
+            .expect("mock call-log mutex poisoned")
+            .push(issue_ref.clone());
+        pop_or_unstubbed(&self.stubs.add_comment_ref, "add_comment_ref")
     }
 
     async fn update_issue_body(&self, _number: u64, _body: String) -> Result<(), Error> {
@@ -935,5 +998,99 @@ mod tests {
             .expect("queued Ok should succeed");
         assert!(second.is_empty());
         assert_eq!(m.calls().search_issues(), 2);
+    }
+
+    // ── add_comment_ref / add_comment_in_repo (unblock-eos.13) ────────────
+
+    #[tokio::test]
+    async fn add_comment_in_repo_counter_and_queue_pop() {
+        let m = mock();
+        assert_eq!(m.calls().add_comment_in_repo(), 0);
+
+        // Empty queue → MockNotStubbed fallback named by the method.
+        let first = m
+            .add_comment_in_repo("acme", "widgets", 42, "body".to_owned())
+            .await;
+        assert!(matches!(
+            first,
+            Err(Error::MockNotStubbed {
+                method: "add_comment_in_repo"
+            })
+        ));
+        assert_eq!(m.calls().add_comment_in_repo(), 1);
+
+        // Queued Ok pops — returns the queued html_url.
+        m.push_add_comment_in_repo(Ok("https://x.invalid/c".to_owned()));
+        let second = m
+            .add_comment_in_repo("other", "repo", 99, "body".to_owned())
+            .await
+            .expect("queued Ok should succeed");
+        assert_eq!(second, "https://x.invalid/c");
+        assert_eq!(m.calls().add_comment_in_repo(), 2);
+    }
+
+    #[tokio::test]
+    async fn add_comment_ref_records_arguments_in_order() {
+        let m = mock();
+        assert!(
+            m.add_comment_ref_calls().is_empty(),
+            "no calls yet → empty log"
+        );
+
+        // Exercise the two variants in a deterministic sequence so tests
+        // can assert the call LOG preserves insertion order.
+        m.push_add_comment_ref(Ok("h1".to_owned()));
+        m.push_add_comment_ref(Ok("h2".to_owned()));
+
+        let _ = m
+            .add_comment_ref(&IssueRef::Local(5), "body-local".to_owned())
+            .await
+            .expect("stubbed Ok");
+        let _ = m
+            .add_comment_ref(
+                &IssueRef::CrossRepo {
+                    owner: "other".to_owned(),
+                    repo: "repo".to_owned(),
+                    number: 99,
+                },
+                "body-cross".to_owned(),
+            )
+            .await
+            .expect("stubbed Ok");
+
+        // Counter reflects both dispatches.
+        assert_eq!(m.calls().add_comment_ref(), 2);
+        // Argument-aware log preserves order AND ref identity.
+        let log = m.add_comment_ref_calls();
+        assert_eq!(
+            log,
+            vec![
+                IssueRef::Local(5),
+                IssueRef::CrossRepo {
+                    owner: "other".to_owned(),
+                    repo: "repo".to_owned(),
+                    number: 99,
+                },
+            ],
+            "add_comment_ref_calls() MUST record every IssueRef in call order"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_comment_ref_empty_queue_falls_back_to_mock_not_stubbed() {
+        let m = mock();
+        let result = m
+            .add_comment_ref(&IssueRef::Local(1), "body".to_owned())
+            .await;
+        assert!(matches!(
+            result,
+            Err(Error::MockNotStubbed {
+                method: "add_comment_ref"
+            })
+        ));
+        // Even on the MockNotStubbed fallback the argument IS recorded —
+        // this guarantees argument-aware assertions work regardless of
+        // whether the test chose to stub the return value.
+        assert_eq!(m.add_comment_ref_calls(), vec![IssueRef::Local(1)]);
     }
 }

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -310,10 +310,12 @@ impl GitHubClient {
         Ok(())
     }
 
-    /// Adds a comment to a GitHub issue.
+    /// Adds a comment to a GitHub issue in the configured repository.
     ///
-    /// Sends a REST POST to `/repos/{owner}/{repo}/issues/{number}/comments`.
-    /// Returns the HTML URL of the created comment.
+    /// Thin convenience wrapper over
+    /// [`add_comment_in_repo`](Self::add_comment_in_repo) — delegates to
+    /// the `(self.owner(), self.repo())` tuple so single-repo callers that
+    /// only speak in local issue numbers keep a single codepath.
     ///
     /// # Errors
     ///
@@ -325,11 +327,39 @@ impl GitHubClient {
     /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
     #[instrument(skip(self, body), fields(owner = %self.owner(), repo = %self.repo()))]
     pub async fn add_comment(&self, number: u64, body: String) -> Result<String, Error> {
-        let url = self.rest_url(&format!(
-            "/repos/{}/{}/issues/{number}/comments",
-            self.owner(),
-            self.repo()
-        ));
+        self.add_comment_in_repo(self.owner(), self.repo(), number, body)
+            .await
+    }
+
+    /// Adds a comment to a GitHub issue in the specified `owner/repo`.
+    ///
+    /// Sends a REST POST to `/repos/{owner}/{repo}/issues/{number}/comments`.
+    /// Returns the HTML URL of the created comment. Unlike
+    /// [`add_comment`](Self::add_comment), the target repository is
+    /// supplied by the caller instead of being read from `self` — this
+    /// is what backs [`add_comment_ref`](Self::add_comment_ref) for
+    /// cross-repo cascade side effects (see SPEC §8.2 step 6 and §11.4
+    /// row 4).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Domain`] with [`DomainError::IssueNotFound`] if the
+    /// issue does not exist in the target repository (HTTP 404).
+    /// Returns [`Error::RateLimited`] for HTTP 429 responses.
+    /// Returns [`Error::GitHubApi`] for other non-2xx responses (notably
+    /// HTTP 403 when the configured token lacks write access on a foreign
+    /// repository — the common failure mode for cross-repo cascades).
+    ///
+    /// [`DomainError::IssueNotFound`]: unblock_core::errors::DomainError::IssueNotFound
+    #[instrument(skip(self, body))]
+    pub async fn add_comment_in_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+        body: String,
+    ) -> Result<String, Error> {
+        let url = self.rest_url(&format!("/repos/{owner}/{repo}/issues/{number}/comments"));
 
         let request_body = AddCommentBody { body };
 
@@ -355,6 +385,44 @@ impl GitHubClient {
             .context(errors::GitHubUnavailableSnafu)?;
 
         Ok(comment.html_url)
+    }
+
+    /// Adds a comment to an issue identified by an [`IssueRef`].
+    ///
+    /// Dispatches on the ref variant:
+    /// - [`Local`](unblock_core::types::IssueRef::Local) delegates to
+    ///   [`add_comment`](Self::add_comment) (posts against the configured
+    ///   repository), preserving the existing single-repo codepath.
+    /// - [`CrossRepo`](unblock_core::types::IssueRef::CrossRepo) delegates
+    ///   to [`add_comment_in_repo`](Self::add_comment_in_repo) with the
+    ///   ref's `(owner, repo, number)` so the comment lands on the
+    ///   correct foreign repository.
+    ///
+    /// Mirrors [`fetch_issue_ref`](Self::fetch_issue_ref) and is what
+    /// the `close` Phase-3 cascade loop (SPEC §8.2 step 6) uses to honor
+    /// the cross-repo cascade contract (§11.4 row 4 / §5.6).
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as the underlying
+    /// [`add_comment`](Self::add_comment) /
+    /// [`add_comment_in_repo`](Self::add_comment_in_repo) paths.
+    ///
+    /// [`IssueRef`]: unblock_core::types::IssueRef
+    #[instrument(skip(self, body))]
+    pub async fn add_comment_ref(
+        &self,
+        issue_ref: &unblock_core::types::IssueRef,
+        body: String,
+    ) -> Result<String, Error> {
+        match issue_ref {
+            unblock_core::types::IssueRef::Local(number) => self.add_comment(*number, body).await,
+            unblock_core::types::IssueRef::CrossRepo {
+                owner,
+                repo,
+                number,
+            } => self.add_comment_in_repo(owner, repo, *number, body).await,
+        }
     }
 
     /// Updates the body of a GitHub issue.
@@ -1913,5 +1981,157 @@ mod tests {
             .await
             .expect_err("search_issues should return Err on 429");
         assert!(matches!(err, Error::RateLimited { .. }));
+    }
+
+    // ── add_comment_in_repo / add_comment_ref (unblock-eos.13) ────────────
+    //
+    // Regression guards for the cross-repo cascade primitives introduced in
+    // unblock-eos.13 (SPEC §5.6 row `close`, §8.2 step 6, §11.4 row 4). The
+    // key contract is that `add_comment_in_repo` routes the REST POST to
+    // `/repos/{owner}/{repo}/issues/{number}/comments` using the ARGUMENTS,
+    // not the configured `self.owner()/self.repo()` — otherwise a cross-repo
+    // dependent's unblock comment silently lands on the wrong repo (the
+    // pre-fix behaviour flagged in the bead's investigation).
+
+    #[tokio::test]
+    async fn add_comment_in_repo_uses_argument_owner_and_repo_not_self() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        // Configured repo is `test-owner/test-repo` (see `new_for_test`),
+        // but we post to `other/repo#99` — the URL path MUST carry the
+        // argument tuple, NOT the configured one. `expect(1)` on the
+        // correct path + `expect(0)` on the wrong path encodes the
+        // argument-routing contract.
+        Mock::given(method("POST"))
+            .and(path("/repos/other/repo/issues/99/comments"))
+            .and(body_json(serde_json::json!({ "body": "cross-repo body" })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://github.com/other/repo/issues/99#issuecomment-1"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Wrong-target guard: if the impl incorrectly retargets the
+        // configured repo, this mock would fire and the test would fail
+        // at Drop via `expect(0)`.
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/issues/99/comments"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://should-not-be-called.invalid"
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let url = client
+            .add_comment_in_repo("other", "repo", 99, "cross-repo body".to_owned())
+            .await
+            .expect("add_comment_in_repo should succeed");
+        assert_eq!(
+            url, "https://github.com/other/repo/issues/99#issuecomment-1",
+            "returned html_url must come from the response body"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_comment_in_repo_returns_issue_not_found_on_404() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/repos/other/repo/issues/4242/comments"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .add_comment_in_repo("other", "repo", 4242, "ignored".to_owned())
+            .await
+            .expect_err("add_comment_in_repo should fail on 404");
+        assert!(
+            matches!(
+                err,
+                Error::Domain {
+                    source: DomainError::IssueNotFound { number: 4242 },
+                }
+            ),
+            "404 MUST surface as DomainError::IssueNotFound preserving the argument number; \
+             got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_comment_ref_dispatches_local_to_configured_repo() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        // IssueRef::Local → must post against the CONFIGURED repo path.
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/issues/7/comments"))
+            .and(body_json(serde_json::json!({ "body": "local-path body" })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://github.com/test-owner/test-repo/issues/7#issuecomment-local"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let url = client
+            .add_comment_ref(
+                &unblock_core::types::IssueRef::Local(7),
+                "local-path body".to_owned(),
+            )
+            .await
+            .expect("add_comment_ref Local should succeed");
+        assert_eq!(
+            url,
+            "https://github.com/test-owner/test-repo/issues/7#issuecomment-local"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_comment_ref_dispatches_cross_repo_to_argument_repo() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        // IssueRef::CrossRepo → must post against the REF's owner/repo,
+        // NOT the configured repo. This is the core unblock-eos.13 fix.
+        Mock::given(method("POST"))
+            .and(path("/repos/alpha/upstream/issues/42/comments"))
+            .and(body_json(serde_json::json!({ "body": "cross-repo body" })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://github.com/alpha/upstream/issues/42#issuecomment-cross"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        // Wrong-target guard: the configured repo MUST NOT be hit.
+        Mock::given(method("POST"))
+            .and(path("/repos/test-owner/test-repo/issues/42/comments"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "html_url": "https://should-not-be-called.invalid"
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let url = client
+            .add_comment_ref(
+                &unblock_core::types::IssueRef::CrossRepo {
+                    owner: "alpha".to_owned(),
+                    repo: "upstream".to_owned(),
+                    number: 42,
+                },
+                "cross-repo body".to_owned(),
+            )
+            .await
+            .expect("add_comment_ref CrossRepo should succeed");
+        assert_eq!(
+            url,
+            "https://github.com/alpha/upstream/issues/42#issuecomment-cross"
+        );
     }
 }

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1065,13 +1065,47 @@ impl UnblockServer {
             // Phase 3: For each newly unblocked issue, update project fields and
             // post an unblock comment. Each update is best-effort — failures are
             // logged but do not abort the cascade.
+            //
+            // SPEC §8.2 step 6 / §11.4 row 4 / §5.6 row `close`: cross-repo
+            // dependents ARE still cascade-updated. The loop dispatches via
+            // the `*_ref` primitives so the comment and issue-fetch land on
+            // the correct `(owner, repo)` — bare-`u64` variants would silently
+            // retarget the configured repo (unblock-eos.13 finding RISK #2).
+            // Project-field updates remain scoped to the configured board
+            // because `project_id` / `item_id` are globally scoped node IDs;
+            // if a cross-repo dependent is not on the board,
+            // `get_project_item_id` fails best-effort and the comment still
+            // lands — matching the spec intent of "cascade side-effects only".
+            let configured_owner = client.owner().to_owned();
+            let configured_repo = client.repo().to_owned();
             for cascaded_qid in &cascade {
                 let cascaded_number = cascaded_qid.number;
-                // Post unblock comment.
+                // Normalize to IssueRef: a QualifiedId whose (owner, repo)
+                // matches the configured repo collapses to Local so the
+                // existing single-repo REST path (with its URL formatting)
+                // keeps running unchanged; foreign refs flow through the
+                // *_in_repo branch.
+                let cascaded_ref = if cascaded_qid.owner == configured_owner
+                    && cascaded_qid.repo == configured_repo
+                {
+                    unblock_core::types::IssueRef::Local(cascaded_number)
+                } else {
+                    unblock_core::types::IssueRef::CrossRepo {
+                        owner: cascaded_qid.owner.clone(),
+                        repo: cascaded_qid.repo.clone(),
+                        number: cascaded_number,
+                    }
+                };
+                // Post unblock comment. Stays best-effort per the pre-existing
+                // §8.2 step 6 semantics — the token may lack write scope on a
+                // foreign repo and we must not tear down the cascade for a
+                // permission error (see unblock-eos.13 investigation Risks).
+                // Qualified ID is logged so operators can distinguish
+                // local-repo failures from cross-repo permission denials.
                 let comment_body = format!("\u{2705} Unblocked by closing #{issue_number}");
-                if let Err(e) = client.add_comment(cascaded_number, comment_body).await {
+                if let Err(e) = client.add_comment_ref(&cascaded_ref, comment_body).await {
                     tracing::warn!(
-                        cascaded_number,
+                        cascaded_qid = %cascaded_qid,
                         error = %e,
                         "Failed to post unblock comment on cascaded issue"
                     );
@@ -1083,8 +1117,11 @@ impl UnblockServer {
                 if let Some(field_ids) = client.field_ids().await
                     && let Ok(project_info) = client.resolve_project_info().await
                 {
-                    // Fetch the cascaded issue to get its node_id and current status.
-                    match client.fetch_issue(cascaded_number).await {
+                    // Fetch the cascaded issue (by ref, not bare number) to
+                    // get its node_id and current status. For cross-repo
+                    // dependents this reads from the foreign repo; for local
+                    // the _ref variant delegates to the unchanged path.
+                    match client.fetch_issue_ref(&cascaded_ref).await {
                         Ok(cascaded_issue) => {
                             if let Ok(item_id) = client
                                 .get_project_item_id(&cascaded_issue.node_id, &project_info.id)
@@ -1103,21 +1140,24 @@ impl UnblockServer {
                                         .await
                                 {
                                     tracing::warn!(
-                                        cascaded_number,
+                                        cascaded_qid = %cascaded_qid,
                                         error = %e,
                                         "Failed to set Status=ready on cascaded issue"
                                     );
                                 }
                             } else {
+                                // Expected for cross-repo dependents that
+                                // were never added as ProjectV2 items on the
+                                // configured board — best-effort per §5.6.
                                 tracing::warn!(
-                                    cascaded_number,
+                                    cascaded_qid = %cascaded_qid,
                                     "Failed to get project item ID for cascaded issue"
                                 );
                             }
                         }
                         Err(e) => {
                             tracing::warn!(
-                                cascaded_number,
+                                cascaded_qid = %cascaded_qid,
                                 error = %e,
                                 "Failed to fetch cascaded issue for field updates"
                             );

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -4302,12 +4302,15 @@ async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
     // exclude the closed issue, but that path is orthogonal to this
     // bead's scope).
     mock.push_fetch_graph_data(Ok((issues, edges)));
-    // Phase 3 loop runs 2×. Each iteration calls add_comment then
-    // field_ids. We push add_comment Ok twice and let field_ids
-    // default to None (queue empty ⇒ None) so the inner project-field
-    // ladder is skipped.
-    mock.push_add_comment(Ok("comment_id".to_owned()));
-    mock.push_add_comment(Ok("comment_id".to_owned()));
+    // Phase 3 loop runs 2×. Each iteration calls add_comment_ref then
+    // field_ids. Post unblock-eos.13 the cascade always dispatches via
+    // the *_ref primitive (SPEC §8.2 step 6 / §5.6 `close` row); local
+    // dependents normalize to `IssueRef::Local(n)`.
+    // We push add_comment_ref Ok twice and let field_ids default to
+    // None (queue empty ⇒ None) so the inner project-field ladder is
+    // skipped.
+    mock.push_add_comment_ref(Ok("comment_id".to_owned()));
+    mock.push_add_comment_ref(Ok("comment_id".to_owned()));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server
@@ -4341,8 +4344,34 @@ async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
         "None cross_repo_refs must be elided from JSON: {json}"
     );
 
-    // Both cascade members received an unblock comment.
-    assert_eq!(mock.calls().add_comment(), 2);
+    // Both cascade members received an unblock comment via the *_ref
+    // dispatch path (SPEC §8.2 step 6 — unblock-eos.13 migration).
+    assert_eq!(mock.calls().add_comment_ref(), 2);
+    // The legacy single-repo `add_comment` primitive is NOT invoked by
+    // the cascade loop anymore; all traffic flows through *_ref.
+    assert_eq!(mock.calls().add_comment(), 0);
+    // Argument-aware assertion (upgrade from pre-unblock-eos.13 call-count
+    // only). Both dependents are local → they normalize to IssueRef::Local.
+    let ref_calls = mock.add_comment_ref_calls();
+    assert_eq!(ref_calls.len(), 2);
+    let ref_numbers: std::collections::HashSet<u64> = ref_calls
+        .iter()
+        .map(|r| match r {
+            unblock_core::types::IssueRef::Local(n) => *n,
+            unblock_core::types::IssueRef::CrossRepo { number, .. } => *number,
+        })
+        .collect();
+    assert_eq!(
+        ref_numbers,
+        std::collections::HashSet::from([10_u64, 11]),
+        "all-local cascade must dispatch add_comment_ref for #10 and #11"
+    );
+    assert!(
+        ref_calls
+            .iter()
+            .all(|r| matches!(r, unblock_core::types::IssueRef::Local(_))),
+        "all-local cascade must normalize every cascaded_qid to IssueRef::Local; got: {ref_calls:?}"
+    );
     assert_eq!(mock.calls().close_issue(), 1);
     assert_eq!(mock.calls().fetch_graph_data(), 1);
 }
@@ -4396,18 +4425,19 @@ async fn close_cross_repo_dependent_populates_cross_repo_refs() {
     mock.push_field_ids(None); // Phase 1: skip project-field ladder.
     mock.push_fetch_graph_data(Ok((issues, edges)));
     // Phase 3 loop runs 3× (#10, other/repo#99, alpha/upstream#42).
-    // Each iteration posts an add_comment; field_ids defaults to None
-    // when the queue is empty, so the inner project-field ladder is
-    // skipped — no further pushes required.
+    // Each iteration posts an add_comment_ref; field_ids defaults to
+    // None when the queue is empty, so the inner project-field ladder
+    // is skipped — no further pushes required.
     //
-    // RISK #2 (close handler is not cross-repo-aware for side effects):
-    // `client.add_comment(99)` actually targets `acme/widgets#99`
-    // in production. The mock just records the call count here, so
-    // this operational limitation is invisible to the test — matches
-    // the bead's scope note.
-    mock.push_add_comment(Ok("c1".to_owned()));
-    mock.push_add_comment(Ok("c2".to_owned()));
-    mock.push_add_comment(Ok("c3".to_owned()));
+    // Post-unblock-eos.13: the cascade dispatches via `add_comment_ref`
+    // (SPEC §8.2 step 6 / §5.6 `close` row: cascade side-effects only).
+    // Local dependents normalize to `IssueRef::Local`; foreign dependents
+    // carry their qualified `(owner, repo, number)` so the REST POST
+    // lands on the correct repository. The argument-aware call log
+    // (`mock.add_comment_ref_calls()`) closes the previous RISK #2 gap.
+    mock.push_add_comment_ref(Ok("c1".to_owned()));
+    mock.push_add_comment_ref(Ok("c2".to_owned()));
+    mock.push_add_comment_ref(Ok("c3".to_owned()));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server
@@ -4454,9 +4484,43 @@ async fn close_cross_repo_dependent_populates_cross_repo_refs() {
     // unblocked carries only the local member.
     assert_eq!(json["unblocked"].as_array().map(Vec::len), Some(1));
 
-    // All three cascade members received an unblock comment (SPEC §8.2
-    // flow step 6: cross-repo dependents ARE still cascade-updated).
-    assert_eq!(mock.calls().add_comment(), 3);
+    // All three cascade members received an unblock comment via the
+    // *_ref path (SPEC §8.2 flow step 6: cross-repo dependents ARE still
+    // cascade-updated — honoured by unblock-eos.13 primitives).
+    assert_eq!(mock.calls().add_comment_ref(), 3);
+    // The legacy bare-`u64` primitive is NOT invoked by the cascade.
+    assert_eq!(mock.calls().add_comment(), 0);
+
+    // Argument-aware assertion: the cross-repo members must be dispatched
+    // with their QUALIFIED refs (not coerced into the configured repo).
+    // This closes the previous RISK #2 gap — mock counters alone couldn't
+    // distinguish "add_comment(99) against acme/widgets" (wrong) from
+    // "add_comment_ref(other/repo#99)" (correct). IssueRef does not
+    // derive `Hash`, so assert on Vec containment.
+    let ref_calls = mock.add_comment_ref_calls();
+    assert_eq!(ref_calls.len(), 3);
+    assert!(
+        ref_calls.contains(&unblock_core::types::IssueRef::Local(10)),
+        "local dependent #10 MUST dispatch IssueRef::Local(10); got: {ref_calls:?}"
+    );
+    assert!(
+        ref_calls.contains(&unblock_core::types::IssueRef::CrossRepo {
+            owner: "other".to_owned(),
+            repo: "repo".to_owned(),
+            number: 99,
+        }),
+        "cross-repo dependent other/repo#99 MUST dispatch IssueRef::CrossRepo; got: {ref_calls:?}"
+    );
+    assert!(
+        ref_calls.contains(&unblock_core::types::IssueRef::CrossRepo {
+            owner: "alpha".to_owned(),
+            repo: "upstream".to_owned(),
+            number: 42,
+        }),
+        "cross-repo dependent alpha/upstream#42 MUST dispatch IssueRef::CrossRepo; \
+         got: {ref_calls:?}"
+    );
+
     assert_eq!(mock.calls().close_issue(), 1);
     assert_eq!(mock.calls().fetch_graph_data(), 1);
 }
@@ -4485,7 +4549,9 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
     mock.push_close_issue(Ok(()));
     mock.push_field_ids(None);
     mock.push_fetch_graph_data(Ok((issues, edges)));
-    mock.push_add_comment(Ok("c1".to_owned()));
+    // Phase 3: single cross-repo dependent — dispatched through the *_ref
+    // primitive (SPEC §8.2 step 6 / §5.6 `close` row).
+    mock.push_add_comment_ref(Ok("c1".to_owned()));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server
@@ -4514,5 +4580,21 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
         refs.summary.as_deref(),
         Some("1 cross-repo dependent cascade-updated but omitted from `unblocked`"),
         "SPEC §11.4: singular phrasing must match byte-for-byte",
+    );
+
+    // Argument-aware dispatch check: the lone cascade member is cross-repo
+    // → MUST dispatch `IssueRef::CrossRepo { other, repo, 99 }` through
+    // `add_comment_ref` (closes unblock-eos.13 RISK #2 on the singular path).
+    assert_eq!(mock.calls().add_comment_ref(), 1);
+    assert_eq!(mock.calls().add_comment(), 0);
+    let ref_calls = mock.add_comment_ref_calls();
+    assert_eq!(
+        ref_calls,
+        vec![unblock_core::types::IssueRef::CrossRepo {
+            owner: "other".to_owned(),
+            repo: "repo".to_owned(),
+            number: 99,
+        }],
+        "single cross-repo cascade MUST dispatch the qualified IssueRef"
     );
 }

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -828,7 +828,8 @@ query($owner: String!, $repo: String!, $cursor: String) {
 |---|---|---|
 | `depends` / `dep_remove` | Yes | Dependencies are the core cross-repo use case |
 | `show` / `fetch_issue_ref` | Yes | Inspect cross-repo blockers |
-| `close`, `reopen`, `update`, `claim`, `comment` | No | Scoped to configured repo for safety |
+| `close` | Cascade side-effects only | The `closeIssue` mutation itself remains scoped to the configured repo for safety; cross-repo **dependents unblocked by the close** receive the Status → `ready` + unblock-comment side effects per §8.2 step 6 / §11.4 row 4. Cross-repo cascade side effects are best-effort: a foreign repo on which the configured token lacks write scope fails with a logged warning and does not abort the close. |
+| `reopen`, `update`, `claim`, `comment` | No | Scoped to configured repo for safety |
 | `create` (`blocked_by` param) | Yes | Cross-repo deps at creation time |
 
 ### 5.7 Projects V2 field management


### PR DESCRIPTION
…ascade

Migrate the Phase-3 close cascade loop in the MCP close tool to dispatch via `*_ref` primitives so cross-repo dependents receive their Status=ready + unblock-comment side effects on the correct (owner, repo) per SPEC §8.2 step 6 and §11.4 row 4. Update §5.6 cross-repo scope table to split `close` out of the "no" group and record the new "Cascade side-effects only" semantics: the `closeIssue` mutation itself stays scoped to the configured repo, but dependents unblocked by the close are cascaded across repos best-effort.

The Phase-3 loop now:
  * Captures (configured_owner, configured_repo) once.
  * Materializes cascaded_ref: IssueRef = Local for same-repo dependents, CrossRepo { owner, repo, number } otherwise.
  * Dispatches add_comment_ref and fetch_issue_ref on the ref.
  * Logs cascaded_qid=%owner/repo#number on warn! fallbacks so operators can observe which dependent dropped.

`update_field` intentionally remains unqualified: Projects V2 mutations act on globally-scoped node IDs (project_id + item_id), not on (owner, repo, number). Only the add_comment + fetch_issue sides of the ladder needed new primitives.

Mock test-hooks gain add_comment_in_repo + add_comment_ref stub queues, AtomicUsize counters, and an argument-aware add_comment_ref_calls: Vec<IssueRef> log used by the integration tests to assert that cross-repo cascade comments route to the dependent's (owner, repo), not to the configured repo. The three §11.4 close integration tests now consume `push_add_comment_ref` and verify dispatch by inspecting the recorded IssueRef values (Vec::contains, because IssueRef does not derive Hash); the "RISK #2" marker from pre-implementation investigation is removed.

API: GitHubApi::add_comment_in_repo(&self, owner: String, repo: String, number: u64, body: String) -> Result<String, Error> — new trait method, additive.
API: GitHubApi::add_comment_ref(&self, issue_ref: &IssueRef, body: String) -> Result<String, Error> — new trait method, additive.
API: GitHubClient::add_comment_in_repo — new inherent method, additive.
API: GitHubClient::add_comment_ref — new inherent method, additive.

Refs: unblock-eos.13