### PR TITLE
chore(mcp): introduce ContextInputsBuilder to shrink handle_prime

### DIFF
--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -385,39 +385,11 @@ impl SessionMeta {
 /// Returns [`rmcp::model::ErrorData`] with `INVALID_PARAMS` if
 /// `stale_threshold_hours` or `max_per_category` is below its minimum
 /// (currently 1), or if the GitHub fetch fails.
-#[allow(clippy::too_many_lines)]
 pub async fn handle_prime(
     params: &PrimeParams,
     state: &Arc<ServerState>,
 ) -> Result<PrimeResult, rmcp::model::ErrorData> {
-    // Validate boundary values before proceeding.
-    if let Some(hours) = params.stale_threshold_hours
-        && hours < MIN_STALE_THRESHOLD_HOURS
-    {
-        return Err(rmcp::model::ErrorData {
-            code: rmcp::model::ErrorCode::INVALID_PARAMS,
-            message: format!(
-                "stale_threshold_hours must be at least {MIN_STALE_THRESHOLD_HOURS}, got {hours}"
-            )
-            .into(),
-            data: None,
-        });
-    }
-    if let Some(max) = params.max_per_category
-        && max < MIN_MAX_PER_CATEGORY
-    {
-        return Err(rmcp::model::ErrorData {
-            code: rmcp::model::ErrorCode::INVALID_PARAMS,
-            message: format!("max_per_category must be at least {MIN_MAX_PER_CATEGORY}, got {max}")
-                .into(),
-            data: None,
-        });
-    }
-
-    let stale_threshold_hours = params
-        .stale_threshold_hours
-        .unwrap_or(DEFAULT_STALE_THRESHOLD_HOURS);
-    let max_per_category = params.max_per_category.unwrap_or(DEFAULT_MAX_PER_CATEGORY);
+    let (stale_threshold_hours, max_per_category) = validate_and_resolve_params(params)?;
 
     info!(
         stale_threshold_hours,
@@ -474,113 +446,308 @@ pub async fn handle_prime(
     // 6. Apply agent filter to relevant categories (PRD §6.3).
     //    `completed` and `hotspots` are NOT filtered — completed provides
     //    global continuity context and hotspots are structural graph properties.
-    let mut filtered_ip = categories.in_progress;
-    let mut filtered_ready = categories.ready;
-    let mut filtered_blocked = categories.blocked;
-    let mut filtered_stale = categories.stale;
-
-    // Normalize empty/whitespace agent strings to None so they don't silently
-    // filter out all results (serde deserializes "" as Some("")).
     let agent_filter = crate::tools::normalize_filter(params.agent.as_deref());
-    if let Some(agent_filter) = agent_filter {
-        let matches_agent = |s: &IssueSummary| s.agent.as_deref() == Some(agent_filter);
-        filtered_ip.retain(matches_agent);
-        filtered_ready.retain(matches_agent);
-        filtered_blocked.retain(matches_agent);
-        filtered_stale.retain(|s| s.agent.as_deref() == Some(agent_filter));
-    }
+    let filtered = apply_agent_filter(categories, agent_filter);
 
-    // 7. Compute counts AFTER filtering and detect cycles for the
-    //    `## Issues with cycles` section. The cache `get_graph()` clone
-    //    is O(1) (`Arc` bump) — the graph we just fed into the cache is
-    //    reused. On the astronomically unlikely race where another
-    //    invalidator clears the cache between steps 5 and 7 we fall back
-    //    to a cycle-free view (the renderer elides the section); this
-    //    matches the "no cycles" branch in SPEC §7.3 flow step 2.
-    let counts = PrimeCounts {
-        in_progress: filtered_ip.len(),
-        ready: filtered_ready.len(),
-        blocked: filtered_blocked.len(),
-        completed: categories.completed.len(),
-        hotspots: categories.hotspots.len(),
-        stale: filtered_stale.len(),
-    };
-
+    // 7. Fetch cycles from the cache (cheap `Arc` clone — the graph we
+    //    just stored in step 5 is reused). On the astronomically
+    //    unlikely race where another invalidator clears the cache
+    //    between steps 5 and 7 we fall back to a cycle-free view (the
+    //    renderer elides the section); this matches the "no cycles"
+    //    branch in SPEC §7.3 flow step 2.
     let cached_graph = state.cache.get_graph().await;
     let raw_cycles = cached_graph
         .as_ref()
         .map(|g| g.detect_all_cycles())
         .unwrap_or_default();
 
-    // Project cycles via the shared §11.4 helper so the cross-repo
-    // trailer is populated identically to `dep_cycles` (parity across
-    // tools is a non-negotiable part of the cross-repo contract).
-    let configured_owner = state.github.owner();
-    let configured_repo = state.github.repo();
-    let (cycle_projection, cross_repo_accum) =
-        cross_repo::project_all_cycles(&raw_cycles, configured_owner, configured_repo);
-    let cross_repo_refs = cross_repo::build_cross_repo_refs_with_summary(
-        cross_repo_accum,
-        cross_repo::cycles_summary,
-    );
-
-    // Truncate the categorised lists to `max_per_category`, matching the
-    // historical (pre-eos.7) truncation semantics so the rendered lists
-    // never blow up the markdown for repos with hundreds of open issues.
-    let ip_top: Vec<PrimeIssueSummary> = filtered_ip
-        .iter()
-        .take(max_per_category)
-        .map(PrimeIssueSummary::from_core)
-        .collect();
-    let ready_top: Vec<PrimeIssueSummary> = filtered_ready
-        .iter()
-        .take(max_per_category)
-        .map(PrimeIssueSummary::from_core)
-        .collect();
-    let blocked_top: Vec<PrimeIssueSummary> = filtered_blocked
-        .iter()
-        .take(max_per_category)
-        .map(PrimeIssueSummary::from_core)
-        .collect();
-    let completed_top: Vec<CompletedIssueSummary> = categories
-        .completed
-        .into_iter()
-        .take(max_per_category)
-        .collect();
-    let hotspots_top: Vec<HotspotSummary> = categories
-        .hotspots
-        .into_iter()
-        .take(max_per_category)
-        .collect();
-    let stale_top: Vec<StaleIssueSummary> =
-        filtered_stale.into_iter().take(max_per_category).collect();
-
-    // 8. Await drift check and assemble the markdown blob.
+    // 8. Await drift check and assemble the markdown blob. The builder
+    //    encapsulates count computation, §11.4 cycle projection, and
+    //    per-category truncation so this function stays within clippy's
+    //    `too_many_lines` budget.
     let drift_warnings = resolve_drift_warnings(drift_check).await;
     let session = SessionMeta::from_state(state);
 
-    let ctx = ContextInputs {
-        owner: configured_owner,
-        repo: configured_repo,
-        project_number: state.config.project_number,
+    let builder = ContextInputsBuilder::new(
+        state.github.owner(),
+        state.github.repo(),
+        state.config.project_number,
         stale_threshold_hours,
         max_per_category,
-        counts: &counts,
-        cycles: &cycle_projection,
-        cross_repo_refs: cross_repo_refs.as_ref(),
-        session: &session,
-        drift_warnings: drift_warnings.as_deref(),
-        in_progress: &ip_top,
-        ready: &ready_top,
-        blocked: &blocked_top,
-        completed: &completed_top,
-        hotspots: &hotspots_top,
-        stale: &stale_top,
-    };
+        filtered,
+        &raw_cycles,
+    );
+    let ctx = builder.build(&session, drift_warnings.as_deref());
 
     Ok(PrimeResult {
         context: render_context(&ctx),
     })
+}
+
+/// Validate the user-supplied boundary values and resolve defaults.
+///
+/// Returns `(stale_threshold_hours, max_per_category)` with
+/// per-parameter defaults applied. Rejects `Some(0)` for either
+/// parameter with [`rmcp::model::ErrorCode::INVALID_PARAMS`] — matching
+/// SPEC §7.3's minimum-of-1 contract for both knobs.
+///
+/// Split out of [`handle_prime`] so the orchestrator stays within
+/// clippy's default `too_many_lines` budget (bead `unblock-eos.8`).
+fn validate_and_resolve_params(
+    params: &PrimeParams,
+) -> Result<(u64, usize), rmcp::model::ErrorData> {
+    if let Some(hours) = params.stale_threshold_hours
+        && hours < MIN_STALE_THRESHOLD_HOURS
+    {
+        return Err(rmcp::model::ErrorData {
+            code: rmcp::model::ErrorCode::INVALID_PARAMS,
+            message: format!(
+                "stale_threshold_hours must be at least {MIN_STALE_THRESHOLD_HOURS}, got {hours}"
+            )
+            .into(),
+            data: None,
+        });
+    }
+    if let Some(max) = params.max_per_category
+        && max < MIN_MAX_PER_CATEGORY
+    {
+        return Err(rmcp::model::ErrorData {
+            code: rmcp::model::ErrorCode::INVALID_PARAMS,
+            message: format!("max_per_category must be at least {MIN_MAX_PER_CATEGORY}, got {max}")
+                .into(),
+            data: None,
+        });
+    }
+
+    let stale_threshold_hours = params
+        .stale_threshold_hours
+        .unwrap_or(DEFAULT_STALE_THRESHOLD_HOURS);
+    let max_per_category = params.max_per_category.unwrap_or(DEFAULT_MAX_PER_CATEGORY);
+
+    Ok((stale_threshold_hours, max_per_category))
+}
+
+/// Apply the optional agent filter to `in_progress`, `ready`, `blocked`,
+/// and `stale` categories (PRD §6.3).
+///
+/// `completed` and `hotspots` are left untouched — `completed` provides
+/// global continuity context and `hotspots` are structural graph
+/// properties, neither scoped to a single agent.
+///
+/// When `agent_filter` is `None` the categorised buckets are returned
+/// unchanged. Split out of [`handle_prime`] so the orchestrator stays
+/// within clippy's default `too_many_lines` budget (bead
+/// `unblock-eos.8`).
+fn apply_agent_filter(
+    mut categories: CategorisedIssues,
+    agent_filter: Option<&str>,
+) -> CategorisedIssues {
+    if let Some(agent_filter) = agent_filter {
+        let matches_agent = |s: &IssueSummary| s.agent.as_deref() == Some(agent_filter);
+        categories.in_progress.retain(matches_agent);
+        categories.ready.retain(matches_agent);
+        categories.blocked.retain(matches_agent);
+        categories
+            .stale
+            .retain(|s| s.agent.as_deref() == Some(agent_filter));
+    }
+    categories
+}
+
+/// Builder that encapsulates construction of [`ContextInputs`] from the
+/// orchestrator's filtered [`CategorisedIssues`] plus the raw cycle set.
+///
+/// Introduced by bead `unblock-eos.8` to shrink [`handle_prime`] below
+/// clippy's `too_many_lines` threshold. The builder owns the derived
+/// state (post-truncation category lists, counts, projected cycles,
+/// optional `cross_repo_refs`) so [`Self::build`] can return a
+/// [`ContextInputs`] borrowing its owned fields without the orchestrator
+/// needing to keep fifteen intermediate locals alive.
+///
+/// # Ownership model
+///
+/// The builder owns every `Vec<_>` it computes. The returned
+/// [`ContextInputs<'_>`] borrows from `self`, so the builder must
+/// outlive the rendered context — typically by binding both to the
+/// same stack frame (`let builder = …; let ctx = builder.build(…);`).
+///
+/// # Determinism
+///
+/// The projection helpers from [`cross_repo`] are the sole source of
+/// the §11.4 cross-repo trailer; this builder calls them exactly once
+/// and binds the result byte-for-byte identically to `dep_cycles`. See
+/// SPEC §14 Invariant 14 and [`cross_repo::cycles_summary`].
+struct ContextInputsBuilder<'a> {
+    /// Configured repository owner (matches `state.github.owner()`).
+    owner: &'a str,
+    /// Configured repository name (matches `state.github.repo()`).
+    repo: &'a str,
+    /// Optional GitHub Projects V2 project number (from `Config`).
+    project_number: Option<u64>,
+    /// Stale threshold echoed into the `## Counts` heading.
+    stale_threshold_hours: u64,
+    /// Per-category rendered-bullet cap (also applied to cycle
+    /// member lists in the renderer).
+    max_per_category: usize,
+    /// Counts computed AFTER agent filtering — rendered verbatim in
+    /// `## Counts`.
+    counts: PrimeCounts,
+    /// Local-only projection of every detected cycle.
+    cycles: Vec<Vec<u64>>,
+    /// §11.4 cross-repo trailer or `None` when no cycle touched a
+    /// cross-repo node.
+    cross_repo_refs: Option<CrossRepoRefs>,
+    /// Top-N in-progress summaries (already truncated).
+    in_progress: Vec<PrimeIssueSummary>,
+    /// Top-N ready summaries (already truncated).
+    ready: Vec<PrimeIssueSummary>,
+    /// Top-N blocked summaries (already truncated).
+    blocked: Vec<PrimeIssueSummary>,
+    /// Top-N completed summaries (already truncated).
+    completed: Vec<CompletedIssueSummary>,
+    /// Top-N hotspots (already truncated).
+    hotspots: Vec<HotspotSummary>,
+    /// Top-N stale claims (already truncated).
+    stale: Vec<StaleIssueSummary>,
+}
+
+impl<'a> ContextInputsBuilder<'a> {
+    /// Construct a builder from the orchestrator's prepared state.
+    ///
+    /// Consumes `filtered` (the post-agent-filter [`CategorisedIssues`])
+    /// and borrows `raw_cycles` (owned by [`handle_prime`]'s cache read).
+    /// Internally performs three derivations in sequence:
+    ///
+    /// 1. **Counts** — `PrimeCounts` from the filtered category lengths.
+    /// 2. **Cycle projection + §11.4 trailer** — delegates to
+    ///    [`cross_repo::project_all_cycles`] and
+    ///    [`cross_repo::build_cross_repo_refs_with_summary`] with
+    ///    [`cross_repo::cycles_summary`] for byte-parity with
+    ///    `dep_cycles`.
+    /// 3. **Truncation** — every category list is capped at
+    ///    `max_per_category` and `IssueSummary` entries are mapped into
+    ///    the renderer-friendly [`PrimeIssueSummary`] shape.
+    ///
+    /// After [`Self::new`] returns, the builder holds every Vec the
+    /// renderer needs. Call [`Self::build`] with the [`SessionMeta`] and
+    /// optional drift warnings to obtain the borrow-based
+    /// [`ContextInputs`].
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        owner: &'a str,
+        repo: &'a str,
+        project_number: Option<u64>,
+        stale_threshold_hours: u64,
+        max_per_category: usize,
+        filtered: CategorisedIssues,
+        raw_cycles: &[Vec<QualifiedId>],
+    ) -> Self {
+        // 1. Counts — computed AFTER agent filtering.
+        let counts = PrimeCounts {
+            in_progress: filtered.in_progress.len(),
+            ready: filtered.ready.len(),
+            blocked: filtered.blocked.len(),
+            completed: filtered.completed.len(),
+            hotspots: filtered.hotspots.len(),
+            stale: filtered.stale.len(),
+        };
+
+        // 2. Project cycles via the shared §11.4 helper so the
+        //    cross-repo trailer is populated identically to
+        //    `dep_cycles` (parity across tools is a non-negotiable part
+        //    of the cross-repo contract — SPEC §11.4 + §14 Invariant 14).
+        let (cycles, cross_repo_accum) = cross_repo::project_all_cycles(raw_cycles, owner, repo);
+        let cross_repo_refs = cross_repo::build_cross_repo_refs_with_summary(
+            cross_repo_accum,
+            cross_repo::cycles_summary,
+        );
+
+        // 3. Truncate the categorised lists to `max_per_category`,
+        //    matching the historical (pre-eos.7) truncation semantics
+        //    so the rendered lists never blow up the markdown for repos
+        //    with hundreds of open issues.
+        let in_progress: Vec<PrimeIssueSummary> = filtered
+            .in_progress
+            .iter()
+            .take(max_per_category)
+            .map(PrimeIssueSummary::from_core)
+            .collect();
+        let ready: Vec<PrimeIssueSummary> = filtered
+            .ready
+            .iter()
+            .take(max_per_category)
+            .map(PrimeIssueSummary::from_core)
+            .collect();
+        let blocked: Vec<PrimeIssueSummary> = filtered
+            .blocked
+            .iter()
+            .take(max_per_category)
+            .map(PrimeIssueSummary::from_core)
+            .collect();
+        let completed: Vec<CompletedIssueSummary> = filtered
+            .completed
+            .into_iter()
+            .take(max_per_category)
+            .collect();
+        let hotspots: Vec<HotspotSummary> = filtered
+            .hotspots
+            .into_iter()
+            .take(max_per_category)
+            .collect();
+        let stale: Vec<StaleIssueSummary> =
+            filtered.stale.into_iter().take(max_per_category).collect();
+
+        Self {
+            owner,
+            repo,
+            project_number,
+            stale_threshold_hours,
+            max_per_category,
+            counts,
+            cycles,
+            cross_repo_refs,
+            in_progress,
+            ready,
+            blocked,
+            completed,
+            hotspots,
+            stale,
+        }
+    }
+
+    /// Consume the builder's borrows and produce a [`ContextInputs`]
+    /// bound to `self`.
+    ///
+    /// `session` and `drift_warnings` come from the orchestrator and
+    /// must outlive the returned context — typically by sharing the
+    /// same stack frame as the builder.
+    fn build<'b>(
+        &'b self,
+        session: &'b SessionMeta,
+        drift_warnings: Option<&'b [String]>,
+    ) -> ContextInputs<'b>
+    where
+        'a: 'b,
+    {
+        ContextInputs {
+            owner: self.owner,
+            repo: self.repo,
+            project_number: self.project_number,
+            stale_threshold_hours: self.stale_threshold_hours,
+            max_per_category: self.max_per_category,
+            counts: &self.counts,
+            cycles: &self.cycles,
+            cross_repo_refs: self.cross_repo_refs.as_ref(),
+            session,
+            drift_warnings,
+            in_progress: &self.in_progress,
+            ready: &self.ready,
+            blocked: &self.blocked,
+            completed: &self.completed,
+            hotspots: &self.hotspots,
+            stale: &self.stale,
+        }
+    }
 }
 
 /// Bundle of renderer inputs — every section of the `context` markdown
