### PR TITLE
 feat(github): extend FETCH_ISSUE_QUERY trackedBy with cross-repo identity (unblock-29p.43)

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -367,6 +367,19 @@ impl fmt::Display for PipelineStage {
 /// Used for dependency relationships (`blockedBy`, `blocking`),
 /// parent issues, and sub-issues returned by `fetch_issue()`.
 /// Contains only the fields available from nested GraphQL fragments.
+///
+/// # Repo identity (`repo_owner` / `repo_name`)
+///
+/// The GitHub `trackedByIssues` connection can return blockers from a
+/// different repository (cross-repo dependencies). When the GraphQL
+/// selection includes the blocker's `repository { owner { login } name }`
+/// subfields, the parser fills `repo_owner` and `repo_name` so callers
+/// can disambiguate a cross-repo blocker from a same-repo blocker.
+///
+/// For parent / sub-issues / `trackedInIssues` and for connections whose
+/// GraphQL selection omits `repository { ... }`, these fields remain
+/// `None` — the caller MUST treat `None` as "unknown / assume
+/// same-repo-as-enclosing-issue" to preserve backwards compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RelatedIssue {
     /// GitHub issue number.
@@ -375,6 +388,16 @@ pub struct RelatedIssue {
     pub title: String,
     /// GitHub native issue state.
     pub state: IssueState,
+    /// Repository owner login. `None` when the GraphQL selection did
+    /// not request `repository { owner { login } }` — callers MUST
+    /// treat `None` as "same repo as the containing issue".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_owner: Option<String>,
+    /// Repository name. `None` when the GraphQL selection did not
+    /// request `repository { name }` — callers MUST treat `None` as
+    /// "same repo as the containing issue".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_name: Option<String>,
 }
 
 /// A blocking edge in the dependency graph.

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -64,6 +64,12 @@ query FetchIssue($owner: String!, $repo: String!, $number: Int!) {
           number
           title
           state
+          repository {
+            name
+            owner {
+              login
+            }
+          }
         }
       }
       parent {
@@ -869,6 +875,16 @@ fn parse_comments(value: &serde_json::Value) -> Vec<IssueComment> {
 
 /// Parses a related-issues connection (blockedBy, blocking, subIssues) into
 /// [`RelatedIssue`] instances.
+///
+/// When an individual node carries a `repository { owner { login } name }`
+/// subfield set, those values populate the resulting
+/// [`RelatedIssue::repo_owner`] / [`RelatedIssue::repo_name`]. The
+/// `trackedByIssues` connection inside [`FETCH_ISSUE_QUERY`] selects
+/// those fields so blocker edges can disambiguate cross-repo blockers
+/// from same-repo blockers (required by `dep_remove` single-issue edge
+/// validation on cross-repo paths — see `unblock-29p.43`). Connections
+/// that omit the `repository` selection (e.g. `subIssues`,
+/// `trackedInIssues`, `parent`) simply leave the fields as `None`.
 fn parse_related_issues(value: &serde_json::Value, key: &str) -> Vec<RelatedIssue> {
     value
         .get(key)
@@ -880,10 +896,33 @@ fn parse_related_issues(value: &serde_json::Value, key: &str) -> Vec<RelatedIssu
                     number: json_u64(node, "number"),
                     title: json_string(node, "title"),
                     state: parse_issue_state(node),
+                    repo_owner: parse_related_repo_owner(node),
+                    repo_name: parse_related_repo_name(node),
                 })
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Parses the optional `repository.owner.login` subfield of a related-
+/// issue node. Returns `None` when the GraphQL selection omitted the
+/// subfield or when the value is not a string.
+fn parse_related_repo_owner(node: &serde_json::Value) -> Option<String> {
+    node.get("repository")
+        .and_then(|r| r.get("owner"))
+        .and_then(|o| o.get("login"))
+        .and_then(|l| l.as_str())
+        .map(String::from)
+}
+
+/// Parses the optional `repository.name` subfield of a related-issue
+/// node. Returns `None` when the GraphQL selection omitted the subfield
+/// or when the value is not a string.
+fn parse_related_repo_name(node: &serde_json::Value) -> Option<String> {
+    node.get("repository")
+        .and_then(|r| r.get("name"))
+        .and_then(|n| n.as_str())
+        .map(String::from)
 }
 
 /// Parses the parent issue field into an optional [`RelatedIssue`].
@@ -896,6 +935,9 @@ fn parse_parent_issue(value: &serde_json::Value) -> Option<RelatedIssue> {
         number: json_u64(parent, "number"),
         title: json_string(parent, "title"),
         state: parse_issue_state(parent),
+        // Parent does not select `repository { ... }` — same-repo semantics.
+        repo_owner: None,
+        repo_name: None,
     })
 }
 
@@ -1477,7 +1519,19 @@ mod tests {
             },
             "trackedBy": {
                 "nodes": [
-                    {"number": 10, "title": "Dep A", "state": "OPEN"}
+                    {
+                        "number": 10,
+                        "title": "Dep A",
+                        "state": "OPEN",
+                        // `FETCH_ISSUE_QUERY` trackedBy subselection
+                        // carries `repository { owner { login } name }`
+                        // so blockers can be disambiguated as same-repo
+                        // or cross-repo (see `unblock-29p.43`).
+                        "repository": {
+                            "name": "test-repo",
+                            "owner": {"login": "test-owner"}
+                        }
+                    }
                 ]
             },
             "parent": {"number": 1, "title": "Epic", "state": "OPEN"},
