### PR TITLE
refactor(github): flatten fetch_issue_in_repo error branch into map_err

### DIFF
--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -233,13 +233,17 @@ impl GitHubClient {
         // Local fetches (owner/repo == configured) stay as the
         // underlying infrastructure error — `CrossRepoAccessDenied`
         // is cross-repo-semantic by name.
-        let response = match self.graphql(FETCH_ISSUE_QUERY, variables).await {
-            Ok(v) => v,
-            Err(err) if owner != self.owner() || repo != self.repo() => {
-                return Err(classify_cross_repo_fetch(err, owner, repo));
-            }
-            Err(err) => return Err(err),
-        };
+        let is_cross_repo = owner != self.owner() || repo != self.repo();
+        let response = self
+            .graphql(FETCH_ISSUE_QUERY, variables)
+            .await
+            .map_err(|err| {
+                if is_cross_repo {
+                    classify_cross_repo_fetch(err, owner, repo)
+                } else {
+                    err
+                }
+            })?;
 
         let issue_value = &response["data"]["repository"]["issue"];
 


### PR DESCRIPTION
Replace the match/guard that scopes classify_cross_repo_fetch to the cross-repo case with a linear `.map_err(...)?` chain driven by an `is_cross_repo` bool. Reads more linearly and keeps the classifier invocation co-located with the call site. Pure style change — no behaviour difference; existing fetch_issue_in_repo and classify_cross_repo_fetch tests still cover the upgrade and passthrough paths.

Scope: crates/unblock-github/src/graphql.rs fetch_issue_in_repo only. Addresses unblock-eos.23 (P3 style finding from unblock-6xj review).