@@ -590,6 +757,9 @@ pub async fn handle_prime(
 /// Lifetime `'a` binds the borrowed slices/refs to the call-site stack
 /// frame of [`handle_prime`]; the renderer performs no allocation
 /// outside the returned `String`.
+///
+/// Constructed via [`ContextInputsBuilder::build`] in production;
+/// renderer unit tests may instantiate the struct literal directly.
 struct ContextInputs<'a> {
     /// Configured repository owner (matches `state.github.owner()`).
     owner: &'a str,
@@ -2505,31 +2675,13 @@ _1 cross-repo cycle member omitted from `cycles`_
     }
 
     // ── Agent filter tests ───────────────────────────────────────────
-
-    /// Helper: apply agent filter the same way `handle_prime` does, returning
-    /// filtered category lengths for assertions.
-    fn apply_agent_filter(
-        categories: &CategorisedIssues,
-        agent: Option<&str>,
-    ) -> (usize, usize, usize, usize) {
-        let count_summary = |items: &[IssueSummary]| -> usize {
-            items
-                .iter()
-                .filter(|s| agent.is_none_or(|a| s.agent.as_deref() == Some(a)))
-                .count()
-        };
-        let count_stale = categories
-            .stale
-            .iter()
-            .filter(|s| agent.is_none_or(|a| s.agent.as_deref() == Some(a)))
-            .count();
-        (
-            count_summary(&categories.in_progress),
-            count_summary(&categories.ready),
-            count_summary(&categories.blocked),
-            count_stale,
-        )
-    }
+    //
+    // These exercise the production `apply_agent_filter` helper
+    // introduced by bead `unblock-eos.8` (extracted out of the old
+    // inline filter block in `handle_prime`). A pre-eos.8 local shim
+    // used to re-implement the filter inline for these assertions —
+    // removed in favour of the real helper so the tests cover the
+    // actual call path.
 
     #[test]
     fn agent_filter_none_returns_all() {
@@ -2546,8 +2698,12 @@ _1 cross-repo cycle member omitted from `cycles`_
         let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
-        let (ip, _r, _b, _s) = apply_agent_filter(&result, None);
-        assert_eq!(ip, 2, "None agent should return all in_progress issues");
+        let filtered = apply_agent_filter(result, None);
+        assert_eq!(
+            filtered.in_progress.len(),
+            2,
+            "None agent should return all in_progress issues"
+        );
     }
 
     #[test]