@@ -1517,9 +1571,26 @@ mod tests {
 
         assert_eq!(issue.blocked_by.len(), 1);
         assert_eq!(issue.blocked_by[0].number, 10);
+        // Repo identity must propagate end-to-end from the trackedBy
+        // subselection — load-bearing for cross-repo dep_remove edge
+        // validation (see `unblock-29p.43`).
+        assert_eq!(
+            issue.blocked_by[0].repo_owner.as_deref(),
+            Some("test-owner"),
+            "trackedBy blocker must carry repository.owner.login"
+        );
+        assert_eq!(
+            issue.blocked_by[0].repo_name.as_deref(),
+            Some("test-repo"),
+            "trackedBy blocker must carry repository.name"
+        );
 
         assert_eq!(issue.blocking.len(), 1);
         assert_eq!(issue.blocking[0].number, 20);
+        // trackedInIssues does NOT request the `repository` subselection
+        // — repo identity stays `None` (same-repo by convention).
+        assert!(issue.blocking[0].repo_owner.is_none());
+        assert!(issue.blocking[0].repo_name.is_none());
 
         let parent = issue.parent.expect("should have parent");
         assert_eq!(parent.number, 1);
@@ -1558,6 +1629,86 @@ mod tests {
         assert!(issue.sub_issues.is_empty());
         assert_eq!(issue.status, Status::Ready);
         assert_eq!(issue.priority, Priority::P2);
+    }
+
+    // ── parse_related_issues + repo identity (unblock-29p.43) ───────────
+
+    /// `FETCH_ISSUE_QUERY` trackedBy emits `repository { owner { login }
+    /// name }` so cross-repo blockers can be disambiguated. Verifies the
+    /// parser round-trips those subfields into `RelatedIssue`.
+    #[test]
+    fn parse_related_issues_extracts_cross_repo_identity() {
+        let json = serde_json::json!({
+            "trackedBy": {
+                "nodes": [
+                    {
+                        "number": 99,
+                        "title": "Cross-repo blocker",
+                        "state": "OPEN",
+                        "repository": {
+                            "name": "other-repo",
+                            "owner": {"login": "other-owner"}
+                        }
+                    }
+                ]
+            }
+        });
+        let blockers = parse_related_issues(&json, "trackedBy");
+        assert_eq!(blockers.len(), 1);
+        assert_eq!(blockers[0].number, 99);
+        assert_eq!(blockers[0].repo_owner.as_deref(), Some("other-owner"));
+        assert_eq!(blockers[0].repo_name.as_deref(), Some("other-repo"));
+    }
+
+    /// Connections whose GraphQL selection omits `repository { ... }`
+    /// (e.g. `trackedInIssues`, `subIssues`, `parent`) must leave
+    /// `repo_owner` / `repo_name` as `None`. Callers treat `None` as
+    /// "same repo as the containing issue" per `RelatedIssue` docs.
+    #[test]
+    fn parse_related_issues_without_repository_subfield_keeps_none() {
+        let json = serde_json::json!({
+            "subIssues": {
+                "nodes": [
+                    {"number": 7, "title": "Sub", "state": "OPEN"}
+                ]
+            }
+        });
+        let subs = parse_related_issues(&json, "subIssues");
+        assert_eq!(subs.len(), 1);
+        assert!(subs[0].repo_owner.is_none());
+        assert!(subs[0].repo_name.is_none());
+    }
+
+    /// A partial `repository` subfield (owner missing or name missing)
+    /// degrades the corresponding field to `None` without taking the
+    /// other side down with it — defensive parsing, matches the rest of
+    /// the graphql module's "missing field = default" posture.
+    #[test]
+    fn parse_related_issues_partial_repository_leaves_missing_field_none() {
+        let json = serde_json::json!({
+            "trackedBy": {
+                "nodes": [
+                    {
+                        "number": 11,
+                        "title": "Partial",
+                        "state": "OPEN",
+                        "repository": {"name": "only-name"}
+                    },
+                    {
+                        "number": 12,
+                        "title": "Other partial",
+                        "state": "OPEN",
+                        "repository": {"owner": {"login": "only-owner"}}
+                    }
+                ]
+            }
+        });
+        let blockers = parse_related_issues(&json, "trackedBy");
+        assert_eq!(blockers.len(), 2);
+        assert!(blockers[0].repo_owner.is_none());
+        assert_eq!(blockers[0].repo_name.as_deref(), Some("only-name"));
+        assert_eq!(blockers[1].repo_owner.as_deref(), Some("only-owner"));
+        assert!(blockers[1].repo_name.is_none());
     }
 
     // ── parse_graph_issue ──────────────────────────────────────────────

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -194,6 +194,11 @@ mod tests {
             number,
             title: format!("Blocker #{number}"),
             state,
+            // Claim tests target local blockers under the configured repo —
+            // leave repo identity unset (None = same-repo-as-enclosing per
+            // `RelatedIssue` docs).
+            repo_owner: None,
+            repo_name: None,
         }
     }
 

--- a/crates/unblock-mcp/src/tools/dep_remove.rs
+++ b/crates/unblock-mcp/src/tools/dep_remove.rs
@@ -14,19 +14,26 @@
 //!    and an edge cannot be "removed" from an issue to itself (which
 //!    would never have been creatable via `depends`). See the PR
 //!    description for the rationale; this is NOT hidden scope creep.
