### PR TITLE
docs(mcp): add dependent(s) summary noun to cross_repo module docblock

### DIFF
--- a/crates/unblock-mcp/src/tools/cross_repo.rs
+++ b/crates/unblock-mcp/src/tools/cross_repo.rs
@@ -17,7 +17,8 @@
 //! 3. Wrap the accumulated set into an `Option<CrossRepoRefs>` (None when
 //!    the set is empty) with a singular/plural italic summary matching the
 //!    tool's semantic noun (`"cycle member(s)"` for projection-from-cycles,
-//!    `"blocker(s)"` for projection-from-ready).
+//!    `"blocker(s)"` for projection-from-ready,
+//!    `"dependent(s)"` for projection-from-close-cascade).
 //!
 //! The canonical primitives live here. Callers bring their own
 //! sum­mary-grammar closure so the tool-specific phrasing in SPEC §11.4 is


### PR DESCRIPTION
The module-level docblock enumerated `cycle member(s)` (dep_cycles / prime) and `blocker(s)` (ready) as the summary-noun forms produced by `build_cross_repo_refs_with_summary`, but omitted the `dependent(s)` noun introduced in `unblock-iov` for the close-cascade projection used by `CloseResult.cross_repo_refs`.

Docblock-only change — `close_summary()` already emits the `dependent` / `dependents` grammar per SPEC §11.4 / §8.2 and is covered by the `close_summary_singular_matches_spec` / `close_summary_plural_matches_spec` tests. This edit simply brings the module-level reference in line with the three-noun reality so future contributors can find the complete summary-noun inventory in one place.

Refs: unblock-eos.11