@@ -2564,8 +2720,12 @@ _1 cross-repo cycle member omitted from `cycles`_
         let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
-        let (ip, _, _, _) = apply_agent_filter(&result, Some("agent-x"));
-        assert_eq!(ip, 1, "should filter in_progress to agent-x only");
+        let filtered = apply_agent_filter(result, Some("agent-x"));
+        assert_eq!(
+            filtered.in_progress.len(),
+            1,
+            "should filter in_progress to agent-x only"
+        );
     }
 
     #[test]
@@ -2580,8 +2740,12 @@ _1 cross-repo cycle member omitted from `cycles`_
         let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
-        let (_, r, _, _) = apply_agent_filter(&result, Some("agent-x"));
-        assert_eq!(r, 1, "should filter ready to agent-x only");
+        let filtered = apply_agent_filter(result, Some("agent-x"));
+        assert_eq!(
+            filtered.ready.len(),
+            1,
+            "should filter ready to agent-x only"
+        );
     }
 
     #[test]
@@ -2610,8 +2774,12 @@ _1 cross-repo cycle member omitted from `cycles`_
         let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
-        let (_, _, b, _) = apply_agent_filter(&result, Some("agent-x"));
-        assert_eq!(b, 1, "should filter blocked to agent-x only");
+        let filtered = apply_agent_filter(result, Some("agent-x"));
+        assert_eq!(
+            filtered.blocked.len(),
+            1,
+            "should filter blocked to agent-x only"
+        );
     }
 
     #[test]