-//! 3. Pre-mutation edge-existence guard — **only when both endpoints are
-//!    `Local`** AND the cache is warm. The cached graph covers the
-//!    configured repo only (same rationale as the `depends` cycle check
-//!    at `server.rs:1273`), so the guard cannot apply to cross-repo
-//!    endpoints. When the cache is cold we skip the guard entirely and
-//!    rely on GitHub's server-side behaviour. GitHub's
-//!    `removeIssueDependency` is effectively idempotent on missing
-//!    edges, so skipping the guard never crashes — it just makes the
-//!    `removed=true` flag technically loose when the edge was already
-//!    absent, which spec §8.5 does not contractually forbid.
+//! 3. Pre-mutation edge-existence guard — honours spec §14 Invariant 11
+//!    ("Validation before mutation") on ALL paths. Branching, per
+//!    `unblock-29p.43`:
+//!    - **Warm cache AND both endpoints `Local`** — fast path: look up
+//!      the edge in the in-memory graph. When absent, surface
+//!      `INVALID_PARAMS` (spec §8.5 literal behaviour). No extra RTT.
+//!    - **Cold cache OR at least one endpoint cross-repo** — fetch the
+//!      source issue via [`GitHubApi::fetch_issue_ref`] (1 GraphQL RTT)
+//!      and scan its `trackedByIssues` list for the target. The
+//!      `FETCH_ISSUE_QUERY` trackedBy subselection carries
+//!      `repository { owner { login } name }` (see `graphql.rs`) so
+//!      cross-repo blockers are correctly disambiguated. When the
+//!      target is NOT present, early-return `DepRemoveResult { removed:
+//!      false, ... }` WITHOUT issuing the mutation — honours Invariant
+//!      11 (validated-absent + mutation would contradict) and saves one
+//!      wasted RTT.
 //! 4. Call [`GitHubApi::remove_blocked_by_refs`] inside
 //!    `execute_write_tool` so the mutation is followed by an atomic
-//!    cache invalidate + rebuild.
+//!    cache invalidate + rebuild. Only reached when the edge was
+//!    confirmed present.
 //! 5. Re-evaluate the source's blocker set against the freshly rebuilt
 //!    graph. If the source is `Local` AND `has_open_blockers` returns
 //!    `false` (zero open blockers remain), issue a best-effort Projects
@@ -35,8 +42,12 @@
 //!    project's `ProjectInfo` / `get_project_item_id` ladder is scoped
 //!    to the configured project, matching the cross-repo posture of the
 //!    `depends` handler (spec §5.6 footnote).
-//! 6. Return [`DepRemoveResult`] with `removed = true`, the rendered
-//!    source/target references, and a human-readable message.
+//! 6. Return [`DepRemoveResult`] with `removed = true` when the
+//!    mutation ran, or `removed = false` when the pre-mutation guard
+//!    proved the edge did not exist (cold-cache / cross-repo path
+//!    only; warm-local-local surfaces `INVALID_PARAMS` instead — see
+//!    step 3). The source/target are rendered in canonical
+//!    [`IssueRef`] form and `message` documents what happened.
 //!
 //! ## Status-transition policy when blockers remain
 //!
@@ -130,10 +141,12 @@ pub struct DepRemoveParams {
 /// `owner/repo#n` for a cross-repo reference.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct DepRemoveResult {
-    /// `true` when the blocking edge was removed. Spec §8.5 does not
-    /// contractually forbid `removed=true` for an already-absent edge
-    /// against a cold cache — see the module-level docs for the
-    /// trade-off.
+    /// `true` when the blocking edge existed and was removed;
+    /// `false` when the cold-cache / cross-repo single-issue edge-
+    /// existence check proved the edge did not exist and the
+    /// mutation was skipped (no-op early return). The warm + both-
+    /// `Local` path surfaces a `Validation` error instead of
+    /// `removed = false` — see the module-level docs.
     pub removed: bool,
     /// The source issue reference in canonical form.
     pub source: String,
@@ -207,27 +220,55 @@ fn parse_ref(value: &str) -> Result<IssueRef, ErrorData> {
     })
 }
 
-/// Warm-cache pre-mutation guard: reject when the edge from
-/// `source_qid` → `target_qid` is absent from the currently cached
-/// graph.
+/// Outcome of the pre-mutation edge-existence probe.
 ///
