### PR TITLE
docs(spec,plan): align §11.1 error variants with cross-repo typing (u…

### DIFF
--- a/docs/plans/01-plan-mcp-foundation.md
+++ b/docs/plans/01-plan-mcp-foundation.md
@@ -330,10 +330,12 @@ An `API:` body line is INSUFFICIENT — Conventional Commits requires `BREAKING 
 - `IssueBlockedSnafu { number: 10, blockers: vec![IssueRef::Local(1), IssueRef::Local(2)] }.build().to_string()` MUST contain `"10"` (matches `errors.rs:170-174`).
 - Cross-repo case: `CircularDependencySnafu { source: IssueRef::CrossRepo { owner: "acme".into(), repo: "widgets".into(), number: 1 }, target: IssueRef::Local(2) }.build().to_string()` renders with `"acme/widgets#1"` somewhere in the string. Add a new test asserting this; do NOT modify the existing Local-only tests.
 
+**Implementer trap — Debug vs. Display for `IssueBlocked.blockers`.** The current `#[snafu(display(...))]` attribute at `crates/unblock-core/src/errors.rs:41` is `"Issue #{number} is blocked by: {blockers:?}"` — `{blockers:?}` is the Debug formatter. Under `Vec<u64>` it renders `[1, 2]`; under `Vec<IssueRef>` it renders `[Local(1), Local(2)]` (variant names leak). The existing test at `errors.rs:170-174` only asserts substring `"10"` so this Debug output still passes, but any future tightening to assert `"#1"` would silently break. The implementation MUST replace the `{blockers:?}` Debug attribute with a Display-based renderer — either a format string interpolating `IssueRef::Display` via a joined helper, or a pre-formatted blocker list built by iterating and calling `IssueRef`'s `Display` impl. This is not a contract change; it is an implementer trap flagged so the Display-preservation contract above is not silently violated. See SPEC §11.1 "Implementer trap".
+
 **Error-side wiring (SPEC §11.1 Decision 2, confirmed no shape change).**
 
 - `InvalidIssueRef { input: String }` — emitted whenever `IssueRef::from_str` fails on tool input. The tool-layer call sites (§8.4 `depends`, §8.5 `dep_remove`, §8.3 `create.blocked_by`, §7.2 `show`) MUST wrap the parse error into `InvalidIssueRefSnafu { input: <raw user string> }` and propagate. Maps to HTTP 400 → MCP `-32602` (invalid params) via §11.3.
-- `CrossRepoAccessDenied { owner: String, repo: String }` — emitted when a GraphQL fetch against a cross-repo node returns `FORBIDDEN` (or equivalent 403). Maps to HTTP 403. Per SPEC §11.3 `github_error_to_mcp` the 403 branch maps to MCP `-32602` (invalid params / business rule, same bucket as other 4xx domain errors). The `unblock-mcp/src/errors.rs` match arm MUST add the 403 → `-32602` mapping explicitly so regressions are caught by the error-mapping test.
+- `CrossRepoAccessDenied { owner: String, repo: String }` — emitted when a GraphQL fetch against a cross-repo node returns `FORBIDDEN` (or equivalent 403). Maps to HTTP 403. Per SPEC §11.3 `github_error_to_mcp` the 403 branch maps to MCP `-32602` (invalid params / business rule, same bucket as other 4xx domain errors). The `unblock-mcp/src/errors.rs` match arm MUST add the 403 → `-32602` mapping explicitly so regressions are caught by the error-mapping test. Add a unit test in `unblock-mcp/src/errors.rs` that maps the new 403 branch so future variant additions don't silently collapse into the catch-all.
 
 These two variants are already spec'd (§11.1 lines above in the table); the implementation bead unblock-6xj wires the propagation paths listed above. No spec shape change is needed for this task — only the wiring contract is new.
 
@@ -878,7 +880,7 @@ SPEC §11.1 (error-side half of the cross-repo contract) and SPEC §11.4 (respon
 
 1. `IssueRef::from_str` failures at tool-boundary call sites (§7.2 `show`, §8.3 `create.blocked_by`, §8.4 `depends`, §8.5 `dep_remove`) MUST propagate as `InvalidIssueRefSnafu { input: <raw string> }` → HTTP 400 → MCP `-32602`.
 2. GraphQL `FORBIDDEN` (or 403) on cross-repo fetch MUST propagate as `CrossRepoAccessDeniedSnafu { owner, repo }` → HTTP 403 → MCP `-32602`.
-3. `crates/unblock-mcp/src/errors.rs` `github_error_to_mcp` match-arm MUST have an explicit 403 → `-32602` branch (Task 02.02 body). Add a unit test mapping the new branch so future variant additions don't silently collapse into the catch-all.
+3. `crates/unblock-mcp/src/errors.rs` `github_error_to_mcp` match-arm MUST have an explicit 403 → `-32602` branch per Task 02.02 "Error-side wiring" (single source of truth; the unit-test requirement for the new branch is hoisted into Task 02.02 to avoid drift).
 
 **Decision 3 — Response-shape universal pattern is documentation-only.** §11.4 affected set is frozen at `ready`, `prime`, `dep_cycles`, `close`; exhaustiveness rationale is embedded inline in SPEC §11.4 (see "Exhaustiveness Rationale — response-shape universality"). No new beads. New tools re-derive the (a)+(b) conjunction from §5.6 + their own response typing when added.
 
@@ -887,7 +889,7 @@ SPEC §11.1 (error-side half of the cross-repo contract) and SPEC §11.4 (respon
 **Parallel-track guarantees:**
 
 - GAP-14.c is independent of GAP-14 (response-side) and GAP-14.b (ready-set scoping) — any ordering is safe.
-- GAP-14.c's BREAKING CHANGE commit and GAP-14.b's BREAKING CHANGE commit MAY ride the same logical change family OR be landed separately; each carries its own footer text because the pub API surfaces changed are disjoint (`DomainError` variants vs. `DependencyGraph::compute_ready_set`).
+- GAP-14.c lands independently; GAP-14.b has already shipped via `unblock-eos.5` (closed). Future cross-repo BREAKING CHANGEs re-enter §11.1 via an explicit spec PR.
 
 **Resolution:** Implementation is split across unblock-6xj (wiring for `InvalidIssueRef` / `CrossRepoAccessDenied` / MCP error mapping) and unblock-29p.25 (Task 02.02 variant shape change + BREAKING CHANGE footer + tests). No additional beads required.
 

--- a/docs/plans/01-plan-mcp-foundation.md
+++ b/docs/plans/01-plan-mcp-foundation.md
@@ -298,7 +298,44 @@ Types:
 
 **File:** `unblock-core/src/errors.rs`
 
-`DomainError` enum — 11+ variants: `IssueNotFound`, `AlreadyClaimed`, `IssueBlocked`, `IssueDeferred`, `IssueClosed`, `IssueNotClosed`, `IssueAlreadyOpen`, `CircularDependency`, `DuplicateDependency`, `FieldNotFound`, `Validation`, `InvalidIssueRef`, `CrossRepoAccessDenied`. Each with `status_code() -> u16`.
+`DomainError` enum — 13 variants: `IssueNotFound`, `AlreadyClaimed`, `IssueBlocked`, `IssueDeferred`, `IssueClosed`, `IssueNotClosed`, `IssueAlreadyOpen`, `CircularDependency`, `DuplicateDependency`, `FieldNotFound`, `Validation`, `InvalidIssueRef`, `CrossRepoAccessDenied`. Each with `status_code() -> u16`.
+
+**Cross-repo-aware variant typing (SPEC §11.1 Decision 1, unblock-eos arbitration 2026-04-17).** The following three variants carry `IssueRef` (§2.7), NOT bare `u64`:
+
+- `IssueBlocked { number: u64, blockers: Vec<IssueRef> }`
+- `CircularDependency { source: IssueRef, target: IssueRef }`
+- `DuplicateDependency { source: IssueRef, target: IssueRef }`
+
+All other variants retain their current shape (bare `u64` or strings) because they refer to an issue in the configured repo only — their call sites in §5.6 never surface a cross-repo number into these error paths.
+
+**BREAKING CHANGE discipline (CLAUDE.md → Pub API Change Tracking).** The variant field-type changes above are an incompatible change to the `unblock-core` pub API (`DomainError` is `pub`, its variants are `pub`, and `Vec<IssueRef>` / `IssueRef` are not interchangeable with `Vec<u64>` / `u64` at the type level). The implementing bead (unblock-29p.25) MUST land the change with a commit message footer of the form:
+
+```
+BREAKING CHANGE: DomainError::{IssueBlocked, CircularDependency,
+DuplicateDependency} variants now carry `IssueRef` instead of bare
+`u64` for cross-repo-aware error reporting. Callers constructing
+these variants via snafu context selectors (e.g. IssueBlockedSnafu,
+CircularDependencySnafu, DuplicateDependencySnafu) must pass
+IssueRef values. Display output for the Local(n) case is preserved
+byte-for-byte; CrossRepo renders as "owner/repo#number". See SPEC
+§11.1 Decision 1 / §11.4 cross-repo contract closure.
+```
+
+An `API:` body line is INSUFFICIENT — Conventional Commits requires `BREAKING CHANGE:` for incompatible pub changes. Scope: library crate (`unblock-core`), so the rule applies per CLAUDE.md.
+
+**Display preservation (SPEC §11.1).** The existing Display tests at `crates/unblock-core/src/errors.rs:215-240` MUST continue to pass byte-for-byte for the `IssueRef::Local` case. Specifically:
+
+- `CircularDependencySnafu { source: IssueRef::Local(1), target: IssueRef::Local(2) }.build().to_string()` MUST render `"Circular dependency: adding #1 → #2 creates cycle"` (matches current test assertions on substrings `'1'`, `'2'`, `"cycle"`).
+- `DuplicateDependencySnafu { source: IssueRef::Local(4), target: IssueRef::Local(5) }.build().to_string()` MUST contain `'4'` and `'5'` (matches current test assertions).
+- `IssueBlockedSnafu { number: 10, blockers: vec![IssueRef::Local(1), IssueRef::Local(2)] }.build().to_string()` MUST contain `"10"` (matches `errors.rs:170-174`).
+- Cross-repo case: `CircularDependencySnafu { source: IssueRef::CrossRepo { owner: "acme".into(), repo: "widgets".into(), number: 1 }, target: IssueRef::Local(2) }.build().to_string()` renders with `"acme/widgets#1"` somewhere in the string. Add a new test asserting this; do NOT modify the existing Local-only tests.
+
+**Error-side wiring (SPEC §11.1 Decision 2, confirmed no shape change).**
+
+- `InvalidIssueRef { input: String }` — emitted whenever `IssueRef::from_str` fails on tool input. The tool-layer call sites (§8.4 `depends`, §8.5 `dep_remove`, §8.3 `create.blocked_by`, §7.2 `show`) MUST wrap the parse error into `InvalidIssueRefSnafu { input: <raw user string> }` and propagate. Maps to HTTP 400 → MCP `-32602` (invalid params) via §11.3.
+- `CrossRepoAccessDenied { owner: String, repo: String }` — emitted when a GraphQL fetch against a cross-repo node returns `FORBIDDEN` (or equivalent 403). Maps to HTTP 403. Per SPEC §11.3 `github_error_to_mcp` the 403 branch maps to MCP `-32602` (invalid params / business rule, same bucket as other 4xx domain errors). The `unblock-mcp/src/errors.rs` match arm MUST add the 403 → `-32602` mapping explicitly so regressions are caught by the error-mapping test.
+
+These two variants are already spec'd (§11.1 lines above in the table); the implementation bead unblock-6xj wires the propagation paths listed above. No spec shape change is needed for this task — only the wiring contract is new.
 
 ### Task 02.03 — Configuration
 
@@ -787,7 +824,7 @@ SPEC §11.4 (added via unblock-9f7) introduces a uniform `cross_repo_refs: Optio
    - Wires population logic inside the tool handler.
    - Adds the integration test branch (`Some` and `None`) required by the updated Task 04.05 / 04.07 / 04.13 acceptance criteria.
    - Because `Option` + `skip_serializing_if` is additive and absent-from-JSON-on-None, this is a non-breaking change for existing MCP clients that did not inspect the new field. (API: note required per CLAUDE.md.)
-4. **Error-side siblings (unblock-29p.25, unblock-6xj) — parallel track.** Cross-referenced in §11.4. Safe to implement before, during, or after this task's retro-fits — the two halves of the cross-repo contract (response-side §11.4, error-side §11.1) are independent.
+4. **Error-side siblings (unblock-29p.25, unblock-6xj) — parallel track.** Cross-referenced in §11.1 and §11.4. Safe to implement before, during, or after this task's retro-fits — the two halves of the cross-repo contract (response-side §11.4, error-side §11.1) are independent. See GAP-14.c for the error-side contract closure (unblock-eos Decisions 1 + 2, arbitrated 2026-04-17).
 
 **Resolution:** Land spec+plan here (unblock-9f7). Create one follow-up bead per retro-fit target (`ready`, `prime`, `close`). Implementation of each retro-fit is sibling-scope to this task, NOT part of it.
 
@@ -831,6 +868,31 @@ An `API:` body line is INSUFFICIENT for this change — Conventional Commits req
 
 ---
 
+### GAP-14.c — Error-side cross-repo contract closure (unblock-eos, Decisions 1 + 2)
+
+SPEC §11.1 (error-side half of the cross-repo contract) and SPEC §11.4 (response-side half) together form the two halves of the cross-repo contract. The response-side retro-fits are tracked by GAP-14; the ready-set source scoping is tracked by GAP-14.b. This entry closes the remaining error-side work under the unblock-eos sub-epic arbitration of 2026-04-17 (Decisions 1–4).
+
+**Decision 1 — Uniform `IssueRef` typing for cross-repo-aware domain errors (SPEC §11.1).** The variants `IssueBlocked`, `CircularDependency`, and `DuplicateDependency` change field types from bare `u64` to `IssueRef` (§2.7). Rationale is embedded in SPEC §11.1 "Cross-repo-aware variant typing — Exhaustiveness Rationale"; do not re-open. Implementation lives in unblock-29p.25 (Task 02.02 above). BREAKING CHANGE footer is MANDATORY per CLAUDE.md Pub API Change Tracking; the exact footer body is spec'd verbatim in Task 02.02. Display byte-for-byte preservation for `IssueRef::Local(n) → "#n"` is required so `crates/unblock-core/src/errors.rs:215-240` existing tests pass without edits.
+
+**Decision 2 — No shape change for `InvalidIssueRef` / `CrossRepoAccessDenied` (SPEC §11.1).** Both variants are already spec'd; the remaining work is wiring only, landed by unblock-6xj:
+
+1. `IssueRef::from_str` failures at tool-boundary call sites (§7.2 `show`, §8.3 `create.blocked_by`, §8.4 `depends`, §8.5 `dep_remove`) MUST propagate as `InvalidIssueRefSnafu { input: <raw string> }` → HTTP 400 → MCP `-32602`.
+2. GraphQL `FORBIDDEN` (or 403) on cross-repo fetch MUST propagate as `CrossRepoAccessDeniedSnafu { owner, repo }` → HTTP 403 → MCP `-32602`.
+3. `crates/unblock-mcp/src/errors.rs` `github_error_to_mcp` match-arm MUST have an explicit 403 → `-32602` branch (Task 02.02 body). Add a unit test mapping the new branch so future variant additions don't silently collapse into the catch-all.
+
+**Decision 3 — Response-shape universal pattern is documentation-only.** §11.4 affected set is frozen at `ready`, `prime`, `dep_cycles`, `close`; exhaustiveness rationale is embedded inline in SPEC §11.4 (see "Exhaustiveness Rationale — response-shape universality"). No new beads. New tools re-derive the (a)+(b) conjunction from §5.6 + their own response typing when added.
+
+**Decision 4 — No further decomposition.** The unblock-eos sub-epic closes with these spec+plan patches. Only two implementation beads consume them: unblock-6xj (error-side wiring) and unblock-29p.25 (Task 02.02 `IssueRef`-typed variants + BREAKING CHANGE commit). No new sub-beads for edge cases; fold anything discovered during implementation into inline decision memos within this GAP or the affected task, not into a new bead.
+
+**Parallel-track guarantees:**
+
+- GAP-14.c is independent of GAP-14 (response-side) and GAP-14.b (ready-set scoping) — any ordering is safe.
+- GAP-14.c's BREAKING CHANGE commit and GAP-14.b's BREAKING CHANGE commit MAY ride the same logical change family OR be landed separately; each carries its own footer text because the pub API surfaces changed are disjoint (`DomainError` variants vs. `DependencyGraph::compute_ready_set`).
+
+**Resolution:** Implementation is split across unblock-6xj (wiring for `InvalidIssueRef` / `CrossRepoAccessDenied` / MCP error mapping) and unblock-29p.25 (Task 02.02 variant shape change + BREAKING CHANGE footer + tests). No additional beads required.
+
+---
+
 ### Summary — Decisions (Resolved)
 
 | # | Decision | Resolution |
@@ -842,6 +904,10 @@ An `API:` body line is INSUFFICIENT for this change — Conventional Commits req
 | D5 | `FieldValue::Date` | **Keep `NaiveDate`, update SPEC** (improvement, not drift) |
 | D6 | Cross-repo response shape | **Uniform `cross_repo_refs: Option<CrossRepoRefs>` per SPEC §11.4.** Retro-fit `ready`, `prime`, `close` via follow-up beads; `dep_cycles` lands with contract from day one. |
 | D6.a | Ready-set source scoping (unblock-eos.4) | **Direction 1 — enforce `(configured_owner, configured_repo)` filter inside `compute_ready_set` at the graph engine.** `pub fn DependencyGraph::compute_ready_set` gains two new required parameters and the function drops cross-repo source issues BEFORE the blocker filter. Direction chosen over (2) tool-layer scrub, (3) fail-fast panic, and (4) soft-warn log. Single chokepoint → every downstream consumer (cached `ready_set`, `ready`, `prime`, `update_status_fields`) inherits §14 Invariant 14(a) for free. BREAKING CHANGE on `unblock-core` pub API — Conventional Commits footer MANDATORY. See GAP-14.b for full migration. |
+| D6.b | Error-side cross-repo variant typing (unblock-eos Decision 1) | **Uniform `IssueRef` typing for cross-repo-aware variants.** `DomainError::{IssueBlocked, CircularDependency, DuplicateDependency}` field types change from bare `u64` to `IssueRef` (§2.7). Display preserved byte-for-byte for `IssueRef::Local(n) → "#n"` so existing tests at `crates/unblock-core/src/errors.rs:215-240` pass unchanged; CrossRepo renders as `"owner/repo#number"`. BREAKING CHANGE on `unblock-core` pub API — Conventional Commits footer MANDATORY on unblock-29p.25 commit. See GAP-14.c and Task 02.02 for the full footer template. |
+| D6.c | Error-side wiring for `InvalidIssueRef` / `CrossRepoAccessDenied` (unblock-eos Decision 2) | **No shape change, wiring only.** `IssueRef::from_str` failures at tool boundary → `InvalidIssueRefSnafu` → 400 → MCP `-32602`. GraphQL `FORBIDDEN` on cross-repo fetch → `CrossRepoAccessDeniedSnafu` → 403 → MCP `-32602` (explicit match arm in `crates/unblock-mcp/src/errors.rs`). Implementation: unblock-6xj. See GAP-14.c and Task 02.02 for the wiring contract. |
+| D6.d | Response-shape universality (unblock-eos Decision 3) | **Documentation-only; frozen.** SPEC §11.4 "Exhaustiveness Rationale" derives the affected set (`ready`, `prime`, `dep_cycles`, `close`) mechanically from §5.6 + response typing. New tools re-derive (a)+(b) in their own spec entries. No new beads; no re-opening. |
+| D6.e | Meta-process (unblock-eos Decision 4) | **No further decomposition.** unblock-eos sub-epic closes with these three spec+plan patches. Only unblock-6xj and unblock-29p.25 remain as implementation beads under this sub-epic. Edge cases discovered during implementation fold into inline decision memos within GAP-14.c / Task 02.02, NOT into new beads. |
 
 ---
 
@@ -859,6 +925,7 @@ Phase 01 is complete when:
 8. **Performance** — `prime` → `ready` → `claim` in under 2 seconds on warm cache
 9. **Zero data loss** — If `unblock-mcp` process dies, all state is in GitHub
 10. **Coverage** — >80% for all 3 crates
-11. **Cross-repo response contract (SPEC §11.4, §14 Invariant 14)** — Both clauses MUST be green:
+11. **Cross-repo contract (SPEC §11.1, §11.4, §14 Invariant 14)** — All three clauses MUST be green:
     - **11(a) — Invariant 14(a) — ready-set source scoping (unblock-eos.4 / D6.a / GAP-14.b).** `DependencyGraph::compute_ready_set` takes `(configured_owner, configured_repo)` and filters cross-repo source issues at §3.3 Filter 3. A property test (§13.3 #7) asserts mixed-repo input → only configured-repo sources in the output. The BREAKING CHANGE footer per CLAUDE.md Pub API discipline has landed on the commit that changed the signature.
     - **11(b) — Invariant 14(b) — response-shape contract (GAP-14 / D6).** `ready`, `prime`, `dep_cycles`, `close` honor the `cross_repo_refs` contract. GAP-14 retro-fits landed. Integration tests cover `Some`/`None` branches for each.
+    - **11(c) — error-side contract (GAP-14.c / unblock-eos Decisions 1 + 2).** `DomainError::{IssueBlocked, CircularDependency, DuplicateDependency}` carry `IssueRef` (unblock-29p.25, Task 02.02) with Display byte-for-byte preservation for `IssueRef::Local`; `InvalidIssueRef` and `CrossRepoAccessDenied` are wired at tool-boundary parse failures and GraphQL `FORBIDDEN` respectively (unblock-6xj); `crates/unblock-mcp/src/errors.rs` explicitly maps 403 → `-32602`. BREAKING CHANGE footer per CLAUDE.md has landed on the unblock-29p.25 commit.

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -1726,6 +1726,8 @@ Each variant has `status_code() → u16`:
 
 The implementation MAY route `IssueRef::Display` through `#[snafu(display(...))]` directly (via `{source}` / `{target}` interpolation that calls `Display`) or pre-format the blocker list with a helper; both satisfy the preservation contract.
 
+**Implementer trap (Debug vs. Display in the existing `IssueBlocked` attribute).** The current `#[snafu(display(...))]` attribute at `crates/unblock-core/src/errors.rs:41` is `"Issue #{number} is blocked by: {blockers:?}"` — the `{blockers:?}` specifier is the Debug formatter, which under `Vec<u64>` renders `[1, 2]` and under `Vec<IssueRef>` renders `[Local(1), Local(2)]` (the `IssueRef` variant names leak into the output). This variant-leaking Debug output satisfies the current substring test at `crates/unblock-core/src/errors.rs:170-174` only because that test asserts `"10"` (the issue number); a future tightening of the test to assert `"#1"` or `"#2"` would silently break. The implementation of this variant MUST replace the `{blockers:?}` Debug attribute with a Display-based renderer — either a format string that interpolates `IssueRef::Display` (e.g. a joined helper) or a pre-formatted blocker list via a helper function that iterates and calls `IssueRef`'s `Display` impl. This is not a contract change; it is an implementer trap flagged so the Display-preservation contract above is not silently violated by leaving the Debug formatter in place.
+
 ### 11.2 Infrastructure errors (`unblock-github/src/errors.rs`)
 
 ```rust
@@ -1844,7 +1846,7 @@ Tools explicitly NOT affected (documented here to pre-empt retro-adoption questi
 
 The `cross_repo_refs: Option<CrossRepoRefs>` field is NOT a universal response contract; it applies to exactly the four tools listed in the affected-tools table above — `ready` (§7.1), `prime` (§7.3), `dep_cycles` (§7.7), `close` (§8.2) — and no others. The axiom that derives the affected set is §5.6 "Cross-repo scope": a tool qualifies iff (a) its response projects node identity down to a bare `u64` AND (b) §5.6 permits cross-repo traversal to touch nodes that would be flattened by that projection. The exempt tools listed above each fail at least one leg of the conjunction for a structural reason documented in their row, not by accident of implementation:
 
-- `show` already emits `QualifiedId` at every level (§2.14), so (a) fails.
+- `show` has bare-`u64` fields in the response projection — `ShowIssue.number` (`crates/unblock-mcp/src/tools/show.rs:73`) and `ShowRelatedIssue.number` (`crates/unblock-mcp/src/tools/show.rs:131`) are `u64`, so leg (a) holds. The exemption is on leg (b): per §5.6 "Cross-repo scope", `show`'s traversal (sub-issues + `trackedByIssues`) is scoped to the configured repo, so no cross-repo node ever reaches the bare-`u64` projection.
 - `stats` emits no issue IDs at all, so (a) fails.
 - `list` / `search` / `claim` / `create` / `update` / `reopen` / `comment` / `init` / `setup` are scoped by §5.6 to the configured repo on the traversal side, so (b) fails.
 - `depends` / `dep_remove` round-trip `IssueRef` strings (never `u64`) on both request and response, so (a) fails.

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -1677,13 +1677,13 @@ compute_expected_status(issue, ready_set) → Status:
 pub enum DomainError {
     IssueNotFound { number: u64 },
     AlreadyClaimed { number: u64, agent: String },
-    IssueBlocked { number: u64, blockers: Vec<u64> },
+    IssueBlocked { number: u64, blockers: Vec<IssueRef> },
     IssueDeferred { number: u64, until: String },
     IssueClosed { number: u64 },
     IssueNotClosed { number: u64 },
     IssueAlreadyOpen { number: u64 },
-    CircularDependency { source: u64, target: u64 },
-    DuplicateDependency { source: u64, target: u64 },
+    CircularDependency { source: IssueRef, target: IssueRef },
+    DuplicateDependency { source: IssueRef, target: IssueRef },
     FieldNotFound { name: String },
     Validation { message: String },
     InvalidIssueRef { input: String },
@@ -1709,7 +1709,22 @@ Each variant has `status_code() → u16`:
 | `InvalidIssueRef` | 400 |
 | `CrossRepoAccessDenied` | 403 |
 
-`InvalidIssueRef`, `CrossRepoAccessDenied`, and the cross-repo-aware forms of `CircularDependency`/`DuplicateDependency` are the **error-side** half of the cross-repo contract. The successful-response half — how responses disclose cross-repo nodes that were flattened to local numbers — is specified in §11.4.
+`InvalidIssueRef`, `CrossRepoAccessDenied`, and the cross-repo-aware forms of `CircularDependency`/`DuplicateDependency`/`IssueBlocked` are the **error-side** half of the cross-repo contract. The successful-response half — how responses disclose cross-repo nodes that were flattened to local numbers — is specified in §11.4.
+
+**Cross-repo-aware variant typing — Exhaustiveness Rationale (Decision 1, 2026-04-17).**
+
+`IssueBlocked.blockers`, `CircularDependency.{source, target}`, and `DuplicateDependency.{source, target}` use `IssueRef` (§2.7) rather than bare `u64`. GitHub's native sub-issue / `trackedByIssues` / `addIssueDependency` graph has been cross-repo-aware since GA in 2024: a cross-repo blocker, a cross-repo cycle participant, and a cross-repo duplicate-edge endpoint are all observable via the API and reachable from any configured repository. Bare `u64` cannot disambiguate `#42` in `configured/repo` from `#42` in `other/repo`; an error referring to the latter would silently alias to the former and mislead the agent. `IssueRef` is the unique fully-qualified-or-local carrier already used by §8.4 `depends`, §8.5 `dep_remove`, §8.3 `create.blocked_by`, and §11.4 `cross_repo_refs::omitted` — keeping §11.1 consistent with §11.4 is the closure property of the cross-repo contract. This is a BREAKING CHANGE in the `unblock-core` pub API (`DomainError` variant field types change); the implementing commit MUST carry a `BREAKING CHANGE:` footer per CLAUDE.md "Pub API Change Tracking" discipline. This rationale closes the question: no further sub-beads are needed for per-variant re-evaluation; new `DomainError` variants that carry issue references MUST default to `IssueRef` typing by the same argument.
+
+**Display byte-for-byte preservation (local-only case).**
+
+`IssueRef::Display` MUST render `IssueRef::Local(n)` as exactly `"#n"` (e.g. `Local(42)` → `"#42"`) so every existing `Display` snapshot at `crates/unblock-core/src/errors.rs:215-240` (and equivalent assertions elsewhere) continues to pass byte-for-byte without edits. `IssueRef::CrossRepo { owner, repo, number }` renders as `"owner/repo#number"` (e.g. `"acme/widgets#42"`), matching `QualifiedId::Display` so agents can copy-paste error text into follow-up tool calls (e.g. `show acme/widgets#42`). Concretely:
+
+- `CircularDependency { source: IssueRef::Local(1), target: IssueRef::Local(2) }` → `"Circular dependency: adding #1 → #2 creates cycle"` (unchanged from today).
+- `DuplicateDependency { source: IssueRef::Local(4), target: IssueRef::Local(5) }` → `"Blocking relationship already exists: #4 → #5"` (unchanged from today).
+- `IssueBlocked { number: 10, blockers: vec![IssueRef::Local(1), IssueRef::Local(2)] }` → MUST still include the substrings `"10"`, `"1"`, and `"2"` (the existing test at `errors.rs:170-174` asserts only substring containment, so `"Issue #10 is blocked by: [#1, #2]"` and `"Issue #10 is blocked by: #1, #2"` are both acceptable formats; the implementation chooses one and commits to it with a test).
+- Cross-repo example: `IssueBlocked { number: 10, blockers: vec![IssueRef::CrossRepo { owner: "acme".into(), repo: "widgets".into(), number: 1 }] }` renders with `"acme/widgets#1"` in the blocker list.
+
+The implementation MAY route `IssueRef::Display` through `#[snafu(display(...))]` directly (via `{source}` / `{target}` interpolation that calls `Display`) or pre-format the blocker list with a helper; both satisfy the preservation contract.
 
 ### 11.2 Infrastructure errors (`unblock-github/src/errors.rs`)
 
@@ -1754,7 +1769,7 @@ Propagation chain: `DomainError` (core) → `Error` (github) → `McpError` (mcp
 
 ### 11.4 Cross-Repo Response Contract
 
-The graph engine nodes are `QualifiedId { owner, repo, number }` (§2.1). Many response types project cross-repo nodes down to bare `u64` issue numbers scoped to the configured repository. When a computation touches one or more `QualifiedId` nodes whose `(owner, repo)` differs from the configured repo AND those nodes are dropped from the bare-`u64` projection of the response, the response MUST surface them in an explicit `cross_repo_refs` field. This is the dual of the error-side contract in §11.1: §11.1 governs how cross-repo failures are reported (`InvalidIssueRef`, `CrossRepoAccessDenied`, cross-repo-aware `CircularDependency`/`DuplicateDependency`); §11.4 governs how successful responses disclose cross-repo nodes that were flattened to local numbers.
+The graph engine nodes are `QualifiedId { owner, repo, number }` (§2.1). Many response types project cross-repo nodes down to bare `u64` issue numbers scoped to the configured repository. When a computation touches one or more `QualifiedId` nodes whose `(owner, repo)` differs from the configured repo AND those nodes are dropped from the bare-`u64` projection of the response, the response MUST surface them in an explicit `cross_repo_refs` field. This is the dual of the error-side contract in §11.1: §11.1 governs how cross-repo failures are reported (`InvalidIssueRef`, `CrossRepoAccessDenied`, and the `IssueRef`-typed forms of `CircularDependency` / `DuplicateDependency` / `IssueBlocked`); §11.4 governs how successful responses disclose cross-repo nodes that were flattened to local numbers.
 
 **Shared type** (`unblock-core/src/types.rs`):
 
@@ -1824,6 +1839,17 @@ Tools explicitly NOT affected (documented here to pre-empt retro-adoption questi
 | `depends` / `dep_remove` (§8.4, §8.5) | Request and response use `IssueRef` strings; no `u64` projection |
 | `comment` (§8.8) | Boolean response only |
 | `init` / `setup` (§8.9, §8.10) | Project-level, no issue references |
+
+**Exhaustiveness Rationale — response-shape universality (Decision 3, 2026-04-17).**
+
+The `cross_repo_refs: Option<CrossRepoRefs>` field is NOT a universal response contract; it applies to exactly the four tools listed in the affected-tools table above — `ready` (§7.1), `prime` (§7.3), `dep_cycles` (§7.7), `close` (§8.2) — and no others. The axiom that derives the affected set is §5.6 "Cross-repo scope": a tool qualifies iff (a) its response projects node identity down to a bare `u64` AND (b) §5.6 permits cross-repo traversal to touch nodes that would be flattened by that projection. The exempt tools listed above each fail at least one leg of the conjunction for a structural reason documented in their row, not by accident of implementation:
+
+- `show` already emits `QualifiedId` at every level (§2.14), so (a) fails.
+- `stats` emits no issue IDs at all, so (a) fails.
+- `list` / `search` / `claim` / `create` / `update` / `reopen` / `comment` / `init` / `setup` are scoped by §5.6 to the configured repo on the traversal side, so (b) fails.
+- `depends` / `dep_remove` round-trip `IssueRef` strings (never `u64`) on both request and response, so (a) fails.
+
+Because the derivation is mechanical from §5.6 + the §7/§8 response typing, future tools inherit the exemption rule automatically: a new tool requires `cross_repo_refs` iff it independently satisfies both (a) and (b). No standalone bead is needed to audit tool-by-tool; the test is applied as tools are specified. This rationale closes the question raised during unblock-eos arbitration (2026-04-17) — the four-tool set is complete and frozen for Phase 01. Tools added in later phases re-evaluate (a)+(b) on their own spec entries and do NOT re-open this decision.
 
 **Determinism.** `omitted` MUST be sorted lexicographically by `QualifiedId::Display` so identical graph state produces identical responses (per Invariant 5, §14).
 


### PR DESCRIPTION
…nblock-eos)

Sub-epic unblock-eos Phase 01 closure — patches-only, no code.

§11.1 (DomainError):
- CircularDependency.{source,target}: u64 → IssueRef
- DuplicateDependency.{source,target}: u64 → IssueRef
- IssueBlocked.blockers: Vec<u64> → Vec<IssueRef>
- Exhaustiveness Rationale (Decision 1, 2026-04-17) documents cross-repo trackedByIssues/addIssueDependency semantics and freezes IssueRef as the default typing for any new DomainError variant carrying issue refs.
- Display byte-for-byte preservation contract pinned against existing tests at crates/unblock-core/src/errors.rs:215-240 (Local(n) → "#n"; CrossRepo → "owner/repo#n").

§11.4 (Cross-Repo Response Contract):
- Exhaustiveness Rationale (Decision 3, 2026-04-17) derives the four affected tools (ready, prime, dep_cycles, close) from §5.6 + §7/§8 response typing; future tools re-evaluate (a)+(b) on their own spec entries without re-opening this decision.

docs/plans/01-plan-mcp-foundation.md:
- Task 02.02 expanded with Cross-repo-aware variant typing, BREAKING CHANGE discipline (verbatim footer template), Display preservation, error-side wiring subsections.
- GAP-14.c consolidates Decisions 1-4, documents parallel-track guarantees, lists downstream beads (unblock-6xj + unblock-29p.25), states no further decomposition.
- D6.b / D6.c / D6.d / D6.e rows added to Decisions Resolved.
- Definition of Done clause 11 expanded with 11(c) for error-side cross-repo.

Downstream: unblock-6xj (InvalidIssueRef / CrossRepoAccessDenied wiring) and unblock-29p.25 (Option A typing impl with BREAKING CHANGE: footer) consume these patches.

Ref: bd show unblock-eos; research findings in bd comments unblock-eos.