@@ -2628,8 +2796,50 @@ _1 cross-repo cycle member omitted from `cycles`_
         let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
         let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
 
-        let (_, _, _, s) = apply_agent_filter(&result, Some("agent-x"));
-        assert_eq!(s, 1, "should filter stale to agent-x only");
+        let filtered = apply_agent_filter(result, Some("agent-x"));
+        assert_eq!(
+            filtered.stale.len(),
+            1,
+            "should filter stale to agent-x only"
+        );
+    }
+
+    #[test]
+    fn agent_filter_leaves_completed_and_hotspots_untouched() {
+        // Completed + hotspots are intentionally excluded from filtering
+        // (PRD §6.3). Build a fixture with completed + hotspot entries
+        // assigned to a different agent than the filter, and verify they
+        // survive.
+        let mut closed = test_issue(1, IssueState::Closed, Status::Closed);
+        closed.agent = Some("agent-y".to_owned());
+        let mut hotspot = test_issue(2, IssueState::Open, Status::Ready);
+        hotspot.agent = Some("agent-y".to_owned());
+        let blocked_by_hotspot = test_issue(3, IssueState::Open, Status::Blocked);
+        let issues = vec![closed, hotspot, blocked_by_hotspot];
+        let edges = vec![BlockingEdge {
+            source: qid(3),
+            target: qid(2),
+        }];
+
+        let graph = DependencyGraph::build(&issues, &edges);
+        let ready = graph.compute_ready_set(&issues, TEST_OWNER, TEST_REPO);
+        let result = categorise_issues(&issues, &graph, &ready, 24, Utc::now());
+
+        // Sanity checks on the pre-filter state.
+        assert_eq!(result.completed.len(), 1);
+        assert_eq!(result.hotspots.len(), 1);
+
+        let filtered = apply_agent_filter(result, Some("agent-x"));
+        assert_eq!(
+            filtered.completed.len(),
+            1,
+            "completed should not be filtered by agent"
+        );
+        assert_eq!(
+            filtered.hotspots.len(),
+            1,
+            "hotspots should not be filtered by agent"
+        );
     }
 
     #[test]