-/// Only meaningful when both endpoints are `Local` and the cache is
-/// warm; the caller MUST perform those checks before delegating.
-/// Returns `Ok(())` when the edge exists (or when the guard is not
-/// applicable), and a `Validation` [`ErrorData`] when the edge is
-/// absent from the current cache view.
+/// The three variants distinguish the decisions the handler must make:
+/// proceed with the mutation, early-return `removed: false`, or surface
+/// `INVALID_PARAMS` on the warm-cache fast path.
+#[derive(Debug, PartialEq, Eq)]
+enum EdgePresence {
+    /// The edge was confirmed present — proceed to
+    /// `remove_blocked_by_refs`.
+    Present,
+    /// The edge was proved absent via the single-issue probe
+    /// (cold-cache / cross-repo path). Return
+    /// `DepRemoveResult { removed: false, ... }` WITHOUT calling the
+    /// mutation (spec §14 Invariant 11 — validation before mutation;
+    /// calling the mutation after proving absence would contradict
+    /// the validation outcome).
+    MissingSkipMutation,
+}
+
+/// Warm-cache edge-existence guard: reject when the edge from
+/// `source_qid` → `target_qid` is absent from the currently cached
+/// graph. Only invoked when the cache is warm AND both endpoints are
+/// `Local` (see [`probe_edge_presence`]).
+///
+/// Returns `Ok(EdgePresence::Present)` when the edge exists, and a
+/// `Validation` [`ErrorData`] when the edge is absent — preserves the
+/// existing spec §8.5 "Validate edge exists in graph" literal behaviour
+/// (caller sees `INVALID_PARAMS`, no `removed: false` wire signal on the
+/// warm-local-local path).
 async fn guard_edge_exists(
     state: &ServerState,
     source_qid: &QualifiedId,
     target_qid: &QualifiedId,
-) -> Result<(), ErrorData> {
-    let Some(graph) = state.cache.get_graph().await else {
-        // Cache is cold — spec §8.5 warm-cache contract does not apply.
-        return Ok(());
-    };
+) -> Result<EdgePresence, ErrorData> {
+    let graph = state.cache.get_graph().await.ok_or_else(|| {
+        // Caller contract violation: `probe_edge_presence` MUST route
+        // to `fetch_issue_ref` when the cache is cold. Surface an
+        // internal error so the bug is visible in logs rather than
+        // silently bypassing the guard.
+        validation_error(
+            "dep_remove: internal invariant violated — guard_edge_exists \
+             invoked on a cold cache; expected warm-cache + both-Local fast path",
+        )
+    })?;
     let node_map = graph.node_map();
     match (node_map.get(source_qid), node_map.get(target_qid)) {
-        (Some(&s_idx), Some(&t_idx)) if graph.inner_graph().contains_edge(s_idx, t_idx) => Ok(()),
+        (Some(&s_idx), Some(&t_idx)) if graph.inner_graph().contains_edge(s_idx, t_idx) => {
+            Ok(EdgePresence::Present)
+        }
         _ => {
             // At least one endpoint is missing from the cached graph OR
             // the directed edge is not present. `fetch_graph_data`
@@ -239,6 +280,85 @@ async fn guard_edge_exists(
                 "dep_remove: no blocking edge exists from {source_qid} to {target_qid}"
             )))
         }
+    }
+}
+
+/// Single-issue edge-existence probe used by the cold-cache and cross-
+/// repo paths: call [`GitHubApi::fetch_issue_ref`] on `source_ref` and
+/// scan the returned `blocked_by` list for a blocker matching
+/// `target_qid`. The `FETCH_ISSUE_QUERY` trackedBy subselection carries
+/// `repository { owner { login } name }` so a cross-repo blocker is
+/// disambiguated from a same-repo blocker (see `unblock-29p.43`).
+///
+/// Returns:
+/// - `Ok(EdgePresence::Present)` — edge confirmed present; caller
+///   proceeds to mutation.
+/// - `Ok(EdgePresence::MissingSkipMutation)` — edge proved absent;
+///   caller MUST NOT call the mutation and instead returns
+///   `DepRemoveResult { removed: false, ... }` to honour Invariant 11.
+///
+/// Errors propagate through `github_error_to_mcp` so upstream failures
+/// (network, rate-limit, cross-repo FORBIDDEN) surface with the same
+/// classification used by the `show` tool.
+async fn probe_edge_via_fetch(
+    state: &ServerState,
+    source_ref: &IssueRef,
+    source_qid: &QualifiedId,
+    target_qid: &QualifiedId,
+) -> Result<EdgePresence, ErrorData> {
+    let issue = state
+        .github
+        .fetch_issue_ref(source_ref)
+        .await
+        .map_err(github_error_to_mcp)?;
+    let present = issue.blocked_by.iter().any(|blocker| {
+        // When the GraphQL selection omitted `repository { ... }` (e.g.
+        // same-repo blocker default today), `repo_owner` / `repo_name`
+        // are `None` — treat `None` as "same repo as the fetched source"
+        // per `RelatedIssue` contract.
+        let owner = blocker
+            .repo_owner
+            .as_deref()
+            .unwrap_or(source_qid.owner.as_str());
+        let repo = blocker
+            .repo_name
+            .as_deref()
+            .unwrap_or(source_qid.repo.as_str());
+        owner == target_qid.owner && repo == target_qid.repo && blocker.number == target_qid.number
+    });
+    if present {
+        Ok(EdgePresence::Present)
+    } else {
+        Ok(EdgePresence::MissingSkipMutation)
+    }
+}
+
+/// Pre-mutation edge-existence probe. Honours spec §14 Invariant 11 on
+/// every path (see module-level docs for the decision tree):
+///
+/// - Warm cache AND both endpoints `Local` — cache-lookup fast path
+///   via [`guard_edge_exists`]. Missing edge → `INVALID_PARAMS`.
+/// - Cold cache OR at least one endpoint cross-repo — single-issue
+///   GraphQL probe via [`probe_edge_via_fetch`]. Missing edge →
+///   `EdgePresence::MissingSkipMutation` (caller early-returns
+///   `removed: false`).
+async fn probe_edge_presence(
+    state: &ServerState,
+    source_ref: &IssueRef,
+    target_ref: &IssueRef,
+    source_qid: &QualifiedId,
+    target_qid: &QualifiedId,
+) -> Result<EdgePresence, ErrorData> {
+    let is_both_local = matches!(
+        (source_ref, target_ref),
+        (IssueRef::Local(_), IssueRef::Local(_))
+    );
+    let is_cache_warm = state.cache.is_fresh().await;
+
+    if is_both_local && is_cache_warm {
+        guard_edge_exists(state, source_qid, target_qid).await
+    } else {
+        probe_edge_via_fetch(state, source_ref, source_qid, target_qid).await
     }
 }
 
