### PR TITLE
docs(spec): align §6.3/§13.3 pseudocode with §3.3 post-eos.4 signature

### DIFF
--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -960,7 +960,16 @@ pub async fn rebuild_cache(state) {
     state.cache.invalidate();
     let (issues, edges) = state.github.fetch_graph_data().await?;
     let graph = DependencyGraph::build(&issues, &edges);
-    let ready_set = graph.compute_ready_set(&issues);
+    // §3.3 Filter 3 / §14 Invariant 14(a): engine is the single chokepoint
+    // that scrubs cross-repo source issues from the ready-set projection.
+    // Callers pass the configured (owner, repo) so downstream consumers
+    // (cached `ready_set`, `ready`, `prime`, `update_status_fields`) inherit
+    // the guarantee without re-checking.
+    let ready_set = graph.compute_ready_set(
+        &issues,
+        state.github.owner(),
+        state.github.repo(),
+    );
     update_status_fields(state, &issues, &ready_set).await?;
     state.cache.update(ready_set, graph);
 }
@@ -1945,7 +1954,12 @@ proptest! {
         edges in vec(arb_edge(), 0..200),
     ) {
         let graph = DependencyGraph::build(&issues, &edges);
-        let ready = graph.compute_ready_set(&issues);
+        // Post-eos.4 signature (§3.3 Filter 3 / §14 Invariant 14(a)):
+        // `compute_ready_set` takes the configured (owner, repo) so that
+        // cross-repo source issues are scrubbed before blocker traversal.
+        // Generator `arb_issue()` produces issues in the configured repo so
+        // Filter 3 is a no-op here; Invariant 14(a) is exercised by #7 below.
+        let ready = graph.compute_ready_set(&issues, "owner", "repo");
         for issue in &ready {
             // No issue in ready set has an open blocker
             let blockers = graph.get_blockers(&issue.qualified_id);


### PR DESCRIPTION
Pseudocode drift fixed in two illustration blocks of `docs/specs/01-spec-mcp-foundation.md`:

- §6.3 `rebuild_cache` (was line 962, now 968): single-arg `compute_ready_set(&issues)` updated to pass the configured (owner, repo) via `state.github.owner()` / `state.github.repo()`, matching the production call-site in `tools/mod.rs::rebuild_cache`.

- §13.3 property-test sketch (was line 1919, now 1962): single-arg `compute_ready_set(&issues)` updated to the post-eos.4 signature `(&issues, "owner", "repo")`, with an inline comment clarifying that Filter 3 is a no-op for `arb_issue()` inputs and Invariant 14(a) is exercised by property #7.

Canonical signature in §3.3 (line 374) and §13.3 Graph invariants #7 (line 1981) were already correct; this aligns the illustration-only pseudocode with the contract. No semantic gap, no implementation impact — docs-only follow-up deferred from the unblock-eos.5 investigation.

Refs: unblock-eos.6, unblock-eos.5, unblock-eos.4