@@ -2762,9 +2972,10 @@ _1 cross-repo cycle member omitted from `cycles`_
             "empty string should normalize to None"
         );
 
-        let (ip, _, _, _) = apply_agent_filter(&result, agent_filter);
+        let filtered = apply_agent_filter(result, agent_filter);
         assert_eq!(
-            ip, 2,
+            filtered.in_progress.len(),
+            2,
             "empty agent string should return all in_progress issues"
         );
     }
@@ -2924,5 +3135,269 @@ _1 cross-repo cycle member omitted from `cycles`_
         > = tokio::spawn(async { panic!("simulated reconcile panic") });
         let result = resolve_drift_warnings(handle).await;
         assert!(result.is_none(), "panic should produce None");
+    }
+
+    // ── ContextInputsBuilder tests (bead unblock-eos.8) ──────────────
+    //
+    // The builder encapsulates the count / cycle-projection /
+    // truncation steps that used to live inline in `handle_prime`. The
+    // tests below pin the behaviour that was previously only verified
+    // indirectly via integration tests.
+
+    /// Build an empty [`CategorisedIssues`] fixture — every bucket is empty.
+    fn empty_categorised() -> CategorisedIssues {
+        CategorisedIssues {
+            in_progress: vec![],
+            ready: vec![],
+            blocked: vec![],
+            completed: vec![],
+            hotspots: vec![],
+            stale: vec![],
+        }
+    }
+
+    /// Build an [`IssueSummary`] fixture for the builder's truncation
+    /// tests. `number` is used as the identifier; other fields are
+    /// given stable defaults so assertions stay byte-stable.
+    fn summary(number: u64) -> IssueSummary {
+        IssueSummary {
+            qualified_id: qid(number),
+            number,
+            title: format!("Issue #{number}"),
+            issue_type: Some(IssueType::Task),
+            status: Status::Ready,
+            priority: Priority::P1,
+            agent: None,
+            milestone: None,
+            story_points: None,
+            defer_until: None,
+            labels: vec![],
+            created_at: Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap(),
+            url: format!("https://github.com/test-owner/test-repo/issues/{number}"),
+        }
+    }
+
+    #[test]
+    fn builder_empty_inputs_produces_zero_counts_and_no_trailer() {
+        let builder =
+            ContextInputsBuilder::new("acme", "widgets", None, 24, 10, empty_categorised(), &[]);
+
+        assert_eq!(builder.counts.in_progress, 0);
+        assert_eq!(builder.counts.ready, 0);
+        assert_eq!(builder.counts.blocked, 0);
+        assert_eq!(builder.counts.completed, 0);
+        assert_eq!(builder.counts.hotspots, 0);
+        assert_eq!(builder.counts.stale, 0);
+        assert!(builder.cycles.is_empty());
+        assert!(
+            builder.cross_repo_refs.is_none(),
+            "no cycles means no cross-repo trailer"
+        );
+    }
+
+    #[test]
+    fn builder_counts_mirror_filtered_category_lengths() {
+        // Four ready summaries, two blocked, zero elsewhere.
+        let categories = CategorisedIssues {
+            in_progress: vec![],
+            ready: vec![summary(1), summary(2), summary(3), summary(4)],
+            blocked: vec![summary(5), summary(6)],
+            completed: vec![],
+            hotspots: vec![],
+            stale: vec![],
+        };
+        let builder = ContextInputsBuilder::new("acme", "widgets", None, 24, 10, categories, &[]);
+
+        assert_eq!(builder.counts.ready, 4, "counts must reflect input lengths");
+        assert_eq!(
+            builder.counts.blocked, 2,
+            "counts must reflect input lengths"
+        );
+    }
+
+    #[test]
+    fn builder_truncates_each_category_at_max_per_category() {
+        // Six ready summaries with a cap of 3 — truncation kicks in.
+        let ready_input: Vec<IssueSummary> = (1..=6).map(summary).collect();
+        let categories = CategorisedIssues {
+            in_progress: vec![],
+            ready: ready_input,
+            blocked: vec![],
+            completed: vec![],
+            hotspots: vec![],
+            stale: vec![],
+        };
+        let builder = ContextInputsBuilder::new("acme", "widgets", None, 24, 3, categories, &[]);
+
+        // Counts are computed BEFORE truncation (pre-filter length).
+        assert_eq!(
+            builder.counts.ready, 6,
+            "counts record the full filtered length"
+        );
+        // Truncated list obeys the cap.
+        assert_eq!(
+            builder.ready.len(),
+            3,
+            "truncated list honours max_per_category"
+        );
+        // First three numbers preserved (truncation takes the prefix).
+        let numbers: Vec<u64> = builder.ready.iter().map(|s| s.number).collect();
+        assert_eq!(numbers, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn builder_populates_cross_repo_trailer_when_cycle_has_cross_repo_member() {
+        // Configured repo is acme/widgets; the cycle includes an
+        // `acme/other#42` member which must land in the trailer.
+        let raw_cycles: Vec<Vec<QualifiedId>> = vec![vec![
+            QualifiedId::new("acme", "widgets", 1),
+            QualifiedId::new("acme", "other", 42),
+            QualifiedId::new("acme", "widgets", 2),
+        ]];
+        let builder = ContextInputsBuilder::new(
+            "acme",
+            "widgets",
+            None,
+            24,
+            10,
+            empty_categorised(),
+            &raw_cycles,
+        );
+
+        let refs = builder
+            .cross_repo_refs
+            .as_ref()
+            .expect("cross-repo member must populate the trailer");
+        assert_eq!(refs.omitted, vec!["acme/other#42".to_owned()]);
+        assert_eq!(
+            refs.summary.as_deref(),
+            Some("1 cross-repo cycle member omitted from `cycles`"),
+            "summary must match cross_repo::cycles_summary byte-for-byte"
+        );
+        // Local projection drops the cross-repo entry.
+        assert_eq!(builder.cycles, vec![vec![1u64, 2u64]]);
+    }
+
+    #[test]
+    fn builder_local_only_cycle_leaves_trailer_none() {
+        let raw_cycles: Vec<Vec<QualifiedId>> = vec![vec![
+            QualifiedId::new("acme", "widgets", 1),
+            QualifiedId::new("acme", "widgets", 2),
+        ]];
+        let builder = ContextInputsBuilder::new(
+            "acme",
+            "widgets",
+            None,
+            24,
+            10,
+            empty_categorised(),
+            &raw_cycles,
+        );
+
+        assert!(
+            builder.cross_repo_refs.is_none(),
+            "local-only cycle must not populate the trailer"
+        );
+        assert_eq!(builder.cycles, vec![vec![1u64, 2u64]]);
+    }
+
+    #[test]
+    fn builder_build_wires_owned_fields_into_context_inputs() {
+        // End-to-end: populate the builder, call build(), and assert
+        // that the ContextInputs references match the builder's owned
+        // state byte-for-byte.
+        let categories = CategorisedIssues {
+            in_progress: vec![summary(1)],
+            ready: vec![summary(2), summary(3)],
+            blocked: vec![],
+            completed: vec![],
+            hotspots: vec![],
+            stale: vec![],
+        };
+        let raw_cycles: Vec<Vec<QualifiedId>> = vec![vec![
+            QualifiedId::new("acme", "widgets", 1),
+            QualifiedId::new("acme", "widgets", 2),
+        ]];
+        let builder =
+            ContextInputsBuilder::new("acme", "widgets", Some(7), 48, 5, categories, &raw_cycles);
+
+        let session = unknown_session();
+        let drift: &[String] = &[];
+        let ctx = builder.build(&session, Some(drift));
+
+        assert_eq!(ctx.owner, "acme");
+        assert_eq!(ctx.repo, "widgets");
+        assert_eq!(ctx.project_number, Some(7));
+        assert_eq!(ctx.stale_threshold_hours, 48);
+        assert_eq!(ctx.max_per_category, 5);
+        assert_eq!(ctx.counts.in_progress, 1);
+        assert_eq!(ctx.counts.ready, 2);
+        assert_eq!(ctx.cycles, &[vec![1u64, 2u64]]);
+        assert!(ctx.cross_repo_refs.is_none());
+        assert_eq!(ctx.in_progress.len(), 1);
+        assert_eq!(ctx.ready.len(), 2);
+        assert!(ctx.blocked.is_empty());
+        assert!(ctx.completed.is_empty());
+        assert!(ctx.hotspots.is_empty());
+        assert!(ctx.stale.is_empty());
+        assert_eq!(ctx.drift_warnings, Some(drift));
+    }
+
+    // ── validate_and_resolve_params tests (bead unblock-eos.8) ───────
+    //
+    // Extracted from the inline validation block at the top of
+    // `handle_prime` so both the happy path and the reject paths can
+    // be covered without spinning up a full `ServerState`.
+
+    #[test]
+    fn validate_and_resolve_params_defaults_apply_when_unset() {
+        let params = PrimeParams {
+            stale_threshold_hours: None,
+            max_per_category: None,
+            agent: None,
+        };
+        let (hours, max) =
+            validate_and_resolve_params(&params).expect("defaults should pass validation");
+        assert_eq!(hours, DEFAULT_STALE_THRESHOLD_HOURS);
+        assert_eq!(max, DEFAULT_MAX_PER_CATEGORY);
+    }
+
+    #[test]
+    fn validate_and_resolve_params_passes_explicit_values_through() {
+        let params = PrimeParams {
+            stale_threshold_hours: Some(48),
+            max_per_category: Some(5),
+            agent: None,
+        };
+        let (hours, max) =
+            validate_and_resolve_params(&params).expect("explicit values should pass");
+        assert_eq!(hours, 48);
+        assert_eq!(max, 5);
+    }
+
+    #[test]
+    fn validate_and_resolve_params_rejects_zero_stale_threshold() {
+        let params = PrimeParams {
+            stale_threshold_hours: Some(0),
+            max_per_category: None,
+            agent: None,
+        };
+        let err = validate_and_resolve_params(&params)
+            .expect_err("zero stale threshold must be rejected");
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("stale_threshold_hours"));
+    }
+
+    #[test]
+    fn validate_and_resolve_params_rejects_zero_max_per_category() {
+        let params = PrimeParams {
+            stale_threshold_hours: None,
+            max_per_category: Some(0),
+            agent: None,
+        };
+        let err = validate_and_resolve_params(&params)
+            .expect_err("zero max_per_category must be rejected");
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("max_per_category"));
     }
 }