@@ -386,19 +506,26 @@ async fn update_status_to_ready(client: &dyn GitHubApi, issue_node_id: &str) {
 /// Execute the `dep_remove` tool handler.
 ///
 /// See the module-level docs for the full spec contract. Flow outline
-/// (mirrors spec §8.5):
+/// (mirrors spec §8.5 with the Invariant 11 tightening from
+/// `unblock-29p.43`):
 ///
 /// 1. Parse and normalize both references against the configured repo.
 /// 2. Reject `source == target` defensively on resolved
 ///    [`QualifiedId`]s.
-/// 3. Pre-mutation edge-existence guard (only when both endpoints are
-///    `Local` AND the cache is warm).
+/// 3. Pre-mutation edge-existence probe:
+///    - Warm cache AND both endpoints `Local` — in-memory graph
+///      lookup (fast path, 0 extra RTT). Missing edge →
+///      `INVALID_PARAMS`.
+///    - Cold cache OR cross-repo endpoints — single-issue
+///      [`GitHubApi::fetch_issue_ref`] probe (1 extra RTT). Missing
+///      edge → early-return `DepRemoveResult { removed: false, ... }`
+///      without calling the mutation.
 /// 4. Run [`GitHubApi::remove_blocked_by_refs`] inside
 ///    `execute_write_tool`.
 /// 5. Re-evaluate blockers on the source via `has_open_blockers` and,
 ///    when the source is `Local` AND newly has zero open blockers, fire
 ///    `update_status_to_ready` best-effort.
-/// 6. Return [`DepRemoveResult`].
+/// 6. Return [`DepRemoveResult`] with `removed = true`.
 ///
 /// # Errors
 ///
@@ -407,8 +534,11 @@ async fn update_status_to_ready(client: &dyn GitHubApi, issue_node_id: &str) {
 ///   `INVALID_PARAMS`.
 /// - `source == target` on resolved `QualifiedId`s → `INVALID_PARAMS`
 ///   with a `Validation` message.
-/// - (Warm-cache path only) the edge is absent from the cached graph →
-///   `INVALID_PARAMS` with a `Validation` message.
+/// - Warm cache AND both `Local` AND edge absent from the cached graph
+///   → `INVALID_PARAMS` with a `Validation` message (spec §8.5 literal
+///   behaviour preserved).
+/// - Cold cache / cross-repo single-issue probe fails (network, 403,
+///   GraphQL error) → propagated via `github_error_to_mcp`.
 /// - `remove_blocked_by_refs` fails → mapped via `github_error_to_mcp`
 ///   (e.g. 404 maps to `INVALID_PARAMS`).
 /// - Cache rebuild fails and leaves the cache empty AND the source is
@@ -416,6 +546,7 @@ async fn update_status_to_ready(client: &dyn GitHubApi, issue_node_id: &str) {
 ///   `show` to observe the final state (R3).
 ///
 /// [`GitHubApi::remove_blocked_by_refs`]: unblock_github::GitHubApi::remove_blocked_by_refs
+/// [`GitHubApi::fetch_issue_ref`]: unblock_github::GitHubApi::fetch_issue_ref
 #[instrument(
     skip(state, params),
     name = "handle_dep_remove",
@@ -461,13 +592,41 @@ pub async fn handle_dep_remove(
         )));
     }
 
-    // Step 3: warm-cache pre-mutation guard. The cached graph covers the
-    // configured repo only, so the guard only applies when BOTH
-    // endpoints are Local. If either endpoint is cross-repo, we skip
-    // the guard entirely and rely on GitHub's server-side behaviour —
-    // `removeIssueDependency` is idempotent on missing edges.
-    if let (IssueRef::Local(_), IssueRef::Local(_)) = (&source_ref, &target_ref) {
-        guard_edge_exists(state, &source_qid, &target_qid).await?;
+    // Step 3: pre-mutation edge-existence probe. Honours Invariant 11
+    // (§14 "Validation before mutation") on every path — warm cache +
+    // both-Local uses the in-memory cache lookup (preserves the spec
+    // §8.5 INVALID_PARAMS behaviour on a missing edge); cold cache OR
+    // cross-repo endpoints use a single-issue GraphQL probe via
+    // `fetch_issue_ref` on the source and scans its trackedBy list for
+    // the target (the query carries repository identity per
+    // unblock-29p.43).
+    match probe_edge_presence(state, &source_ref, &target_ref, &source_qid, &target_qid).await? {
+        EdgePresence::Present => {
+            // Fall through to the mutation in step 4.
+        }
+        EdgePresence::MissingSkipMutation => {
+            // Cold-cache / cross-repo probe proved the edge absent.
+            // Invariant 11 forbids mutating after validation failed, so
+            // we SKIP `remove_blocked_by_refs` entirely and surface a
+            // truthful `removed: false` on the wire. The warm + both-
+            // Local fast path never reaches this arm — it surfaces
+            // `INVALID_PARAMS` via `guard_edge_exists` instead.
+            let source_rendered = source_ref.to_string();
+            let target_rendered = target_ref.to_string();
+            info!(
+                source = %source_rendered,
+                target = %target_rendered,
+                "dep_remove: edge not present per single-issue probe — skipping mutation (removed=false)"
+            );
+            return Ok(DepRemoveResult {
+                removed: false,
+                source: source_rendered.clone(),
+                target: target_rendered.clone(),
+                message: format!(
+                    "No blocking edge to remove: {source_rendered} is not currently blocked by {target_rendered}"
+                ),
+            });
+        }
     }
 
     // Step 4: run the mutation inside execute_write_tool so the cache

--- a/crates/unblock-mcp/src/tools/show.rs
+++ b/crates/unblock-mcp/src/tools/show.rs
@@ -209,6 +209,8 @@ mod tests {
             number: 1,
             title: String::from("test"),
             state,
+            repo_owner: None,
+            repo_name: None,
         }
     }
 
