### PR TITLE
feat(core)!: migrate DomainError variants to IssueRef for cross-repo …

### DIFF
--- a/crates/unblock-core/src/errors.rs
+++ b/crates/unblock-core/src/errors.rs
@@ -10,6 +10,23 @@
 
 use snafu::prelude::*;
 
+use crate::types::IssueRef;
+
+/// Renders a list of [`IssueRef`] via their `Display` impl for use in
+/// `#[snafu(display(...))]` attributes.
+///
+/// Joins each ref with a comma + space so the output reads like
+/// `"#1, #2, acme/widgets#3"` — matching the `Display`-based rendering
+/// contract at SPEC §11.1 and avoiding the variant-leaking `Debug`
+/// formatter (`[Local(1), Local(2)]`).
+fn render_blockers(blockers: &[IssueRef]) -> String {
+    blockers
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Domain-level errors for the unblock system.
 ///
 /// Each variant represents a specific business-rule violation or lookup failure.
@@ -38,12 +55,20 @@ pub enum DomainError {
     },
 
     /// The issue has unresolved blocking dependencies.
-    #[snafu(display("Issue #{number} is blocked by: {blockers:?}"))]
+    ///
+    /// `blockers` carries [`IssueRef`] values so cross-repo blockers
+    /// (which are observable via GitHub's native `trackedByIssues`
+    /// connection) render with `owner/repo#n` qualification in the
+    /// error message, rather than aliasing to a same-numbered local
+    /// issue. See SPEC §11.1 Decision 1 (2026-04-17).
+    #[snafu(display("Issue #{number} is blocked by: {}", render_blockers(blockers)))]
     IssueBlocked {
         /// The issue number.
         number: u64,
-        /// Issue numbers that block this issue.
-        blockers: Vec<u64>,
+        /// Issue references that block this issue. Each entry is an
+        /// [`IssueRef`] so cross-repo blockers are disambiguated from
+        /// same-numbered local issues in the rendered message.
+        blockers: Vec<IssueRef>,
     },
 
     /// The issue is deferred until a future date.
@@ -77,23 +102,38 @@ pub enum DomainError {
     },
 
     /// Adding the dependency would create a cycle in the graph.
-    #[snafu(display("Circular dependency: adding #{source} → #{target} creates cycle"))]
+    ///
+    /// `source` / `target` carry [`IssueRef`] so cross-repo participants
+    /// render with `owner/repo#n` qualification. The literal `#` prefix
+    /// is intentionally absent from the format string because
+    /// `IssueRef::Local(n)` renders as `#n` via its own `Display` impl —
+    /// adding the prefix here would produce `##n` in the output. See
+    /// SPEC §11.1 Decision 1 (2026-04-17) and the byte-for-byte
+    /// preservation contract for the `Local`-only case.
+    #[snafu(display("Circular dependency: adding {source} → {target} creates cycle"))]
     CircularDependency {
-        /// The source issue number of the proposed edge.
+        /// The source issue reference of the proposed edge.
         #[snafu(source(false))]
-        source: u64,
-        /// The target issue number of the proposed edge.
-        target: u64,
+        source: IssueRef,
+        /// The target issue reference of the proposed edge.
+        target: IssueRef,
     },
 
     /// The blocking relationship already exists.
-    #[snafu(display("Blocking relationship already exists: #{source} → #{target}"))]
+    ///
+    /// `source` / `target` carry [`IssueRef`] so cross-repo participants
+    /// render with `owner/repo#n` qualification. The literal `#` prefix
+    /// is intentionally absent from the format string because
+    /// `IssueRef::Local(n)` renders as `#n` via its own `Display` impl —
+    /// adding the prefix here would produce `##n` in the output. See
+    /// SPEC §11.1 Decision 1 (2026-04-17).
+    #[snafu(display("Blocking relationship already exists: {source} → {target}"))]
     DuplicateDependency {
-        /// The source issue number.
+        /// The source issue reference.
         #[snafu(source(false))]
-        source: u64,
-        /// The target issue number.
-        target: u64,
+        source: IssueRef,
+        /// The target issue reference.
+        target: IssueRef,
     },
 
     /// A referenced field does not exist.
@@ -165,7 +205,7 @@ mod tests {
     fn issue_blocked_display_and_status() {
         let err = IssueBlockedSnafu {
             number: 10_u64,
-            blockers: vec![1_u64, 2],
+            blockers: vec![IssueRef::Local(1), IssueRef::Local(2)],
         }
         .build();
         let msg = err.to_string();
@@ -215,8 +255,8 @@ mod tests {
     #[test]
     fn circular_dependency_display_and_status() {
         let err = CircularDependencySnafu {
-            source: 1_u64,
-            target: 2_u64,
+            source: IssueRef::Local(1),
+            target: IssueRef::Local(2),
         }
         .build();
         let msg = err.to_string();
@@ -227,15 +267,132 @@ mod tests {
     }
 
     #[test]
+    fn circular_dependency_display_byte_for_byte_local_only() {
+        // SPEC §11.1:1722 locks the Local-only Display form:
+        // "Circular dependency: adding #1 → #2 creates cycle".
+        // This guards against format-string drift now that `IssueRef`
+        // owns the `#` prefix.
+        let err = CircularDependencySnafu {
+            source: IssueRef::Local(1),
+            target: IssueRef::Local(2),
+        }
+        .build();
+        assert_eq!(
+            err.to_string(),
+            "Circular dependency: adding #1 → #2 creates cycle"
+        );
+    }
+
+    #[test]
+    fn circular_dependency_cross_repo_display() {
+        // Cross-repo source; local target. Verifies `owner/repo#n` is
+        // surfaced in the error message (plan Task 02.02 contract).
+        let err = CircularDependencySnafu {
+            source: IssueRef::CrossRepo {
+                owner: "acme".to_owned(),
+                repo: "widgets".to_owned(),
+                number: 1,
+            },
+            target: IssueRef::Local(2),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("acme/widgets#1"),
+            "expected qualified source ref in message, got: {msg}"
+        );
+        assert!(msg.contains("#2"), "expected local target ref, got: {msg}");
+        assert!(msg.contains("cycle"));
+        assert_eq!(err.status_code(), 422);
+    }
+
+    #[test]
     fn duplicate_dependency_display_and_status() {
         let err = DuplicateDependencySnafu {
-            source: 4_u64,
-            target: 5_u64,
+            source: IssueRef::Local(4),
+            target: IssueRef::Local(5),
         }
         .build();
         let msg = err.to_string();
         assert!(msg.contains('4'));
         assert!(msg.contains('5'));
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn duplicate_dependency_display_byte_for_byte_local_only() {
+        // SPEC §11.1:1723 locks the Local-only Display form:
+        // "Blocking relationship already exists: #4 → #5".
+        let err = DuplicateDependencySnafu {
+            source: IssueRef::Local(4),
+            target: IssueRef::Local(5),
+        }
+        .build();
+        assert_eq!(
+            err.to_string(),
+            "Blocking relationship already exists: #4 → #5"
+        );
+    }
+
+    #[test]
+    fn duplicate_dependency_cross_repo_display() {
+        // Cross-repo source AND cross-repo target (both in the same
+        // foreign repo — the shape produced by
+        // `add_blocked_by_refs` cross-repo source arm).
+        let err = DuplicateDependencySnafu {
+            source: IssueRef::CrossRepo {
+                owner: "acme".to_owned(),
+                repo: "widgets".to_owned(),
+                number: 4,
+            },
+            target: IssueRef::CrossRepo {
+                owner: "acme".to_owned(),
+                repo: "widgets".to_owned(),
+                number: 5,
+            },
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("acme/widgets#4"),
+            "expected qualified source ref in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("acme/widgets#5"),
+            "expected qualified target ref in message, got: {msg}"
+        );
+        assert_eq!(err.status_code(), 409);
+    }
+
+    #[test]
+    fn issue_blocked_cross_repo_display() {
+        // Verifies the `render_blockers` Display helper replaces the
+        // legacy `{blockers:?}` Debug formatter: variant names must NOT
+        // leak, and each cross-repo blocker must carry its
+        // `owner/repo#n` qualification.
+        let err = IssueBlockedSnafu {
+            number: 10_u64,
+            blockers: vec![
+                IssueRef::CrossRepo {
+                    owner: "acme".to_owned(),
+                    repo: "widgets".to_owned(),
+                    number: 1,
+                },
+                IssueRef::Local(2),
+            ],
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("10"), "expected issue number, got: {msg}");
+        assert!(
+            msg.contains("acme/widgets#1"),
+            "expected qualified cross-repo blocker, got: {msg}"
+        );
+        assert!(msg.contains("#2"), "expected local blocker ref, got: {msg}");
+        assert!(
+            !msg.contains("Local(") && !msg.contains("CrossRepo"),
+            "Debug-formatted variant names must not leak into Display, got: {msg}"
+        );
         assert_eq!(err.status_code(), 409);
     }
 
@@ -273,7 +430,7 @@ mod tests {
             .build(),
             IssueBlockedSnafu {
                 number: 1_u64,
-                blockers: vec![2_u64],
+                blockers: vec![IssueRef::Local(2)],
             }
             .build(),
             IssueDeferredSnafu {
@@ -285,13 +442,13 @@ mod tests {
             IssueNotClosedSnafu { number: 1_u64 }.build(),
             IssueAlreadyOpenSnafu { number: 1_u64 }.build(),
             CircularDependencySnafu {
-                source: 1_u64,
-                target: 2_u64,
+                source: IssueRef::Local(1),
+                target: IssueRef::Local(2),
             }
             .build(),
             DuplicateDependencySnafu {
-                source: 1_u64,
-                target: 2_u64,
+                source: IssueRef::Local(1),
+                target: IssueRef::Local(2),
             }
             .build(),
             FieldNotFoundSnafu {

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -903,8 +903,8 @@ impl GitHubClient {
 
         if already_blocked {
             return Err(unblock_core::errors::DuplicateDependencySnafu {
-                source: issue_number,
-                target: blocked_by_number,
+                source: unblock_core::types::IssueRef::Local(issue_number),
+                target: unblock_core::types::IssueRef::Local(blocked_by_number),
             }
             .build()
             .into());
@@ -1501,15 +1501,21 @@ impl GitHubClient {
                 if let Some(n) = blocker_number_in_source_repo
                     && source_issue.blocked_by.iter().any(|r| r.number == n)
                 {
-                    // TODO(unblock-29p.25): DuplicateDependencySnafu's `source`
-                    // field is `u64` and loses the cross-repo source's
-                    // owner/repo context — the error message is ambiguous
-                    // with a same-numbered local issue. Tracked as a spec
-                    // §11.1 revision (extend CircularDependency /
-                    // DuplicateDependency with cross-repo context).
+                    // Both source and duplicate target live in the
+                    // source's `owner/repo` (the duplicate pre-check
+                    // above only fires when the blocker matches source's
+                    // own repo — see comment on
+                    // `blocker_number_in_source_repo`), so the error
+                    // surfaces both endpoints qualified with
+                    // `owner/repo#n`. Per SPEC §11.1 Decision 1 this
+                    // disambiguates from same-numbered local issues.
                     return Err(unblock_core::errors::DuplicateDependencySnafu {
-                        source: *source_number,
-                        target: n,
+                        source: source.clone(),
+                        target: unblock_core::types::IssueRef::CrossRepo {
+                            owner: source_owner.clone(),
+                            repo: source_repo.clone(),
+                            number: n,
+                        },
                     }
                     .build()
                     .into());

--- a/crates/unblock-mcp/src/errors.rs
+++ b/crates/unblock-mcp/src/errors.rs
@@ -48,7 +48,15 @@ pub enum BootstrapError {
     ))]
     ClientInit {
         /// The underlying GitHub client error.
-        source: unblock_github::errors::Error,
+        ///
+        /// Boxed to keep `BootstrapError` compact. `unblock_github::errors::Error`
+        /// transitively wraps `DomainError`, which now carries `IssueRef` fields
+        /// (SPEC §11.1 Decision 1, 2026-04-17). Without boxing, `Result<(), BootstrapError>`
+        /// at `main()` exceeds the `clippy::result_large_err` threshold. This mirrors
+        /// the pattern already used by the `Transport` variant for
+        /// `rmcp::service::ServerInitializeError`.
+        #[snafu(source(from(unblock_github::errors::Error, Box::new)))]
+        source: Box<unblock_github::errors::Error>,
     },
 
     /// Failed to start the MCP stdio transport.

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1313,8 +1313,8 @@ impl UnblockServer {
                 {
                     return Err(crate::errors::github_error_to_mcp(
                         CircularDependencySnafu {
-                            source: *source_number,
-                            target: *target_number,
+                            source: unblock_core::types::IssueRef::Local(*source_number),
+                            target: unblock_core::types::IssueRef::Local(*target_number),
                         }
                         .build()
                         .into(),

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use unblock_core::errors::{
     AlreadyClaimedSnafu, IssueBlockedSnafu, IssueClosedSnafu, IssueDeferredSnafu, ValidationSnafu,
 };
-use unblock_core::types::{IssueState, RelatedIssue, Status};
+use unblock_core::types::{IssueRef, IssueState, RelatedIssue, Status};
 
 /// Input parameters for the `claim` MCP tool.
 ///
@@ -87,11 +87,20 @@ pub(crate) fn validate_claimable(
     }
 
     // Check 2: blocked (filter to open blockers).
-    let open_blockers: Vec<u64> = candidate
+    //
+    // GitHub's native `trackedByIssues` connection — the source of
+    // `candidate.blocked_by` — only surfaces blockers in the same
+    // `owner/repo` as the issue being claimed (see SPEC §8.2 / mutations
+    // `add_blocked_by_refs` cross-repo commentary). Since `claim`
+    // operates on a local issue, all blockers it observes live in the
+    // configured repo; we wrap each as `IssueRef::Local(r.number)`.
+    // If `RelatedIssue` is later extended to carry `owner/repo`, this
+    // mapping trivially evolves to produce `IssueRef::CrossRepo`.
+    let open_blockers: Vec<IssueRef> = candidate
         .blocked_by
         .iter()
         .filter(|r| r.state == IssueState::Open)
-        .map(|r| r.number)
+        .map(|r| IssueRef::Local(r.number))
         .collect();
 
     if !open_blockers.is_empty() {


### PR DESCRIPTION
…awareness

Replaces bare `u64` with `IssueRef` in three `DomainError` variants so error messages disambiguate cross-repo issues from same-numbered local ones. Removes the literal `#` prefix from Circular/Duplicate display strings because `IssueRef::Local` now owns the prefix via its own `Display` impl; swaps the `IssueBlocked` `{blockers:?}` Debug formatter for a `render_blockers` helper so variant names no longer leak.

Touches unblock-github (add_blocked_by local + add_blocked_by_refs cross-repo source arm, closing the TODO at mutations.rs:1504) and unblock-mcp (depends CircularDependency site, claim IssueBlocked collection, and boxing ClientInit source to keep BootstrapError compact past the clippy::result_large_err threshold that the wider IssueRef payload would otherwise trip — mirroring the existing Transport variant's Box<ServerInitializeError> pattern).

Adds six new unit tests: three cross-repo Display assertions (one per migrated variant) and two byte-for-byte Local-only Display assertions lifted from SPEC §11.1:1722-1723 to lock the format string against future drift.

BREAKING CHANGE: DomainError::{IssueBlocked, CircularDependency, DuplicateDependency} variants now carry `IssueRef` instead of bare `u64` for cross-repo-aware error reporting. Callers constructing these variants via snafu context selectors (e.g. IssueBlockedSnafu, CircularDependencySnafu, DuplicateDependencySnafu) must pass IssueRef values. Display output for the Local(n) case is preserved byte-for-byte; CrossRepo renders as "owner/repo#number". See SPEC §11.1 Decision 1 / §11.4 cross-repo contract closure.