### PR TITLE
 test(github): tighten with_repo_rejects_invalid_token_header to assert Error::GitRemote variant (unblock-29p.50)

### DIFF
--- a/crates/unblock-github/src/client.rs
+++ b/crates/unblock-github/src/client.rs
@@ -790,8 +790,14 @@ mod tests {
         assert_eq!(client.graphql_url(), "https://api.github.com/graphql");
     }
 
-    /// `with_repo` must surface the same `GitHubUnavailable` error as `new`
+    /// `with_repo` must surface the same `Error::GitRemote` error as `new`
     /// when the token contains bytes that are not valid for an HTTP header.
+    ///
+    /// Asserts BOTH the variant (`matches!`) AND the Display string — the
+    /// variant check pins the typed contract that callers pattern-match on
+    /// (`build_http_client` -> `GitRemoteSnafu`, not `GitHubUnavailable`),
+    /// while the Display check keeps the human-readable message stable for
+    /// log and error-propagation consumers.
     #[tokio::test]
     async fn with_repo_rejects_invalid_token_header() {
         let config = Config {
@@ -810,6 +816,10 @@ mod tests {
         let err = GitHubClient::with_repo(&config, "acme", "widgets")
             .await
             .expect_err("invalid token header should be rejected");
+        assert!(
+            matches!(err, Error::GitRemote { .. }),
+            "expected Error::GitRemote variant, got: {err:?}"
+        );
         let msg = err.to_string();
         assert!(
             msg.contains("invalid token header value"),

--- a/crates/unblock-github/src/client.rs
+++ b/crates/unblock-github/src/client.rs
@@ -54,8 +54,10 @@ impl GitHubClient {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::GitRemote`] if repo resolution fails, or
-    /// [`Error::GitHubUnavailable`] if the HTTP client cannot be built.
+    /// Returns [`Error::GitRemote`] if repo resolution fails, or if the HTTP
+    /// client cannot be built (e.g. the token is not a valid HTTP header
+    /// value — the invalid-header path is surfaced via `build_http_client`
+    /// as [`Error::GitRemote`] with status 500).
     #[allow(clippy::unused_async)] // Async signature required by callers; resolve_project_info() is separate.
     pub async fn new(config: &Config) -> Result<Self, Error> {
         let http = Self::build_http_client(&config.token)?;
@@ -101,8 +103,10 @@ impl GitHubClient {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::GitHubUnavailable`] if the HTTP client cannot be
-    /// built (e.g. the token is not a valid HTTP header value).
+    /// Returns [`Error::GitRemote`] if the HTTP client cannot be built
+    /// (e.g. the token is not a valid HTTP header value — the
+    /// invalid-header path is surfaced via `build_http_client` as
+    /// [`Error::GitRemote`] with status 500).
     #[allow(clippy::unused_async)] // Async signature kept symmetric with `new`.
     pub async fn with_repo(
         config: &Config,


### PR DESCRIPTION
The test previously commented that `with_repo` must surface the same
`GitHubUnavailable` error as `new`, but only asserted the Display
string. The actual returned variant is `Error::GitRemote` (via
`build_http_client` + `HeaderValue::from_str` -> `GitRemoteSnafu`),
so the typed contract was unenforced.

Add a `matches!(err, Error::GitRemote { .. })` assertion so the test
pins BOTH the variant and the Display string. Update the doc comment
to reference `Error::GitRemote` and explain why both assertions are
present (variant = typed contract for pattern-match callers; Display
= stable human-readable message for logs).

Pairs with unblock-29p.49 (docstring fix for `new` and `with_repo`
constructors).