@@ -237,6 +239,8 @@ mod tests {
             number: 42,
             title: String::from("Important task"),
             state: IssueState::Open,
+            repo_owner: None,
+            repo_name: None,
         };
         let show = ShowRelatedIssue::from(&ri);
         assert_eq!(show.number, 42);

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -2732,6 +2732,324 @@ async fn dep_remove_surfaces_error_when_post_mutation_rebuild_fails() {
     );
 }
 
+// ── dep_remove — cold-cache + cross-repo edge validation (unblock-29p.43)
+
+/// Build a fixture issue with a populated `blocked_by` list — the list
+/// is what `probe_edge_via_fetch` scans on the cold-cache / cross-repo
+/// path. The blocker's `repo_owner` / `repo_name` default to `None`
+/// (same-repo convention) unless the caller passes explicit values via
+/// the second argument.
+fn dep_remove_fixture_issue_with_blockers(
+    number: u64,
+    blockers: Vec<unblock_core::types::RelatedIssue>,
+) -> unblock_core::types::Issue {
+    let mut issue = dep_remove_fixture_issue(number);
+    issue.blocked_by = blockers;
+    issue
+}
+
+/// Helper: local (same-repo-as-configured) blocker — `repo_owner` /
+/// `repo_name` left as `None` so callers exercise the default-to-
+/// enclosing-repo branch in `probe_edge_via_fetch`.
+fn local_blocker(number: u64) -> unblock_core::types::RelatedIssue {
+    unblock_core::types::RelatedIssue {
+        number,
+        title: format!("Blocker #{number}"),
+        state: IssueState::Open,
+        repo_owner: None,
+        repo_name: None,
+    }
+}
+
+/// Helper: cross-repo blocker — explicit `repo_owner` / `repo_name` so
+/// the probe can distinguish a cross-repo blocker from a same-repo
+/// blocker of the same number (the `FETCH_ISSUE_QUERY` subselection
+/// extension in `unblock-29p.43`).
+fn cross_repo_blocker(owner: &str, repo: &str, number: u64) -> unblock_core::types::RelatedIssue {
+    unblock_core::types::RelatedIssue {
+        number,
+        title: format!("{owner}/{repo}#{number}"),
+        state: IssueState::Open,
+        repo_owner: Some(owner.to_owned()),
+        repo_name: Some(repo.to_owned()),
+    }
+}
+
+/// Cold cache, edge DOES exist → the handler calls `fetch_issue_ref`
+/// on the source, sees the target in `blocked_by`, proceeds to the
+/// mutation, and returns `removed: true`. Locks the cold-cache arm of
+/// `probe_edge_presence` — no cache pre-seeding, exactly one
+/// `fetch_issue_ref` call, exactly one `remove_blocked_by_refs` call.
+#[tokio::test]
+async fn dep_remove_cold_cache_validates_edge_via_single_issue_fetch() {
+    use unblock_mcp::tools::dep_remove::{DepRemoveParams, handle_dep_remove};
+
+    let mock = new_mock();
+
+    // Pre-mutation probe: source #42 reports #99 as an open blocker.
+    let source_with_blocker = dep_remove_fixture_issue_with_blockers(42, vec![local_blocker(99)]);
+    mock.push_fetch_issue_ref(Ok(source_with_blocker));
+
+    // Mutation succeeds.
+    mock.push_remove_blocked_by_refs(Ok(()));
+
+    // Post-mutation rebuild returns the two issues without any edges —
+    // source is now unblocked, so the Status-update ladder fires.
+    mock.push_fetch_graph_data(Ok((
+        vec![dep_remove_fixture_issue(42), dep_remove_fixture_issue(99)],
+        vec![],
+    )));
+    mock.push_field_ids(Some(dep_remove_field_ids()));
+    mock.push_resolve_project_info(Ok(unblock_github::projects::ProjectInfo {
+        id: "PVT_1".to_owned(),
+        number: 1,
+    }));
+    mock.push_get_project_item_id(Ok("PVTI_42".to_owned()));
+    mock.push_update_field(Ok(()));
+
+    // Cold cache — no seeding.
+    let state = state_with_mock(Arc::clone(&mock));
+    assert!(
+        !state.cache.is_fresh().await,
+        "precondition: cache must be cold"
+    );
+
+    let result = handle_dep_remove(
+        &state,
+        DepRemoveParams {
+            source: "42".to_owned(),
+            target: "99".to_owned(),
+        },
+    )
+    .await
+    .expect("cold-cache existing edge must drive a successful removal");
+
+    assert!(result.removed, "existing edge must be reported as removed");
+    assert_eq!(result.source, "#42");
+    assert_eq!(result.target, "#99");
+
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        1,
+        "cold-cache probe must call fetch_issue_ref exactly once"
+    );
+    assert_eq!(
+        calls.remove_blocked_by_refs(),
+        1,
+        "mutation must run when the edge was confirmed present"
+    );
+    assert_eq!(calls.fetch_graph_data(), 1, "one post-mutation rebuild");
+    assert_eq!(
+        calls.update_field(),
+        1,
+        "zero-blocker source must flip Status to ready"
+    );
+}
+
+/// Cold cache, edge does NOT exist → the probe reports absence and the
+/// handler MUST NOT call `remove_blocked_by_refs`. Response:
+/// `removed: false`, message explains "no blocking edge to remove".
+/// Locks Invariant 11 on the cold-cache path (spec §14 "Validation
+/// before mutation").
+#[tokio::test]
+async fn dep_remove_cold_cache_reports_false_when_edge_never_existed() {
+    use unblock_mcp::tools::dep_remove::{DepRemoveParams, handle_dep_remove};
+
+    let mock = new_mock();
+
+    // Source #42 has NO blockers — the probe returns an empty
+    // `blocked_by` so `probe_edge_via_fetch` yields MissingSkipMutation.
+    mock.push_fetch_issue_ref(Ok(dep_remove_fixture_issue_with_blockers(42, vec![])));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    assert!(
+        !state.cache.is_fresh().await,
+        "precondition: cache must be cold"
+    );
+
+    let result = handle_dep_remove(
+        &state,
+        DepRemoveParams {
+            source: "42".to_owned(),
+            target: "99".to_owned(),
+        },
+    )
+    .await
+    .expect("cold-cache absent edge must early-return, not error");
+
+    assert!(
+        !result.removed,
+        "absent edge must be reported as removed=false"
+    );
+    assert_eq!(result.source, "#42");
+    assert_eq!(result.target, "#99");
+    assert!(
+        result.message.contains("No blocking edge to remove"),
+        "message must document the no-op: {}",
+        result.message,
+    );
+
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        1,
+        "cold-cache probe must call fetch_issue_ref exactly once"
+    );
+    assert_eq!(
+        calls.remove_blocked_by_refs(),
+        0,
+        "Invariant 11: mutation MUST NOT run when the probe proved absence"
+    );
+    assert_eq!(
+        calls.remove_blocked_by_ref(),
+        0,
+        "single-side variant must NOT run either"
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "no mutation → no post-mutation rebuild"
+    );
+    assert_eq!(
+        calls.update_field(),
+        0,
+        "no mutation → no Status update ladder"
+    );
+}
+
+/// Cross-repo target, edge DOES exist → the probe (triggered by the
+/// non-Local target) sees the cross-repo blocker disambiguated via
+/// `RelatedIssue.repo_owner` / `.repo_name` (fetched by the extended
+/// `FETCH_ISSUE_QUERY` subselection), proceeds to the mutation, and
+/// returns `removed: true`. Locks the cross-repo arm of
+/// `probe_edge_presence`.
+#[tokio::test]
+async fn dep_remove_cross_repo_validates_edge_via_single_issue_fetch() {
+    use unblock_mcp::tools::dep_remove::{DepRemoveParams, handle_dep_remove};
+
+    let mock = new_mock();
+
+    // Source is local #42, target is cross-repo other/repo#99. The
+    // probe fetches the source and must find a blocker whose
+    // repository.owner.login == "other" AND repository.name == "repo"
+    // AND number == 99. `cross_repo_blocker` encodes that fixture.
+    let source_with_xrepo_blocker =
+        dep_remove_fixture_issue_with_blockers(42, vec![cross_repo_blocker("other", "repo", 99)]);
+    mock.push_fetch_issue_ref(Ok(source_with_xrepo_blocker));
+
+    mock.push_remove_blocked_by_refs(Ok(()));
+
+    // Post-mutation rebuild (source is local, so the rebuild + Status
+    // ladder still fires). No in-repo edges remain after the mutation.
+    mock.push_fetch_graph_data(Ok((vec![dep_remove_fixture_issue(42)], vec![])));
+    mock.push_field_ids(Some(dep_remove_field_ids()));
+    mock.push_resolve_project_info(Ok(unblock_github::projects::ProjectInfo {
+        id: "PVT_1".to_owned(),
+        number: 1,
+    }));
+    mock.push_get_project_item_id(Ok("PVTI_42".to_owned()));
+    mock.push_update_field(Ok(()));
+
+    // Warm the cache — but with NO edge in-repo. The handler must still
+    // use the cross-repo probe path, not the warm-cache fast path
+    // (which only fires on both-Local). Validates that the branch
+    // predicate is `is_both_local && is_cache_warm`, not just warm.
+    let state = state_with_mock(Arc::clone(&mock));
+    let pre_issues = vec![dep_remove_fixture_issue(42)];
+    let pre_graph = DependencyGraph::build(&pre_issues, &[]);
+    let pre_ready = pre_graph.compute_ready_set(&pre_issues, "acme", "widgets");
+    state.cache.update(pre_issues, pre_ready, pre_graph).await;
+    assert!(state.cache.is_fresh().await);
+
+    let result = handle_dep_remove(
+        &state,
+        DepRemoveParams {
+            source: "42".to_owned(),
+            target: "other/repo#99".to_owned(),
+        },
+    )
+    .await
+    .expect("cross-repo edge present must drive a successful removal");
+
+    assert!(result.removed);
+    assert_eq!(result.source, "#42");
+    assert_eq!(result.target, "other/repo#99");
+
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        1,
+        "cross-repo probe routes through fetch_issue_ref even with a warm cache"
+    );
+    assert_eq!(calls.remove_blocked_by_refs(), 1);
+    assert_eq!(calls.fetch_graph_data(), 1);
+}
+
+/// Cross-repo target, edge does NOT exist → probe returns absence, the
+/// handler early-returns `removed: false`, and the mutation MUST NOT
+/// run. Locks Invariant 11 on the cross-repo path.
+#[tokio::test]
+async fn dep_remove_cross_repo_reports_false_when_edge_never_existed() {
+    use unblock_mcp::tools::dep_remove::{DepRemoveParams, handle_dep_remove};
+
+    let mock = new_mock();
+
+    // Source #42 blocked only by a DIFFERENT cross-repo issue — the
+    // probe must reject the lookup because (owner, repo, number) does
+    // not match the target. This also guards against a naive scan that
+    // only compares `number` and would incorrectly accept other/repo#99
+    // when only other/different-repo#99 is present.
+    let source_with_unrelated_xrepo_blocker = dep_remove_fixture_issue_with_blockers(
+        42,
+        vec![cross_repo_blocker("other", "different-repo", 99)],
+    );
+    mock.push_fetch_issue_ref(Ok(source_with_unrelated_xrepo_blocker));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    assert!(
+        !state.cache.is_fresh().await,
+        "precondition: cache must be cold (also exercises cold+cross-repo)",
+    );
+
+    let result = handle_dep_remove(
+        &state,
+        DepRemoveParams {
+            source: "42".to_owned(),
+            target: "other/repo#99".to_owned(),
+        },
+    )
+    .await
+    .expect("cross-repo absent edge must early-return, not error");
+
+    assert!(!result.removed, "absent edge must yield removed=false");
+    assert_eq!(result.source, "#42");
+    assert_eq!(result.target, "other/repo#99");
+    assert!(
+        result.message.contains("No blocking edge to remove"),
+        "message must document the no-op: {}",
+        result.message,
+    );
+
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        1,
+        "cross-repo probe must call fetch_issue_ref exactly once"
+    );
+    assert_eq!(
+        calls.remove_blocked_by_refs(),
+        0,
+        "Invariant 11: mutation MUST NOT run when the probe proved absence"
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "no mutation → no post-mutation rebuild"
+    );
+    assert_eq!(calls.update_field(), 0);
+}
+
 // ── Create tool: integration tests ────────────────────────────────
 
 /// Create tool is registered in the server tool list.