### PR DESCRIPTION
Extract the per-category truncation, cycle projection and count computation out of handle_prime into a dedicated ContextInputsBuilder. Two additional helpers (validate_and_resolve_params, apply_agent_filter) move the param-validation and agent-filter blocks to free-standing functions so the orchestrator is a thin sequencer.

handle_prime shrinks from 143 clippy-counted lines (with an #[allow(clippy::too_many_lines)] suppression) to well under the default 100-line threshold; the allow attribute is removed. No renderer function exceeds the threshold, so the bead's expected relocation of the suppression is unnecessary — verified by a full cargo clippy --workspace --all-targets -- -D warnings pass.

Behaviour preserved byte-for-byte:
- Cycle projection uses the same cross_repo::project_all_cycles + cross_repo::cycles_summary path (SPEC §11.4 byte-parity with dep_cycles).
- Counts are computed AFTER agent filtering, matching the pre-builder sequencing.
- Truncation prefix semantics (.take(max_per_category)) preserved.
- ContextInputs struct-literal construction path retained for unit tests (minimal_inputs helper).

New unit coverage:
- ContextInputsBuilder: empty inputs, count derivation, truncation cap, cross-repo trailer (populated vs absent), end-to-end build() wiring.
- validate_and_resolve_params: defaults, explicit values, both reject paths.
- apply_agent_filter: re-pointed existing tests at the real helper.

Bead: unblock-eos.8