### PR TITLE
 feat(core): add InvalidIssueRef and CrossRepoAccessDenied DomainError variants

### DIFF
--- a/crates/unblock-core/src/errors.rs
+++ b/crates/unblock-core/src/errors.rs
@@ -4,9 +4,10 @@
 //! Each variant carries the relevant context and maps to an HTTP status code
 //! via `DomainError::status_code`.
 //!
-//! Variants: `IssueNotFound`, `AlreadyClaimed`, `IssueBlocked`, `IssueDeferred`,
+//! 13 variants: `IssueNotFound`, `AlreadyClaimed`, `IssueBlocked`, `IssueDeferred`,
 //! `IssueClosed`, `IssueNotClosed`, `IssueAlreadyOpen`, `CircularDependency`,
-//! `DuplicateDependency`, `FieldNotFound`, `Validation`.
+//! `DuplicateDependency`, `FieldNotFound`, `Validation`, `InvalidIssueRef`,
+//! `CrossRepoAccessDenied`.
 
 use snafu::prelude::*;
 
@@ -149,6 +150,33 @@ pub enum DomainError {
         /// Description of the validation failure.
         message: String,
     },
+
+    /// An issue reference string failed to parse into an [`IssueRef`].
+    ///
+    /// Emitted whenever `IssueRef::from_str` fails on tool input at the
+    /// MCP tool boundary (`show`, `depends`, `dep_remove`,
+    /// `create.blocked_by`). Carries the raw user-provided string so
+    /// agents can see exactly what they sent. Per SPEC §11.1 this maps
+    /// to HTTP 400.
+    #[snafu(display("Invalid issue reference: '{input}'"))]
+    InvalidIssueRef {
+        /// The raw user input that failed to parse as an [`IssueRef`].
+        input: String,
+    },
+
+    /// The configured token lacks access to a referenced cross-repo issue.
+    ///
+    /// Emitted when a GraphQL fetch against a cross-repo node returns
+    /// `FORBIDDEN` (or equivalent HTTP 403). Carries the target
+    /// `owner/repo` so the agent can surface which cross-repo access
+    /// the token is missing. Per SPEC §11.1 this maps to HTTP 403.
+    #[snafu(display("Access denied to cross-repo issue {owner}/{repo}"))]
+    CrossRepoAccessDenied {
+        /// The owner of the cross-repo the token cannot access.
+        owner: String,
+        /// The repository name of the cross-repo the token cannot access.
+        repo: String,
+    },
 }
 
 impl DomainError {
@@ -162,7 +190,9 @@ impl DomainError {
             // 404 Not Found
             Self::IssueNotFound { .. } | Self::FieldNotFound { .. } => 404,
             // 400 Bad Request
-            Self::Validation { .. } => 400,
+            Self::Validation { .. } | Self::InvalidIssueRef { .. } => 400,
+            // 403 Forbidden — cross-repo access denial
+            Self::CrossRepoAccessDenied { .. } => 403,
             // 422 Unprocessable Entity
             Self::CircularDependency { .. } => 422,
             // 409 Conflict
@@ -419,6 +449,46 @@ mod tests {
     }
 
     #[test]
+    fn invalid_issue_ref_display_and_status() {
+        // SPEC §11.1 — `InvalidIssueRef { input }` surfaces the raw user
+        // input in the Display output so agents can see exactly what
+        // they sent, and maps to HTTP 400.
+        let err = InvalidIssueRefSnafu {
+            input: "not-a-ref".to_owned(),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not-a-ref"),
+            "expected raw input in message, got: {msg}"
+        );
+        assert_eq!(err.status_code(), 400);
+    }
+
+    #[test]
+    fn cross_repo_access_denied_display_and_status() {
+        // SPEC §11.1 — `CrossRepoAccessDenied { owner, repo }` surfaces
+        // the target `owner/repo` so agents know which cross-repo their
+        // token cannot access. Maps to HTTP 403 (first variant to claim
+        // this status code in the domain-error bucket).
+        let err = CrossRepoAccessDeniedSnafu {
+            owner: "acme".to_owned(),
+            repo: "widgets".to_owned(),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("acme"),
+            "expected owner in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("widgets"),
+            "expected repo in message, got: {msg}"
+        );
+        assert_eq!(err.status_code(), 403);
+    }
+
+    #[test]
     fn all_variants_implement_error_trait() {
         // Verify DomainError implements std::error::Error by using it as &dyn Error
         let errors: Vec<DomainError> = vec![
@@ -457,6 +527,15 @@ mod tests {
             .build(),
             ValidationSnafu {
                 message: "bad".to_owned(),
+            }
+            .build(),
+            InvalidIssueRefSnafu {
+                input: "bad-ref".to_owned(),
+            }
+            .build(),
+            CrossRepoAccessDeniedSnafu {
+                owner: "acme".to_owned(),
+                repo: "widgets".to_owned(),
             }
             .build(),
         ];

--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -47,6 +47,31 @@ pub enum Error {
         errors: Vec<String>,
     },
 
+    /// A GitHub GraphQL response containing at least one error with
+    /// `type == "FORBIDDEN"`.
+    ///
+    /// The GraphQL spec (and GitHub's implementation) returns HTTP 200
+    /// with a typed `errors` array for permission-denied cases — the
+    /// `type` field is the wire-safe signal rather than the free-text
+    /// `message`. The GraphQL-level reducer in `graphql_with_features`
+    /// on [`crate::client::GitHubClient`] inspects `type` BEFORE
+    /// reducing to messages (per SPEC §11.1 wiring, user decision
+    /// 2026-04-17) and emits this variant when any error carries
+    /// `FORBIDDEN`. Callers that know a cross-repo `owner/repo` context
+    /// (e.g. `fetch_issue_in_repo`, `resolve_issue_ref` cross-repo arm)
+    /// upgrade this variant to [`DomainError::CrossRepoAccessDenied`].
+    ///
+    /// [`DomainError::CrossRepoAccessDenied`]:
+    ///     unblock_core::errors::DomainError::CrossRepoAccessDenied
+    #[snafu(display("GitHub GraphQL FORBIDDEN: {}", errors.join("; ")))]
+    GitHubGraphQLForbidden {
+        /// Messages from the GraphQL errors whose `type` was
+        /// `FORBIDDEN`. Non-FORBIDDEN messages from the same response
+        /// are discarded; the classifier treats any FORBIDDEN as
+        /// authoritative.
+        errors: Vec<String>,
+    },
+
     /// Network or connection failure when reaching GitHub.
     #[snafu(display("Cannot connect to GitHub: {source}"))]
     GitHubUnavailable {
@@ -120,6 +145,12 @@ impl Error {
             Self::Domain { source } => source.status_code(),
             Self::GitHubApi { status, .. } => *status,
             Self::GitHubGraphQL { .. } => 422,
+            // 403 Forbidden — GraphQL FORBIDDEN-typed error before
+            // cross-repo classification upgrades it to DomainError
+            // CrossRepoAccessDenied. An un-upgraded variant still
+            // reaches the MCP layer with the right status-code bucket
+            // so `github_error_to_mcp` maps it to INVALID_PARAMS.
+            Self::GitHubGraphQLForbidden { .. } => 403,
             Self::GitHubUnavailable { .. } | Self::CircuitBreakerOpen { .. } => 503,
             Self::RateLimited { .. } => 429,
             Self::ProjectNotConfigured => 412,
@@ -191,6 +222,30 @@ mod tests {
         }
         .build();
         assert_eq!(err.to_string(), "GitHub GraphQL error: ");
+    }
+
+    #[test]
+    fn github_graphql_forbidden_display_and_status() {
+        // The `GitHubGraphQLForbidden` variant is emitted by the
+        // GraphQL reducer when any errors[i].type == "FORBIDDEN" (per
+        // SPEC §11.1 wiring, user decision 2026-04-17). Display embeds
+        // the FORBIDDEN messages; status_code is 403 so the un-upgraded
+        // variant still reaches `github_error_to_mcp` with the right
+        // bucket (INVALID_PARAMS).
+        let err = GitHubGraphQLForbiddenSnafu {
+            errors: vec!["Resource not accessible by integration".to_owned()],
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(
+            msg.starts_with("GitHub GraphQL FORBIDDEN: "),
+            "unexpected display: {msg}"
+        );
+        assert!(
+            msg.contains("Resource not accessible by integration"),
+            "display must include FORBIDDEN messages: {msg}"
+        );
+        assert_eq!(err.status_code(), 403);
     }
 
     #[tokio::test]
@@ -272,6 +327,10 @@ mod tests {
             .build(),
             GitHubGraphQLSnafu {
                 errors: vec!["err".to_owned()],
+            }
+            .build(),
+            GitHubGraphQLForbiddenSnafu {
+                errors: vec!["Resource not accessible by integration".to_owned()],
             }
             .build(),
             RateLimitedSnafu {

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -227,7 +227,19 @@ impl GitHubClient {
             "number": number.cast_signed(),
         });
 
-        let response = self.graphql(FETCH_ISSUE_QUERY, variables).await?;
+        // Per SPEC §11.1 / plan Task 02.02 "Error-side wiring", a 403
+        // (HTTP) or a GraphQL FORBIDDEN response on a cross-repo fetch
+        // MUST be upgraded to `DomainError::CrossRepoAccessDenied`.
+        // Local fetches (owner/repo == configured) stay as the
+        // underlying infrastructure error — `CrossRepoAccessDenied`
+        // is cross-repo-semantic by name.
+        let response = match self.graphql(FETCH_ISSUE_QUERY, variables).await {
+            Ok(v) => v,
+            Err(err) if owner != self.owner() || repo != self.repo() => {
+                return Err(classify_cross_repo_fetch(err, owner, repo));
+            }
+            Err(err) => return Err(err),
+        };
 
         let issue_value = &response["data"]["repository"]["issue"];
 
@@ -436,17 +448,47 @@ impl GitHubClient {
             .context(errors::GitHubUnavailableSnafu)?;
 
         // Check for GraphQL-level errors.
+        //
+        // Inspect each error's `type` BEFORE reducing to message
+        // strings: GitHub's GraphQL API returns HTTP 200 with a typed
+        // `errors` array for permission-denied cases, and the `type`
+        // field (e.g. `"FORBIDDEN"`) is the wire-safe signal rather
+        // than the free-text `message`. Per SPEC §11.1 wiring (user
+        // decision 2026-04-17 for unblock-6xj), we partition the
+        // errors into FORBIDDEN-typed and other-typed before emitting
+        // the appropriate variant, so cross-repo classifiers can
+        // upgrade FORBIDDEN to `DomainError::CrossRepoAccessDenied`
+        // without substring-sniffing messages.
         if let Some(arr) = json
             .get("errors")
             .and_then(serde_json::Value::as_array)
             .filter(|a| !a.is_empty())
         {
-            let messages: Vec<String> = arr
-                .iter()
-                .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
-                .map(String::from)
-                .collect();
-            return Err(errors::GitHubGraphQLSnafu { errors: messages }.build());
+            let mut forbidden_messages: Vec<String> = Vec::new();
+            let mut other_messages: Vec<String> = Vec::new();
+            for err in arr {
+                let message = err
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or_default()
+                    .to_owned();
+                let ty = err.get("type").and_then(|t| t.as_str()).unwrap_or_default();
+                if ty == "FORBIDDEN" {
+                    forbidden_messages.push(message);
+                } else if !message.is_empty() {
+                    other_messages.push(message);
+                }
+            }
+            if !forbidden_messages.is_empty() {
+                return Err(errors::GitHubGraphQLForbiddenSnafu {
+                    errors: forbidden_messages,
+                }
+                .build());
+            }
+            return Err(errors::GitHubGraphQLSnafu {
+                errors: other_messages,
+            }
+            .build());
         }
 
         Ok(json)
@@ -494,6 +536,39 @@ pub(crate) async fn check_rest_response(
     }
 
     Ok(response)
+}
+
+/// Upgrades a cross-repo fetch error to
+/// [`DomainError::CrossRepoAccessDenied`] when the underlying failure
+/// is an HTTP 403 ([`Error::GitHubApi`]) or a GraphQL FORBIDDEN
+/// ([`Error::GitHubGraphQLForbidden`]).
+///
+/// Other errors pass through unchanged. Per SPEC §11.1 / plan Task
+/// 02.02 "Error-side wiring" this is the cross-repo-only classifier:
+/// local-repo 403s stay as [`Error::GitHubApi`] because
+/// `CrossRepoAccessDenied` is cross-repo-semantic by name.
+///
+/// [`DomainError::CrossRepoAccessDenied`]:
+///     unblock_core::errors::DomainError::CrossRepoAccessDenied
+/// [`Error::GitHubApi`]: errors::Error::GitHubApi
+/// [`Error::GitHubGraphQLForbidden`]: errors::Error::GitHubGraphQLForbidden
+pub(crate) fn classify_cross_repo_fetch(
+    err: errors::Error,
+    owner: &str,
+    repo: &str,
+) -> errors::Error {
+    match err {
+        errors::Error::GitHubApi { status: 403, .. }
+        | errors::Error::GitHubGraphQLForbidden { .. } => {
+            unblock_core::errors::CrossRepoAccessDeniedSnafu {
+                owner: owner.to_owned(),
+                repo: repo.to_owned(),
+            }
+            .build()
+            .into()
+        }
+        other => other,
+    }
 }
 
 /// Parses the `X-RateLimit-Reset` header from a response into a `DateTime<Utc>`.
@@ -909,6 +984,103 @@ fn parse_issue_type_field(fields: &std::collections::HashMap<String, String>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── classify_cross_repo_fetch ───────────────────────────────────────
+
+    #[test]
+    fn classify_cross_repo_fetch_upgrades_403_to_cross_repo_access_denied() {
+        // SPEC §11.1 wiring: a cross-repo fetch returning HTTP 403
+        // (wrapped as `Error::GitHubApi { status: 403, .. }`) MUST
+        // upgrade to `DomainError::CrossRepoAccessDenied` carrying the
+        // known owner/repo context.
+        let api_err = errors::GitHubApiSnafu {
+            status: 403_u16,
+            message: "Must have push access to repository".to_owned(),
+        }
+        .build();
+        let upgraded = classify_cross_repo_fetch(api_err, "acme", "widgets");
+        match upgraded {
+            errors::Error::Domain { source } => {
+                let msg = source.to_string();
+                assert_eq!(source.status_code(), 403);
+                assert!(msg.contains("acme"), "expected owner in message: {msg}");
+                assert!(msg.contains("widgets"), "expected repo in message: {msg}");
+            }
+            other => panic!("expected CrossRepoAccessDenied Domain error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_cross_repo_fetch_upgrades_graphql_forbidden() {
+        // SPEC §11.1 wiring: a cross-repo fetch returning GraphQL
+        // FORBIDDEN (wrapped as `Error::GitHubGraphQLForbidden`) MUST
+        // upgrade to `DomainError::CrossRepoAccessDenied`. The reducer
+        // emits this variant by inspecting `errors[i].type == "FORBIDDEN"`
+        // BEFORE reducing to messages.
+        let gql_err = errors::GitHubGraphQLForbiddenSnafu {
+            errors: vec!["Resource not accessible by integration".to_owned()],
+        }
+        .build();
+        let upgraded = classify_cross_repo_fetch(gql_err, "acme", "widgets");
+        match upgraded {
+            errors::Error::Domain { source } => {
+                let msg = source.to_string();
+                assert_eq!(source.status_code(), 403);
+                assert!(msg.contains("acme"), "expected owner in message: {msg}");
+                assert!(msg.contains("widgets"), "expected repo in message: {msg}");
+            }
+            other => panic!("expected CrossRepoAccessDenied Domain error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_cross_repo_fetch_passes_through_non_403_api() {
+        // A non-403 GitHubApi error MUST stay as GitHubApi — only 403
+        // is cross-repo-access-semantic.
+        let api_err = errors::GitHubApiSnafu {
+            status: 500_u16,
+            message: "Internal Server Error".to_owned(),
+        }
+        .build();
+        let result = classify_cross_repo_fetch(api_err, "acme", "widgets");
+        match result {
+            errors::Error::GitHubApi { status, .. } => assert_eq!(status, 500),
+            other => panic!("expected GitHubApi passthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_cross_repo_fetch_passes_through_non_forbidden_graphql() {
+        // A non-FORBIDDEN GraphQL error (the reducer's default bucket)
+        // MUST stay as GitHubGraphQL — only the FORBIDDEN-typed variant
+        // upgrades.
+        let gql_err = errors::GitHubGraphQLSnafu {
+            errors: vec!["Field 'x' not found".to_owned()],
+        }
+        .build();
+        let result = classify_cross_repo_fetch(gql_err, "acme", "widgets");
+        match result {
+            errors::Error::GitHubGraphQL { errors } => {
+                assert_eq!(errors, vec!["Field 'x' not found".to_owned()]);
+            }
+            other => panic!("expected GitHubGraphQL passthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_cross_repo_fetch_passes_through_unrelated_errors() {
+        // A rate-limit error MUST pass through unchanged — the
+        // classifier is scoped to 403 / FORBIDDEN only.
+        let err = errors::RateLimitedSnafu {
+            reset_at: chrono::Utc::now(),
+        }
+        .build();
+        let result = classify_cross_repo_fetch(err, "acme", "widgets");
+        match result {
+            errors::Error::RateLimited { .. } => {}
+            other => panic!("expected RateLimited passthrough, got: {other:?}"),
+        }
+    }
 
     // ── parse_issue_state ───────────────────────────────────────────────
 
@@ -1837,6 +2009,227 @@ mod tests {
                 assert_eq!(message, "Not Found");
             }
             other => panic!("expected GitHubApi, got: {other}"),
+        }
+    }
+
+    // ── GraphQL reducer: FORBIDDEN partition (SPEC §11.1 wiring) ───────
+
+    #[tokio::test]
+    async fn graphql_errors_array_with_forbidden_type_emits_forbidden_variant() {
+        // When any errors[i].type == "FORBIDDEN", the reducer MUST emit
+        // `GitHubGraphQLForbidden` with the forbidden messages, rather
+        // than substring-sniffing after reducing to a `Vec<String>`.
+        // This is the wire-form partition contract per user decision
+        // 2026-04-17 (unblock-6xj).
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "FORBIDDEN",
+                        "message": "Resource not accessible by integration"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .graphql("query { viewer { login } }", serde_json::json!({}))
+            .await
+            .expect_err("FORBIDDEN should produce Err");
+
+        match err {
+            errors::Error::GitHubGraphQLForbidden { errors } => {
+                assert_eq!(errors.len(), 1);
+                assert_eq!(errors[0], "Resource not accessible by integration");
+            }
+            other => panic!("expected GitHubGraphQLForbidden, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn graphql_errors_array_without_forbidden_type_emits_graphql_variant() {
+        // Non-FORBIDDEN-typed GraphQL errors MUST keep their existing
+        // `GitHubGraphQL` shape. Regression guard: the partition logic
+        // must NOT default all typed errors into the FORBIDDEN bucket.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to a Repository with the name"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .graphql("query { viewer { login } }", serde_json::json!({}))
+            .await
+            .expect_err("error should produce Err");
+
+        match err {
+            errors::Error::GitHubGraphQL { errors } => {
+                assert_eq!(errors.len(), 1);
+                assert!(errors[0].contains("Repository"));
+            }
+            other => panic!("expected GitHubGraphQL, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn graphql_errors_mixed_forbidden_and_other_prefers_forbidden() {
+        // When at least one error is FORBIDDEN-typed and others are
+        // not, the reducer MUST emit `GitHubGraphQLForbidden` with
+        // ONLY the forbidden messages — FORBIDDEN is authoritative.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    { "type": "NOT_FOUND", "message": "side-effect error" },
+                    { "type": "FORBIDDEN", "message": "access denied" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .graphql("query { viewer { login } }", serde_json::json!({}))
+            .await
+            .expect_err("error should produce Err");
+
+        match err {
+            errors::Error::GitHubGraphQLForbidden { errors } => {
+                assert_eq!(errors.len(), 1);
+                assert_eq!(errors[0], "access denied");
+            }
+            other => panic!("expected GitHubGraphQLForbidden, got: {other}"),
+        }
+    }
+
+    // ── fetch_issue_in_repo: cross-repo classifier (SPEC §11.1) ────────
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_cross_repo_http_403_upgrades_to_access_denied() {
+        // A cross-repo fetch returning HTTP 403 MUST upgrade to
+        // `DomainError::CrossRepoAccessDenied` carrying the target
+        // owner/repo. Local fetches do NOT upgrade.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+        // client.owner()/repo() are "test-owner"/"test-repo" — any
+        // other owner/repo is treated as cross-repo.
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("acme", "widgets", 1)
+            .await
+            .expect_err("403 should produce Err");
+
+        match err {
+            errors::Error::Domain { source } => {
+                let msg = source.to_string();
+                assert_eq!(source.status_code(), 403);
+                assert!(msg.contains("acme"), "expected owner in message: {msg}");
+                assert!(msg.contains("widgets"), "expected repo in message: {msg}");
+            }
+            other => panic!("expected CrossRepoAccessDenied Domain error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_cross_repo_graphql_forbidden_upgrades_to_access_denied() {
+        // A cross-repo fetch whose GraphQL response contains
+        // errors[i].type == "FORBIDDEN" MUST upgrade to
+        // `CrossRepoAccessDenied`.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "FORBIDDEN",
+                        "message": "Resource not accessible by integration"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("acme", "widgets", 1)
+            .await
+            .expect_err("FORBIDDEN should produce Err");
+
+        match err {
+            errors::Error::Domain { source } => {
+                let msg = source.to_string();
+                assert_eq!(source.status_code(), 403);
+                assert!(msg.contains("acme"), "expected owner in message: {msg}");
+                assert!(msg.contains("widgets"), "expected repo in message: {msg}");
+            }
+            other => panic!("expected CrossRepoAccessDenied Domain error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_local_403_stays_as_github_api() {
+        // A local fetch (owner/repo == configured) returning HTTP 403
+        // MUST stay as `GitHubApi` — `CrossRepoAccessDenied` is
+        // cross-repo-semantic by name.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("test-owner", "test-repo", 1)
+            .await
+            .expect_err("403 should produce Err");
+
+        match err {
+            errors::Error::GitHubApi { status, .. } => assert_eq!(status, 403),
+            other => panic!("expected GitHubApi passthrough for local 403, got: {other}"),
         }
     }
 }

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -31,7 +31,7 @@ use unblock_core::types::{Issue, IssueSummary, IssueType, Priority, QualifiedId,
 
 use crate::client::GitHubClient;
 use crate::errors::{self, Error};
-use crate::graphql::check_rest_response;
+use crate::graphql::{check_rest_response, classify_cross_repo_fetch};
 
 /// Parameters for creating a new GitHub issue.
 ///
@@ -1062,7 +1062,14 @@ impl GitHubClient {
                     "number": number,
                 });
 
-                let response = self.graphql(query, variables).await?;
+                // Per SPEC §11.1 / plan Task 02.02 "Error-side wiring",
+                // a 403 (HTTP) or GraphQL FORBIDDEN response on this
+                // cross-repo resolver MUST upgrade to
+                // `DomainError::CrossRepoAccessDenied { owner, repo }`.
+                let response = self
+                    .graphql(query, variables)
+                    .await
+                    .map_err(|err| classify_cross_repo_fetch(err, owner, repo))?;
                 let node_id = response["data"]["repository"]["issue"]["id"]
                     .as_str()
                     .unwrap_or_default()

--- a/crates/unblock-mcp/src/errors.rs
+++ b/crates/unblock-mcp/src/errors.rs
@@ -80,17 +80,24 @@ pub enum BootstrapError {
 /// Converts the HTTP status code from the error into the most appropriate
 /// JSON-RPC error code:
 ///
-/// | HTTP status              | JSON-RPC code             |
-/// |--------------------------|---------------------------|
-/// | 400, 404, 409, 412, 422  | `INVALID_PARAMS` (-32602) |
-/// | 429, 500, 503            | `INTERNAL_ERROR` (-32603) |
-/// | other                    | `INTERNAL_ERROR` (-32603) |
+/// | HTTP status                   | JSON-RPC code             |
+/// |-------------------------------|---------------------------|
+/// | 400, 403, 404, 409, 412, 422  | `INVALID_PARAMS` (-32602) |
+/// | 429, 500, 503                 | `INTERNAL_ERROR` (-32603) |
+/// | other                         | `INTERNAL_ERROR` (-32603) |
+///
+/// The 403 branch is an explicit match arm (not a catch-all fall-through)
+/// per SPEC §11.3 / plan Task 02.02 "Error-side wiring" and plan
+/// GAP-14.c Decision 2 #3 — this makes the `CrossRepoAccessDenied`
+/// mapping a named branch so regressions are caught by the error-mapping
+/// tests rather than silently collapsing into `INTERNAL_ERROR` when
+/// future variants alter the status-code table.
 ///
 /// The error's `Display` output becomes the JSON-RPC error message.
 #[allow(clippy::needless_pass_by_value)] // Intentional: consumes the error in a map_err chain.
 pub(crate) fn github_error_to_mcp(err: unblock_github::errors::Error) -> ErrorData {
     let code = match err.status_code() {
-        400 | 404 | 409 | 412 | 422 => ErrorCode::INVALID_PARAMS,
+        400 | 403 | 404 | 409 | 412 | 422 => ErrorCode::INVALID_PARAMS,
         _ => ErrorCode::INTERNAL_ERROR,
     };
     ErrorData {
@@ -105,7 +112,9 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use snafu::IntoError;
-    use unblock_core::errors::IssueNotFoundSnafu;
+    use unblock_core::errors::{
+        CrossRepoAccessDeniedSnafu, InvalidIssueRefSnafu, IssueNotFoundSnafu,
+    };
     use unblock_github::errors::{
         CircuitBreakerOpenSnafu, GitHubApiSnafu, GitHubGraphQLSnafu, GitRemoteSnafu,
         ProjectNotConfiguredSnafu, RateLimitedSnafu,
@@ -127,6 +136,54 @@ mod tests {
         assert!(
             msg.contains("42"),
             "message should contain issue number: {msg}"
+        );
+    }
+
+    #[test]
+    fn invalid_issue_ref_maps_to_invalid_params() {
+        // `InvalidIssueRef` has status_code 400; the 400 branch of
+        // `github_error_to_mcp` must route it to `INVALID_PARAMS` and
+        // preserve the raw input in the message so the agent can see
+        // what they sent. Mirrors `domain_error_maps_to_invalid_params`
+        // for the new 400 wiring added in unblock-6xj.
+        let err = unblock_github::errors::Error::from(
+            InvalidIssueRefSnafu {
+                input: "not-a-ref".to_owned(),
+            }
+            .build(),
+        );
+        let (code, msg) = convert(err);
+        assert_eq!(code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            msg.contains("not-a-ref"),
+            "message should contain raw input: {msg}"
+        );
+    }
+
+    #[test]
+    fn cross_repo_access_denied_maps_to_invalid_params() {
+        // `CrossRepoAccessDenied` has status_code 403; the 403 branch of
+        // `github_error_to_mcp` MUST route it to `INVALID_PARAMS` via an
+        // explicit match arm (SPEC §11.3 / plan Task 02.02 "Error-side
+        // wiring" / GAP-14.c Decision 2 #3). This test is the
+        // regression guard: without the explicit 403 arm, 403 would
+        // silently collapse into the catch-all `INTERNAL_ERROR`.
+        let err = unblock_github::errors::Error::from(
+            CrossRepoAccessDeniedSnafu {
+                owner: "acme".to_owned(),
+                repo: "widgets".to_owned(),
+            }
+            .build(),
+        );
+        let (code, msg) = convert(err);
+        assert_eq!(code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            msg.contains("acme"),
+            "message should contain owner: {msg}"
+        );
+        assert!(
+            msg.contains("widgets"),
+            "message should contain repo: {msg}"
         );
     }
 

--- a/crates/unblock-mcp/src/errors.rs
+++ b/crates/unblock-mcp/src/errors.rs
@@ -177,10 +177,7 @@ mod tests {
         );
         let (code, msg) = convert(err);
         assert_eq!(code, ErrorCode::INVALID_PARAMS);
-        assert!(
-            msg.contains("acme"),
-            "message should contain owner: {msg}"
-        );
+        assert!(msg.contains("acme"), "message should contain owner: {msg}");
         assert!(
             msg.contains("widgets"),
             "message should contain repo: {msg}"

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -46,7 +46,7 @@ use unblock_core::cache::GraphCache;
 use unblock_core::client::{AgentClient, AgentKind};
 use unblock_core::config::Config;
 use unblock_core::detection::ClientDetector;
-use unblock_core::errors::{CircularDependencySnafu, IssueClosedSnafu};
+use unblock_core::errors::{CircularDependencySnafu, InvalidIssueRefSnafu, IssueClosedSnafu};
 use unblock_core::types::IssueState;
 use unblock_github::GitHubApi;
 use unblock_github::projects::FieldValue;
@@ -676,15 +676,22 @@ impl UnblockServer {
             include_comments, include_deps, "Show tool invoked"
         );
 
-        // Parse the input string into an IssueRef. Mirrors the `depends`
-        // handler's parsing so error messages stay consistent.
+        // Parse the input string into an IssueRef. Per SPEC §11.1 / plan
+        // Task 02.02 "Error-side wiring", parse failures at the tool
+        // boundary MUST propagate as `InvalidIssueRefSnafu { input }`
+        // through `github_error_to_mcp` (HTTP 400 → MCP `-32602`). The
+        // raw user string flows into `input` so the agent can see
+        // exactly what they sent.
         let issue_ref = params
             .issue
             .parse::<unblock_core::types::IssueRef>()
-            .map_err(|e| ErrorData {
-                code: rmcp::model::ErrorCode::INVALID_PARAMS,
-                message: format!("Invalid issue reference '{}': {e}", params.issue).into(),
-                data: None,
+            .map_err(|_| {
+                crate::errors::github_error_to_mcp(unblock_github::errors::Error::from(
+                    InvalidIssueRefSnafu {
+                        input: params.issue.clone(),
+                    }
+                    .build(),
+                ))
             })?;
 
         // Step 1: Fetch the full issue via execute_read_tool. `fetch_issue_ref`
@@ -1226,22 +1233,32 @@ impl UnblockServer {
             "Depends tool invoked"
         );
 
-        // Parse source string into IssueRef.
+        // Parse source string into IssueRef. Per SPEC §11.1 / plan Task
+        // 02.02 "Error-side wiring", parse failures at the tool boundary
+        // MUST propagate as `InvalidIssueRefSnafu { input }` through
+        // `github_error_to_mcp` (HTTP 400 → MCP `-32602`).
         let source_ref_raw = source_str
             .parse::<unblock_core::types::IssueRef>()
-            .map_err(|e| ErrorData {
-                code: rmcp::model::ErrorCode::INVALID_PARAMS,
-                message: format!("Invalid source reference '{source_str}': {e}").into(),
-                data: None,
+            .map_err(|_| {
+                crate::errors::github_error_to_mcp(unblock_github::errors::Error::from(
+                    InvalidIssueRefSnafu {
+                        input: source_str.clone(),
+                    }
+                    .build(),
+                ))
             })?;
 
-        // Parse target string into IssueRef.
+        // Parse target string into IssueRef. See `source_ref_raw` for
+        // the wiring rationale.
         let target_ref_raw = target_str
             .parse::<unblock_core::types::IssueRef>()
-            .map_err(|e| ErrorData {
-                code: rmcp::model::ErrorCode::INVALID_PARAMS,
-                message: format!("Invalid target reference '{target_str}': {e}").into(),
-                data: None,
+            .map_err(|_| {
+                crate::errors::github_error_to_mcp(unblock_github::errors::Error::from(
+                    InvalidIssueRefSnafu {
+                        input: target_str.clone(),
+                    }
+                    .build(),
+                ))
             })?;
 
         // Normalize both refs against the configured repo. A
@@ -1483,17 +1500,19 @@ impl UnblockServer {
             None
         };
 
-        // Parse blocked_by refs.
+        // Parse blocked_by refs. Per SPEC §11.1 / plan Task 02.02
+        // "Error-side wiring", each per-element parse failure
+        // propagates as `InvalidIssueRefSnafu { input }` through
+        // `github_error_to_mcp` (HTTP 400 → MCP `-32602`).
         let blocked_by_refs: Vec<unblock_core::types::IssueRef> =
             if let Some(ref refs) = params.blocked_by {
                 refs.iter()
                     .map(|s| {
-                        s.parse::<unblock_core::types::IssueRef>()
-                            .map_err(|e| ErrorData {
-                                code: rmcp::model::ErrorCode::INVALID_PARAMS,
-                                message: format!("Invalid blocked_by reference '{s}': {e}").into(),
-                                data: None,
-                            })
+                        s.parse::<unblock_core::types::IssueRef>().map_err(|_| {
+                            crate::errors::github_error_to_mcp(unblock_github::errors::Error::from(
+                                InvalidIssueRefSnafu { input: s.clone() }.build(),
+                            ))
+                        })
                     })
                     .collect::<Result<Vec<_>, _>>()?
             } else {

--- a/crates/unblock-mcp/src/tools/dep_remove.rs
+++ b/crates/unblock-mcp/src/tools/dep_remove.rs
@@ -95,7 +95,7 @@ use rmcp::model::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument, warn};
-use unblock_core::errors::ValidationSnafu;
+use unblock_core::errors::{InvalidIssueRefSnafu, ValidationSnafu};
 use unblock_core::graph::DependencyGraph;
 use unblock_core::types::{Issue, IssueRef, IssueState, QualifiedId};
 use unblock_github::GitHubApi;
@@ -185,13 +185,25 @@ fn validation_error(message: impl Into<String>) -> ErrorData {
     github_error_to_mcp(github)
 }
 
-/// Parse an [`IssueRef`] from a raw string, tagging the field name in
-/// the error message so the caller can tell which side was malformed.
-fn parse_ref(field: &str, value: &str) -> Result<IssueRef, ErrorData> {
-    value.parse::<IssueRef>().map_err(|e| ErrorData {
-        code: rmcp::model::ErrorCode::INVALID_PARAMS,
-        message: format!("Invalid {field} reference '{value}': {e}").into(),
-        data: None,
+/// Parse an [`IssueRef`] from a raw string, surfacing a malformed
+/// reference as [`InvalidIssueRefSnafu`] lifted through
+/// [`github_error_to_mcp`] (HTTP 400 → MCP `-32602`).
+///
+/// Per SPEC §11.1 / plan Task 02.02 "Error-side wiring" the domain
+/// variant carries only the raw `input`, so this helper no longer
+/// tags a `source`/`target` field name in the message — the caller
+/// already knows which side they passed. Both `handle_dep_remove`
+/// call sites parse `source` first, then `target`, so on a malformed
+/// input the position (and therefore the field) is implicit in the
+/// failure ordering.
+fn parse_ref(value: &str) -> Result<IssueRef, ErrorData> {
+    value.parse::<IssueRef>().map_err(|_| {
+        github_error_to_mcp(unblock_github::errors::Error::from(
+            InvalidIssueRefSnafu {
+                input: value.to_owned(),
+            }
+            .build(),
+        ))
     })
 }
 
@@ -431,8 +443,8 @@ pub async fn handle_dep_remove(
     // `CrossRepo { owner, repo, .. }` pointing at the configured repo
     // back to `Local`, so all downstream dispatch (edge check, Status
     // update scope) treats aliased and canonical local forms identically.
-    let source_raw = parse_ref("source", &params.source)?;
-    let target_raw = parse_ref("target", &params.target)?;
+    let source_raw = parse_ref(&params.source)?;
+    let target_raw = parse_ref(&params.target)?;
     let source_ref = source_raw.normalize(&owner, &repo);
     let target_ref = target_raw.normalize(&owner, &repo);
 
@@ -549,19 +561,19 @@ mod tests {
 
     #[test]
     fn parse_ref_accepts_bare_local_number() {
-        let r = parse_ref("source", "42").expect("bare local number should parse");
+        let r = parse_ref("42").expect("bare local number should parse");
         assert_eq!(r, IssueRef::Local(42));
     }
 
     #[test]
     fn parse_ref_accepts_hash_prefixed_local() {
-        let r = parse_ref("source", "#7").expect("hash-prefixed local should parse");
+        let r = parse_ref("#7").expect("hash-prefixed local should parse");
         assert_eq!(r, IssueRef::Local(7));
     }
 
     #[test]
     fn parse_ref_accepts_cross_repo() {
-        let r = parse_ref("target", "acme/widgets#99").expect("cross-repo reference should parse");
+        let r = parse_ref("acme/widgets#99").expect("cross-repo reference should parse");
         assert_eq!(
             r,
             IssueRef::CrossRepo {
@@ -573,14 +585,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_ref_rejects_garbage_with_field_tag() {
-        let err = parse_ref("source", "not-a-ref").expect_err("garbage should not parse");
+    fn parse_ref_rejects_garbage_surfaces_invalid_issue_ref() {
+        // Per SPEC §11.1 / plan Task 02.02 "Error-side wiring", a
+        // malformed IssueRef at the tool boundary MUST surface as
+        // `DomainError::InvalidIssueRef { input }` lifted through
+        // `github_error_to_mcp` — i.e. MCP `INVALID_PARAMS` with the
+        // raw input preserved in the message. The previous `field`
+        // tag (`source`/`target`) was dropped with unblock-6xj because
+        // the spec variant only carries `input`; the position is
+        // implicit in the caller's parse ordering.
+        let err = parse_ref("not-a-ref").expect_err("garbage should not parse");
         assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
-        assert!(
-            err.message.contains("source"),
-            "error should name the field: {}",
-            err.message,
-        );
         assert!(
             err.message.contains("not-a-ref"),
             "error should include the raw value: {}",


### PR DESCRIPTION
Per SPEC §11.1 / plan GAP-14.c Decision 2, add the two error-side
variants required to surface IssueRef parse failures and cross-repo
403 (FORBIDDEN) responses to MCP clients with the correct HTTP bucket.

- `InvalidIssueRef { input: String }` — HTTP 400; Display embeds the
  raw user string so agents can see what they sent.
- `CrossRepoAccessDenied { owner: String, repo: String }` — HTTP 403;
  first domain-error variant to claim the 403 bucket.

Also bumps the module docblock from 11 to 13 variants and appends the
two new names to the list (closes sibling unblock-eos.18 docblock drift).

API: DomainError gains InvalidIssueRef { input: String } (HTTP 400) and
CrossRepoAccessDenied { owner: String, repo: String } (HTTP 403)
variants. Generated snafu context selectors (InvalidIssueRefSnafu,
CrossRepoAccessDeniedSnafu) become part of the `pub(crate)` exports of
`unblock_core::errors` via `visibility(pub)` on the enum. This is an
additive change — existing call sites and exhaustive matches on
DomainError are unaffected unless they already relied on non-exhaustive
matching.

Refs unblock-6xj, unblock-eos (GAP-14.c / D6.c), unblock-eos.18