### PR DESCRIPTION
The `FETCH_ISSUE_QUERY` trackedBy subselection previously returned only
`{number, title, state}` for each blocker — sufficient to enumerate
blockers under the enclosing issue's repo, but unable to distinguish a
cross-repo blocker from a same-repo one. `dep_remove`'s cold-cache and
cross-repo edge-validation paths (unblock-29p.43) need that
disambiguation to honour Invariant 11 (§14 "Validation before mutation")
without false positives.

Changes:
- `FETCH_ISSUE_QUERY.trackedBy.nodes` now selects
  `repository { owner { login } name }` alongside the existing fields.
- `RelatedIssue` gains two optional fields, `repo_owner` /
  `repo_name`, both `#[serde(default, skip_serializing_if = "Option::is_none")]`
  to stay wire-compatible with existing consumers. The module-level
  docstring states the semantics: `None` means "unknown / same repo as
  the containing issue" for connections whose GraphQL selection omits
  `repository { ... }` (parent, subIssues, trackedInIssues today).
- `parse_related_issues` extracts the new subfields via
  `parse_related_repo_owner` / `parse_related_repo_name`, defaulting to
  `None` when absent. `parse_parent_issue` is explicit about leaving
  them `None` since the `parent` GraphQL selection does not request
  `repository { ... }`.
- `FETCH_GRAPH_DATA_QUERY` is intentionally unchanged — its
  `trackedBy` subselection still returns only `{number}`, matching the
  existing fetch_graph_data contract. Cross-repo blocker identity lands
  only on the single-issue read path used by dep_remove validation.

Tests:
- Extend `parse_full_issue_from_json` with a populated `repository`
  subfield on the trackedBy blocker and assert `repo_owner` / `repo_name`
  propagate end-to-end; assert `blocking` (trackedInIssues) stays `None`.
- Add three focused unit tests:
  * `parse_related_issues_extracts_cross_repo_identity`
  * `parse_related_issues_without_repository_subfield_keeps_none`
  * `parse_related_issues_partial_repository_leaves_missing_field_none`
- Update two `RelatedIssue` literal constructors in `claim.rs` /
  `show.rs` test fixtures with explicit `repo_owner: None, repo_name: None`.

API: `RelatedIssue` gains two public fields `repo_owner: Option<String>`
and `repo_name: Option<String>`. Additive — old consumers ignore them
because both fields carry `#[serde(default, skip_serializing_if = ...)]`
and existing literal constructors only need the two new fields added.