### PR TITLE
 refactor(mcp): parameterise test_state to dedup test_state_with_project (unblock-eos.38)

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -260,18 +260,20 @@ mod tests {
         // the FORBIDDEN messages; status_code is 403 so the un-upgraded
         // variant still reaches `github_error_to_mcp` with the right
         // bucket (INVALID_PARAMS).
+        //
+        // Uses an exact-string `assert_eq!` so the Display contract is
+        // symmetric with the empty-vector companion test below
+        // (`github_graphql_forbidden_display_empty_vec_renders_no_details_sentinel`):
+        // both cases pin the full rendered string, making the contract
+        // explicit and harder to accidentally weaken (bead
+        // `unblock-eos.36`).
         let err = GitHubGraphQLForbiddenSnafu {
             errors: vec!["Resource not accessible by integration".to_owned()],
         }
         .build();
-        let msg = err.to_string();
-        assert!(
-            msg.starts_with("GitHub GraphQL FORBIDDEN: "),
-            "unexpected display: {msg}"
-        );
-        assert!(
-            msg.contains("Resource not accessible by integration"),
-            "display must include FORBIDDEN messages: {msg}"
+        assert_eq!(
+            err.to_string(),
+            "GitHub GraphQL FORBIDDEN: Resource not accessible by integration"
         );
         assert_eq!(err.status_code(), 403);
     }

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -701,7 +701,7 @@ impl<'a> ContextInputsBuilder<'a> {
     /// optional drift warnings to obtain the borrow-based
     /// [`ContextInputs`].
     fn new(
-        repo: RepoIdentity<'a>,
+        repo_identity: RepoIdentity<'a>,
         stale_threshold_hours: u64,
         max_per_category: usize,
         filtered: CategorisedIssues,
@@ -712,11 +712,15 @@ impl<'a> ContextInputsBuilder<'a> {
         // preserving the visual field-order parity with [`ContextInputs`]
         // that the eos.32 comment at the struct definition depends on
         // (see bead `unblock-eos.34`, Option (i) trade-off).
+        //
+        // Parameter is named `repo_identity` rather than `repo` to avoid
+        // shadowing the destructured `repo: &'a str` field below (bead
+        // `unblock-eos.37`).
         let RepoIdentity {
             owner,
             repo,
             project_number,
-        } = repo;
+        } = repo_identity;
 
         // 1. Counts — computed AFTER agent filtering.
         let counts = PrimeCounts {

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -1544,11 +1544,21 @@ mod tests {
         }
     }
 
-    /// Create a `ServerState` for unit tests.
-    async fn test_state() -> ServerState {
+    /// Shared constructor for the `test_state*` fixture family.
+    ///
+    /// Builds a `ServerState` with `GITHUB_TOKEN` + `UNBLOCK_REPO`
+    /// pinned to the canonical unit-test values, optionally setting
+    /// `UNBLOCK_PROJECT` when `project_number` is `Some(_)`. Both
+    /// `test_state` (`None`) and `test_state_with_project(u64)`
+    /// (`Some(_)`) delegate here so future fixture variants can be
+    /// added without re-duplicating the setup (bead `unblock-eos.38`).
+    async fn test_state_inner(project_number: Option<u64>) -> ServerState {
         let config = Config::load_from(|key| match key {
             "GITHUB_TOKEN" => Ok("ghp_test_token_for_unit_tests".to_owned()),
             "UNBLOCK_REPO" => Ok("test-owner/test-repo".to_owned()),
+            "UNBLOCK_PROJECT" => project_number
+                .map(|n| n.to_string())
+                .ok_or(std::env::VarError::NotPresent),
             _ => Err(std::env::VarError::NotPresent),
         })
         .expect("test config should load");
@@ -1565,6 +1575,15 @@ mod tests {
             agent_client: std::sync::OnceLock::new(),
             connected_at: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Create a `ServerState` for unit tests.
+    ///
+    /// Thin wrapper over [`test_state_inner`] that leaves
+    /// `UNBLOCK_PROJECT` unset. Preserved as a zero-arg helper so the
+    /// existing call sites don't need to thread `None` through.
+    async fn test_state() -> ServerState {
+        test_state_inner(None).await
     }
 
     // ── Categorisation tests ──────────────────────────────────────────
@@ -1962,29 +1981,12 @@ mod tests {
 
     /// Build a [`ServerState`] with an explicit `UNBLOCK_PROJECT` value
     /// so the populated test can exercise the `Some(project_number)`
-    /// branch of [`RepoIdentity::from_state`]. Shape matches
-    /// [`test_state`] byte-for-byte apart from the extra env var.
+    /// branch of [`RepoIdentity::from_state`]. Thin wrapper over
+    /// [`test_state_inner`] — shares setup byte-for-byte with
+    /// [`test_state`] apart from the extra env var (bead
+    /// `unblock-eos.38`).
     async fn test_state_with_project(project_number: u64) -> ServerState {
-        let config = Config::load_from(|key| match key {
-            "GITHUB_TOKEN" => Ok("ghp_test_token_for_unit_tests".to_owned()),
-            "UNBLOCK_REPO" => Ok("test-owner/test-repo".to_owned()),
-            "UNBLOCK_PROJECT" => Ok(project_number.to_string()),
-            _ => Err(std::env::VarError::NotPresent),
-        })
-        .expect("test config should load");
-
-        let client = unblock_github::client::GitHubClient::new(&config)
-            .await
-            .expect("test client should initialize");
-
-        ServerState {
-            config: Arc::new(config),
-            github: Arc::new(client) as Arc<dyn unblock_github::GitHubApi>,
-            cache: Arc::new(GraphCache::new(Duration::from_secs(300))),
-            agent_kind: std::sync::OnceLock::new(),
-            agent_client: std::sync::OnceLock::new(),
-            connected_at: std::sync::OnceLock::new(),
-        }
+        test_state_inner(Some(project_number)).await
     }
 
     #[tokio::test]


### PR DESCRIPTION
Extract a shared `test_state_inner(project_number: Option<u64>)`
helper and have both `test_state()` (the zero-arg fixture, `None`)
and `test_state_with_project(u64)` (`Some(_)`) delegate to it. The
env-key closure now branches on `project_number` for `UNBLOCK_PROJECT`:
`Some(n)` returns `n.to_string()`, `None` returns
`std::env::VarError::NotPresent` — matching the prior per-fixture
behaviour exactly.

Removes the byte-for-byte duplication flagged by the review of
unblock-eos.34 while keeping both public fixture surfaces intact so
the 8 existing `test_state()` call sites and the single
`test_state_with_project(42)` call site don't need updates. The two
`repo_identity_from_state_*` tests added by eos.34 and both
`prime_markdown_*_cross_repo_section_*` golden-file integration tests
remain green.