### PR TITLE
 fix(mcp): surface 503 error when reopen rebuild cache lacks reopened issue (unblock-29p.34)

### DIFF
--- a/crates/unblock-mcp/src/tools/reopen.rs
+++ b/crates/unblock-mcp/src/tools/reopen.rs
@@ -328,8 +328,9 @@ async fn update_status_field(client: &dyn GitHubApi, issue_node_id: &str, slug: 
 /// - Cache rebuild fails and leaves the cache empty, or the rebuild
 ///   succeeds but the reopened issue is absent from the rebuilt set
 ///   (concurrent re-close race) → a 503-class
-///   `GitHubUnavailable`-style error is surfaced so the caller re-runs
-///   `show` to observe the final state (R3).
+///   [`GitHubApi`](unblock_github::errors::Error::GitHubApi) error is
+///   surfaced so the caller re-runs `show` to observe the final state
+///   (R3).
 #[instrument(
     skip(state, params),
     name = "handle_reopen",

--- a/crates/unblock-mcp/src/tools/reopen.rs
+++ b/crates/unblock-mcp/src/tools/reopen.rs
@@ -82,18 +82,27 @@
 //! this is not a new divergence. Once `unblock-a36` lands this caveat
 //! vanishes.
 //!
-//! ## R3 caveat — cache absent after rebuild
+//! ## R3 caveat — cannot compute `blocked` after rebuild
 //!
-//! If the `fetch_graph_data()` call inside [`crate::tools::rebuild_cache`]
-//! fails (e.g. transient GitHub 503), the cache is left invalidated and
-//! the handler cannot compute `blocked` locally. The reopen itself has
-//! already succeeded server-side, so the mutation is not lost. The
-//! handler surfaces this as a
-//! [`GitHubUnavailable`](unblock_github::errors::Error::GitHubUnavailable)-
-//! style error with a message instructing the caller to re-run `show`
-//! to observe the final status. This matches the stats R6 posture:
-//! propagate real errors rather than silently returning a
-//! degraded-but-plausible envelope.
+//! Two failure modes share a single posture:
+//!
+//! 1. **Empty cache.** If `fetch_graph_data()` inside
+//!    [`crate::tools::rebuild_cache`] fails (e.g. transient GitHub 503),
+//!    the cache is left invalidated.
+//! 2. **Missing issue (race).** If the rebuild succeeds but the
+//!    reopened issue is absent from the returned set — e.g. another
+//!    agent re-closed it between our `reopen_issue` mutation and the
+//!    `fetch_graph_data` rebuild — we cannot locate it in the cache.
+//!
+//! In both cases the reopen itself has already succeeded server-side,
+//! so the mutation is not lost. The handler surfaces a 503-class
+//! [`GitHubApi`](unblock_github::errors::Error::GitHubApi) error with a
+//! message instructing the caller to re-run `show` to observe the final
+//! status, rather than returning a fabricated `blocked = false`
+//! envelope. Matches the stats R6 posture: propagate real errors rather
+//! than silently returning a degraded-but-plausible envelope. Preserves
+//! spec §14 invariants 8 and 13 (no fictional Status/`blocked` claims
+//! when the graph cannot be consulted).
 //!
 //! ## Cache contract
 //!
@@ -300,7 +309,11 @@ async fn update_status_field(client: &dyn GitHubApi, issue_node_id: &str, slug: 
 ///    mutation is followed by a cache rebuild atomically.
 /// 3. Pull the fresh graph + issue vector from the cache; if either is
 ///    absent propagate a clear error (R3).
-/// 4. Compute `blocked` via the local `has_open_blockers` helper.
+/// 4. Locate the reopened issue in the rebuilt cache and compute
+///    `blocked` via the local `has_open_blockers` helper. If the issue
+///    is missing from the rebuilt set (short race window — another
+///    agent re-closed it between steps 2 and 3) surface a 503-class
+///    error instead of defaulting `blocked = false` (R3).
 /// 5. Best-effort Projects V2 Status update.
 /// 6. Return [`ReopenResult`].
 ///
@@ -312,7 +325,9 @@ async fn update_status_field(client: &dyn GitHubApi, issue_node_id: &str, slug: 
 /// - The fetched issue is not Closed → `IssueAlreadyOpen` (R2).
 /// - `reopen_issue` fails → mapped via `github_error_to_mcp` (e.g. 404
 ///   maps to `INVALID_PARAMS`).
-/// - Cache rebuild fails and leaves the cache empty → a
+/// - Cache rebuild fails and leaves the cache empty, or the rebuild
+///   succeeds but the reopened issue is absent from the rebuilt set
+///   (concurrent re-close race) → a 503-class
 ///   `GitHubUnavailable`-style error is surfaced so the caller re-runs
 ///   `show` to observe the final state (R3).
 #[instrument(
@@ -397,25 +412,34 @@ pub async fn handle_reopen(
     // Step 4: locate the reopened issue in the rebuilt cache and
     // compute `blocked` against the new graph. The fetch_graph_data
     // call already re-fetched the issue as Open (since reopen_issue
-    // succeeded), so the cache view is canonical.
-    let issue_ref = issues.iter().find(|i| i.number == issue_number);
-
-    let blocked = if let Some(issue) = issue_ref {
-        has_open_blockers(issue, graph.as_ref())
-    } else {
-        // The issue is missing from the rebuilt cache — this can happen
-        // if the upstream `fetch_graph_data` query loses the issue
-        // between the reopen and the rebuild (e.g. a race against
-        // another agent closing it again). Treat as unblocked; the
-        // Status update still lands since we captured the node_id
-        // above, and an agent re-running `show` observes the canonical
-        // state. Log a warning so this is observable in diagnostics.
+    // succeeded), so the cache view is canonical on the happy path.
+    //
+    // If the issue is missing from the rebuilt set — a short race
+    // window where another agent re-closed it between our
+    // `reopen_issue` mutation and the `fetch_graph_data` rebuild — we
+    // cannot compute `blocked` without consulting the graph. Surface a
+    // 503-class error (mirroring the empty-cache arm above) rather
+    // than silently defaulting to `blocked = false`, which would
+    // fabricate a ready/unblocked claim without actually evaluating
+    // the graph. Preserves spec §14 invariants 8 and 13. The reopen
+    // mutation remains durable on GitHub regardless of this failure.
+    let Some(issue) = issues.iter().find(|i| i.number == issue_number) else {
         warn!(
             issue_number,
-            "Reopened issue not present in rebuilt cache — treating as unblocked"
+            "Reopened issue not present in rebuilt cache (possible concurrent re-close) — surfacing partial-state error"
         );
-        false
+        return Err(github_error_to_mcp(
+            unblock_github::errors::GitHubApiSnafu {
+                status: 503_u16,
+                message: format!(
+                    "Issue #{issue_number} reopened successfully, but the rebuilt cache does not contain it (possible concurrent close by another agent) — please re-run `show` to observe the final blocked status"
+                ),
+            }
+            .build(),
+        ));
     };
+
+    let blocked = has_open_blockers(issue, graph.as_ref());
 
     let slug = if blocked { "blocked" } else { "ready" };
 

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -2382,6 +2382,75 @@ async fn reopen_surfaces_error_when_post_reopen_rebuild_fails() {
     );
 }
 
+/// R3 race-window path: when the post-reopen cache rebuild succeeds
+/// (returning a non-empty issue set) but the reopened issue is absent
+/// from the rebuilt set — e.g. another agent re-closed it between our
+/// `reopen_issue` mutation and the `fetch_graph_data` rebuild — the
+/// handler MUST NOT silently default `blocked = false` and return
+/// `status = "ready"`. It must surface a 503-class error instructing
+/// the caller to re-run `show`, mirroring the empty-cache arm.
+/// Preserves spec §14 invariants 8 and 13 (no fictional Status claims
+/// when the graph cannot actually be consulted for the reopened issue).
+#[tokio::test]
+async fn reopen_surfaces_error_when_rebuilt_cache_missing_reopened_issue() {
+    use unblock_mcp::tools::reopen::{ReopenParams, handle_reopen};
+
+    let mock = new_mock();
+
+    // Phase 1: fetch + reopen both succeed.
+    let closed = reopen_fixture_issue(42, Status::Closed, IssueState::Closed);
+    mock.push_fetch_issue(Ok(closed));
+    mock.push_reopen_issue(Ok(()));
+
+    // Post-reopen rebuild SUCCEEDS but returns a set that does NOT
+    // contain the reopened issue #42. Simulates the race where another
+    // agent re-closed #42 between our mutation and the rebuild. The
+    // rebuilt graph is non-trivial (issue #7 is present) so the
+    // empty-cache arm at reopen.rs:382-410 is explicitly NOT exercised
+    // here — the missing-issue arm at :426-440 is.
+    let unrelated = reopen_fixture_issue(7, Status::Ready, IssueState::Open);
+    mock.push_fetch_graph_data(Ok((vec![unrelated], vec![])));
+
+    let state = state_with_mock(Arc::clone(&mock));
+
+    let err = handle_reopen(&state, ReopenParams { id: 42 })
+        .await
+        .expect_err(
+            "rebuilt cache missing the reopened issue must surface as a handler error (R3 race)",
+        );
+
+    // 503 → INTERNAL_ERROR per github_error_to_mcp.
+    assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    // The error must reference the partial-state guidance so agents
+    // know to retry `show`.
+    assert!(
+        err.message.contains("reopened") && err.message.contains("show"),
+        "error message must instruct caller to re-run `show`: {}",
+        err.message,
+    );
+
+    // Despite the race, the reopen mutation DID land — it is durable.
+    assert_eq!(
+        mock.calls().reopen_issue(),
+        1,
+        "reopen is durable: mutation persists even if the rebuilt cache races",
+    );
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(
+        mock.calls().fetch_graph_data(),
+        1,
+        "post-reopen rebuild is attempted exactly once",
+    );
+
+    // The rebuild itself succeeded (returned a non-empty issue set),
+    // so execute_write_tool leaves the cache in a fresh state. Only
+    // the *reopened* issue is missing from that fresh cache.
+    assert!(
+        state.cache.is_fresh().await,
+        "cache must be fresh when the rebuild succeeded — only the reopened issue is missing",
+    );
+}
+
 // ── dep_remove tool: integration tests ────────────────────────────
 
 /// Build a [`ProjectFieldIds`] fixture with a populated Status-option map

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -1482,6 +1482,16 @@ pub struct ReopenResult {
 5. If no open blockers: Status → `ready`
 6. Update cache
 
+**Post-rebuild re-evaluation failure.** If the rebuild succeeds but the
+reopened issue cannot be located in the rebuilt graph (transient 503, or
+the issue has been re-closed concurrently between steps 2 and 3), the
+tool MUST surface a 503-class error with a message instructing the
+caller to re-run `show` rather than defaulting `blocked` to `false`. The
+`reopen` mutation is durable on GitHub regardless of this failure — the
+error signals only the inability to compute the final `blocked` /
+`status` fields locally. Preserves §14 invariants 8 and 13 (no fictional
+Status/`blocked` claims when the graph cannot actually be consulted).
+
 **API calls:** 1 (fetch) + 1 (reopen) + 1-2 (fields) + 1+ (rebuild)
 **Cache:** Invalidates.
 


### PR DESCRIPTION
The post-reopen rebuild can succeed (non-empty issues set) while still
omitting the reopened issue — a short race window where another agent
re-closed the issue between our \`reopen_issue\` mutation and the
\`fetch_graph_data\` rebuild. The previous handler silently defaulted
\`blocked = false\` and returned \`status = "ready"\` in this branch,
fabricating a ready claim without actually consulting the graph.

Flip the branch to surface the same 503-class \`GitHubApi\` error used
by the empty-cache arm, with a \`show\` retry hint. Restructure the
\`if let\` into \`let Some(...) = ... else { return Err(...) }\` so the
happy path stays linear. Extend the R3 module-doc to cover both
failure modes (empty cache + missing issue) and update the function
\`# Errors\` bullet to match. Preserves spec §14 invariants 8 and 13.

Binary crate (unblock-mcp) — no library API change.