### PR TITLE
docs(mcp): narrow TODO(unblock-45a.12) in close.rs to uncovered paths

### DIFF
--- a/crates/unblock-mcp/src/tools/close.rs
+++ b/crates/unblock-mcp/src/tools/close.rs
@@ -67,5 +67,23 @@ pub struct CloseResult {
     pub cross_repo_refs: Option<CrossRepoRefs>,
 }
 
-// TODO(unblock-45a.12): Add integration tests for close tool (cascade, co-blocking,
-// already-closed paths) as part of the E2E workflow integration test.
+// TODO(unblock-45a.12): Extend close-tool integration coverage for the two
+// paths the §11.4 cross-repo suite did not exercise:
+//
+//   * already-closed — Phase 1 `IssueClosedSnafu` short-circuit when the
+//     fetched issue's `state == IssueState::Closed` (server.rs §`close`
+//     handler, step 1). `compute_unblock_cascade` is unit-tested at the
+//     graph-engine level but the tool boundary is not.
+//   * co-blocking — end-to-end assertion that a dependent with at least
+//     one remaining open blocker is NOT emitted in `unblocked` /
+//     `cross_repo_refs`. The graph engine's
+//     `cascade_co_blockers_returns_empty_when_other_open` covers the
+//     topology, but the MCP response projection through the tool is not.
+//
+// Already covered by the §11.4 suite in `tests/integration.rs`
+// (`close_no_cross_repo_dependents_cross_repo_refs_is_none`,
+// `close_cross_repo_dependent_populates_cross_repo_refs`,
+// `close_single_cross_repo_dependent_uses_singular_summary`,
+// `close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade`):
+// the None branch, plural-dependents branch, singular-summary branch,
+// and the best-effort `add_comment_ref` failure path.


### PR DESCRIPTION
The unblock-iov cross-repo test suite (plus the add_comment_ref failure test) now covers the None branch, plural-dependents branch, singular- summary branch, and the best-effort comment-failure path of the close tool. Keeping the original broad TODO ("add integration tests for close") misrepresents the coverage landscape and hides what actually remains to do.

The rewritten comment calls out only the two paths still lacking MCP integration coverage: the Phase 1 already-closed short-circuit (IssueClosedSnafu) and the co-blocking cascade projection (graph engine unit test exists, tool boundary does not). It also lists the four §11.4 tests that are known to cover the other paths, so future readers can verify the remaining scope without re-deriving it.