### PR TITLE
fix(mcp): surface 503 when close post-rebuild cache is empty (R3)

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1002,6 +1002,17 @@ impl UnblockServer {
     ///
     /// This is a write tool -- uses `execute_write_tool` for the close mutation
     /// and cache rebuild, then performs cascade updates as a second phase.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ErrorData`] in the following cases:
+    /// - `fetch_issue` fails (e.g. 404) → mapped via `github_error_to_mcp`.
+    /// - The fetched issue is already Closed → `IssueClosed` domain error.
+    /// - `close_issue` fails → mapped via `github_error_to_mcp`.
+    /// - Cache rebuild fails and leaves the cache empty → a 503-class
+    ///   [`GitHubApi`](unblock_github::errors::Error::GitHubApi) error is
+    ///   surfaced so the caller re-runs `show` to observe the final cascade
+    ///   state (R3 — see `tools::close` module-doc).
     #[tool(
         name = "close",
         description = "Close an issue and cascade-unblock dependents. Validates the issue is open, closes it, updates project fields (Status=Done), and auto-unblocks any dependent issues whose blockers are now all closed. Returns the list of newly unblocked issue numbers. Triggers graph rebuild."
@@ -1093,48 +1104,68 @@ impl UnblockServer {
         .await?;
 
         // Phase 2: Compute cascade from the freshly rebuilt cache.
-        let mut unblocked = Vec::new();
-        let mut cross_repo_refs: Option<unblock_core::types::CrossRepoRefs> = None;
+        //
+        // R3 — honest partial state (see `tools::close` module-doc):
+        // if the rebuild inside `execute_write_tool` failed, the cache is
+        // empty. The close mutation has already succeeded server-side, but
+        // we cannot compute the cascade here. Surface a 503-class error
+        // instructing the caller to re-run `show`, rather than silently
+        // returning `unblocked = []`, `cross_repo_refs = None` — a
+        // fabricated "no cascade" claim indistinguishable from a
+        // legitimate leaf-close. Preserves §14 invariants 8 and 13.
+        let Some(graph) = state.cache.get_graph().await else {
+            tracing::warn!(
+                issue_number,
+                "Cache not available after close — rebuild failed; caller must re-run `show` to observe final cascade"
+            );
+            return Err(crate::errors::github_error_to_mcp(
+                unblock_github::errors::GitHubApiSnafu {
+                    status: 503_u16,
+                    message: format!(
+                        "Issue #{issue_number} closed successfully, but cache rebuild failed — please re-run `show` to observe the final cascade state"
+                    ),
+                }
+                .build(),
+            ));
+        };
 
-        if let Some(graph) = state.cache.get_graph().await {
-            // compute_unblock_cascade's _all_issues param is currently unused —
-            // pass an empty slice (see graph.rs:215-220 for rationale).
-            let issue_qid =
-                unblock_core::types::QualifiedId::new(client.owner(), client.repo(), issue_number);
-            let cascade = graph.compute_unblock_cascade(&issue_qid, &[]);
+        // compute_unblock_cascade's _all_issues param is currently unused —
+        // pass an empty slice (see graph.rs:215-220 for rationale).
+        let issue_qid =
+            unblock_core::types::QualifiedId::new(client.owner(), client.repo(), issue_number);
+        let cascade = graph.compute_unblock_cascade(&issue_qid, &[]);
 
-            // Phase 3: For each newly unblocked issue, update project fields and
-            // post an unblock comment. Each update is best-effort — failures are
-            // logged but do not abort the cascade.
-            //
-            // SPEC §8.2 step 6 / §11.4 row 4 / §5.6 row `close`: cross-repo
-            // dependents ARE still cascade-updated. The loop dispatches via
-            // the `*_ref` primitives so the comment and issue-fetch land on
-            // the correct `(owner, repo)` — bare-`u64` variants would silently
-            // retarget the configured repo (unblock-eos.13 finding RISK #2).
-            // Project-field updates remain scoped to the configured board
-            // because `project_id` / `item_id` are globally scoped node IDs;
-            // if a cross-repo dependent is not on the board,
-            // `get_project_item_id` fails best-effort and the comment still
-            // lands — matching the spec intent of "cascade side-effects only".
-            let configured_owner = client.owner().to_owned();
-            let configured_repo = client.repo().to_owned();
-            for cascaded_qid in &cascade {
-                // Normalize to IssueRef so the downstream call dispatches via
-                // the `_ref` primitive: `add_comment_ref` matches on the
-                // IssueRef variant, and both arms ultimately funnel through
-                // `add_comment_in_repo` — `Local` delegates to `add_comment`
-                // (which calls `add_comment_in_repo` with the configured
-                // `(owner, repo)`), and `CrossRepo` calls `add_comment_in_repo`
-                // directly with the ref's own `(owner, repo)`. Collapsing a
-                // QualifiedId whose `(owner, repo)` matches the configured
-                // repo to `Local` keeps the configured-repo path tagged as
-                // such (and preserves the `add_comment` tracing span /
-                // instrumented fields) rather than routing an
-                // effectively-local ref through the CrossRepo arm.
-                let cascaded_ref = if cascaded_qid.owner == configured_owner
-                    && cascaded_qid.repo == configured_repo
-                {
+        // Phase 3: For each newly unblocked issue, update project fields and
+        // post an unblock comment. Each update is best-effort — failures are
+        // logged but do not abort the cascade.
+        //
+        // SPEC §8.2 step 6 / §11.4 row 4 / §5.6 row `close`: cross-repo
+        // dependents ARE still cascade-updated. The loop dispatches via
+        // the `*_ref` primitives so the comment and issue-fetch land on
+        // the correct `(owner, repo)` — bare-`u64` variants would silently
+        // retarget the configured repo (unblock-eos.13 finding RISK #2).
+        // Project-field updates remain scoped to the configured board
+        // because `project_id` / `item_id` are globally scoped node IDs;
+        // if a cross-repo dependent is not on the board,
+        // `get_project_item_id` fails best-effort and the comment still
+        // lands — matching the spec intent of "cascade side-effects only".
+        let configured_owner = client.owner().to_owned();
+        let configured_repo = client.repo().to_owned();
+        for cascaded_qid in &cascade {
+            // Normalize to IssueRef so the downstream call dispatches via
+            // the `_ref` primitive: `add_comment_ref` matches on the
+            // IssueRef variant, and both arms ultimately funnel through
+            // `add_comment_in_repo` — `Local` delegates to `add_comment`
+            // (which calls `add_comment_in_repo` with the configured
+            // `(owner, repo)`), and `CrossRepo` calls `add_comment_in_repo`
+            // directly with the ref's own `(owner, repo)`. Collapsing a
+            // QualifiedId whose `(owner, repo)` matches the configured
+            // repo to `Local` keeps the configured-repo path tagged as
+            // such (and preserves the `add_comment` tracing span /
+            // instrumented fields) rather than routing an
+            // effectively-local ref through the CrossRepo arm.
+            let cascaded_ref =
+                if cascaded_qid.owner == configured_owner && cascaded_qid.repo == configured_repo {
                     unblock_core::types::IssueRef::Local(cascaded_qid.number)
                 } else {
                     unblock_core::types::IssueRef::CrossRepo {
@@ -1143,93 +1174,90 @@ impl UnblockServer {
                         number: cascaded_qid.number,
                     }
                 };
-                // Post unblock comment. Stays best-effort per the pre-existing
-                // §8.2 step 6 semantics — the token may lack write scope on a
-                // foreign repo and we must not tear down the cascade for a
-                // permission error (see unblock-eos.13 investigation Risks).
-                // Qualified ID is logged so operators can distinguish
-                // local-repo failures from cross-repo permission denials.
-                let comment_body = format!("\u{2705} Unblocked by closing #{issue_number}");
-                if let Err(e) = client.add_comment_ref(&cascaded_ref, comment_body).await {
-                    tracing::warn!(
-                        cascaded_qid = %cascaded_qid,
-                        error = %e,
-                        "Failed to post unblock comment on cascaded issue"
-                    );
-                }
+            // Post unblock comment. Stays best-effort per the pre-existing
+            // §8.2 step 6 semantics — the token may lack write scope on a
+            // foreign repo and we must not tear down the cascade for a
+            // permission error (see unblock-eos.13 investigation Risks).
+            // Qualified ID is logged so operators can distinguish
+            // local-repo failures from cross-repo permission denials.
+            let comment_body = format!("\u{2705} Unblocked by closing #{issue_number}");
+            if let Err(e) = client.add_comment_ref(&cascaded_ref, comment_body).await {
+                tracing::warn!(
+                    cascaded_qid = %cascaded_qid,
+                    error = %e,
+                    "Failed to post unblock comment on cascaded issue"
+                );
+            }
 
-                // Update Projects V2 fields:
-                // Status → ready (if not already InProgress).
-                // TODO(unblock-b6b.79): Third copy of field update ladder — extract shared helper.
-                if let Some(field_ids) = client.field_ids().await
-                    && let Ok(project_info) = client.resolve_project_info().await
-                {
-                    // Fetch the cascaded issue (by ref, not bare number) to
-                    // get its node_id and current status. For cross-repo
-                    // dependents this reads from the foreign repo; for local
-                    // the _ref variant delegates to the unchanged path.
-                    match client.fetch_issue_ref(&cascaded_ref).await {
-                        Ok(cascaded_issue) => {
-                            if let Ok(item_id) = client
-                                .get_project_item_id(&cascaded_issue.node_id, &project_info.id)
-                                .await
+            // Update Projects V2 fields:
+            // Status → ready (if not already InProgress).
+            // TODO(unblock-b6b.79): Third copy of field update ladder — extract shared helper.
+            if let Some(field_ids) = client.field_ids().await
+                && let Ok(project_info) = client.resolve_project_info().await
+            {
+                // Fetch the cascaded issue (by ref, not bare number) to
+                // get its node_id and current status. For cross-repo
+                // dependents this reads from the foreign repo; for local
+                // the _ref variant delegates to the unchanged path.
+                match client.fetch_issue_ref(&cascaded_ref).await {
+                    Ok(cascaded_issue) => {
+                        if let Ok(item_id) = client
+                            .get_project_item_id(&cascaded_issue.node_id, &project_info.id)
+                            .await
+                        {
+                            // Status → ready (only if not already InProgress).
+                            if cascaded_issue.status != unblock_core::types::Status::InProgress
+                                && let Some(option_id) = field_ids.status.options.get("ready")
+                                && let Err(e) = client
+                                    .update_field(
+                                        &project_info.id,
+                                        &item_id,
+                                        &field_ids.status.field_id,
+                                        &FieldValue::SingleSelectOption(option_id.clone()),
+                                    )
+                                    .await
                             {
-                                // Status → ready (only if not already InProgress).
-                                if cascaded_issue.status != unblock_core::types::Status::InProgress
-                                    && let Some(option_id) = field_ids.status.options.get("ready")
-                                    && let Err(e) = client
-                                        .update_field(
-                                            &project_info.id,
-                                            &item_id,
-                                            &field_ids.status.field_id,
-                                            &FieldValue::SingleSelectOption(option_id.clone()),
-                                        )
-                                        .await
-                                {
-                                    tracing::warn!(
-                                        cascaded_qid = %cascaded_qid,
-                                        error = %e,
-                                        "Failed to set Status=ready on cascaded issue"
-                                    );
-                                }
-                            } else {
-                                // Expected for cross-repo dependents that
-                                // were never added as ProjectV2 items on the
-                                // configured board — best-effort per §5.6.
                                 tracing::warn!(
                                     cascaded_qid = %cascaded_qid,
-                                    "Failed to get project item ID for cascaded issue"
+                                    error = %e,
+                                    "Failed to set Status=ready on cascaded issue"
                                 );
                             }
-                        }
-                        Err(e) => {
+                        } else {
+                            // Expected for cross-repo dependents that
+                            // were never added as ProjectV2 items on the
+                            // configured board — best-effort per §5.6.
                             tracing::warn!(
                                 cascaded_qid = %cascaded_qid,
-                                error = %e,
-                                "Failed to fetch cascaded issue for field updates"
+                                "Failed to get project item ID for cascaded issue"
                             );
                         }
                     }
+                    Err(e) => {
+                        tracing::warn!(
+                            cascaded_qid = %cascaded_qid,
+                            error = %e,
+                            "Failed to fetch cascaded issue for field updates"
+                        );
+                    }
                 }
             }
-
-            // SPEC §8.2 flow step 9 / §11.4 row 4: partition the cascade
-            // into local dependents (projected to `unblocked: Vec<u64>`)
-            // vs cross-repo dependents (surfaced via `cross_repo_refs`).
-            // The Phase 3 loop above intentionally does NOT gate on
-            // (owner, repo) == (config.owner, config.repo) — cross-repo
-            // dependents ARE still cascade-updated; only the response
-            // shape differs here (SPEC §11.4 affected-tools table).
-            let (local_unblocked, cross_repo_accum) =
-                crate::tools::cross_repo::project_cascade(&cascade, client.owner(), client.repo());
-            unblocked = local_unblocked;
-            cross_repo_refs = crate::tools::cross_repo::build_cross_repo_refs_with_summary(
-                cross_repo_accum,
-                crate::tools::cross_repo::close_summary,
-            );
-        } else {
-            tracing::warn!("Cache not available after rebuild — cascade computation skipped");
         }
+
+        // SPEC §8.2 flow step 9 / §11.4 row 4: partition the cascade
+        // into local dependents (projected to `unblocked: Vec<u64>`)
+        // vs cross-repo dependents (surfaced via `cross_repo_refs`).
+        // The Phase 3 loop above intentionally does NOT gate on
+        // (owner, repo) == (config.owner, config.repo) — cross-repo
+        // dependents ARE still cascade-updated; only the response
+        // shape differs here (SPEC §11.4 affected-tools table).
+        let (local_unblocked, cross_repo_accum) =
+            crate::tools::cross_repo::project_cascade(&cascade, client.owner(), client.repo());
+        let unblocked = local_unblocked;
+        let cross_repo_refs = crate::tools::cross_repo::build_cross_repo_refs_with_summary(
+            cross_repo_accum,
+            crate::tools::cross_repo::close_summary,
+        );
 
         Ok(Json(CloseResult {
             issue: issue_number,

--- a/crates/unblock-mcp/src/tools/close.rs
+++ b/crates/unblock-mcp/src/tools/close.rs
@@ -13,6 +13,27 @@
 //! vector is scoped to the configured repo; cross-repo dependents are surfaced
 //! in [`CloseResult::cross_repo_refs`] (`Some` iff at least one cross-repo
 //! dependent participated in the cascade, per SPEC §14 Invariant 14(b)).
+//!
+//! ## R3 caveat — cannot compute unblock cascade after rebuild
+//!
+//! After the close mutation lands and `execute_write_tool` rebuilds the
+//! cache, the handler reads [`GraphCache::get_graph`][`unblock_core::cache::GraphCache::get_graph`]
+//! to compute the cascade. When that read returns `None` — either because
+//! the underlying `fetch_graph_data()` call failed (e.g. transient GitHub
+//! 503) and left the cache invalidated, OR because the closed issue was
+//! excluded from the rebuilt graph in a way that makes the cascade
+//! uncomputable — the handler cannot authoritatively answer "which
+//! dependents were unblocked". The close itself has already succeeded
+//! server-side, so the mutation is not lost. The handler surfaces a
+//! 503-class [`GitHubApi`](unblock_github::errors::Error::GitHubApi)
+//! error with a message instructing the caller to re-run `show` to
+//! observe the final cascade state, rather than returning a fabricated
+//! `unblocked = []`, `cross_repo_refs = None` envelope (which would be
+//! indistinguishable from a legitimate leaf-close with no cascade).
+//! Mirrors the reopen R3 posture. Preserves spec §14 invariants 8 (no
+//! write leaves cache or Status fields inconsistent) and 13 (Status
+//! field values match graph computation — we refuse to pretend no
+//! dependents exist when we cannot consult the graph).
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -5416,3 +5416,90 @@ async fn close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade() 
     assert_eq!(mock.calls().close_issue(), 1);
     assert_eq!(mock.calls().fetch_graph_data(), 1);
 }
+
+/// R3 empty-cache arm — when the post-close cache rebuild fails
+/// (transient 503 from GitHub GraphQL), `execute_write_tool` leaves
+/// the cache empty and `state.cache.get_graph()` returns `None`. The
+/// close handler MUST NOT silently default `unblocked = []`,
+/// `cross_repo_refs = None` (which is indistinguishable from a
+/// legitimate leaf-close with no cascade). It must surface a
+/// 503-class error instructing the caller to re-run `show` to
+/// observe the final cascade state. Preserves spec §14 invariants 8
+/// and 13 (no fictional cascade/Status claims when the graph cannot
+/// be consulted). Mirrors the reopen R3 regression guard at
+/// `reopen_surfaces_error_when_post_reopen_rebuild_fails`.
+#[tokio::test]
+async fn close_surfaces_error_when_rebuilt_cache_missing_closed_issue() {
+    use rmcp::handler::server::wrapper::Parameters;
+    use unblock_github::errors::GitHubApiSnafu;
+    use unblock_mcp::server::UnblockServer;
+    use unblock_mcp::tools::close::CloseParams;
+
+    let mock = new_mock();
+
+    // Phase 1: fetch + close both succeed.
+    mock.push_fetch_issue(Ok(close_fixture_issue(8)));
+    mock.push_close_issue(Ok(()));
+    // Phase 1 field-ladder: None skips the Projects V2 update on #8
+    // so `update_field` is not called from the write-tool closure.
+    mock.push_field_ids(None);
+    // Post-close rebuild: simulate a transient 503 — `execute_write_tool`
+    // leaves the cache empty after logging the error, so the close
+    // handler's cache-check falls through to the R3 "surface an error"
+    // early return.
+    mock.push_fetch_graph_data(Err(GitHubApiSnafu {
+        status: 503_u16,
+        message: "upstream service unavailable".to_owned(),
+    }
+    .build()));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+
+    // `rmcp::Json` does not implement `Debug`, so we can't use
+    // `expect_err` here — destructure directly with `let...else`.
+    let result = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await;
+    let Err(err) = result else {
+        panic!("cache rebuild failure must surface as a handler error (R3)");
+    };
+
+    // 503 → INTERNAL_ERROR per github_error_to_mcp.
+    assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+    // Family-consistency with reopen: the error must reference both
+    // `closed` (the mutation verb) and `show` (the recovery hint) so
+    // agents recognise the "re-run show" guidance.
+    assert!(
+        err.message.contains("closed") && err.message.contains("show"),
+        "error message must instruct caller to re-run `show`: {}",
+        err.message,
+    );
+
+    // Despite the rebuild failure, the close mutation DID land — it
+    // is durable on GitHub regardless of the local cache outcome.
+    assert_eq!(
+        mock.calls().close_issue(),
+        1,
+        "close is durable: mutation persists even if rebuild fails",
+    );
+    assert_eq!(mock.calls().fetch_issue(), 1);
+    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // With `field_ids = None`, the Phase 1 Projects V2 ladder
+    // short-circuits at the `tracing::debug!` branch — no
+    // `update_field` fires for the closed issue.
+    assert_eq!(
+        mock.calls().update_field(),
+        0,
+        "status update should be skipped under error — no best-effort Phase 1 field updates fire when field_ids=None",
+    );
+    // Cache is invalidated by `execute_write_tool` on rebuild failure
+    // and not repopulated; the handler must not claim cascade-level
+    // consistency against an empty cache.
+    assert!(
+        !server.state().cache.is_fresh().await,
+        "cache must be invalidated and not repopulated after rebuild failure",
+    );
+}

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -1290,6 +1290,18 @@ pub struct CloseResult {
 9. Partition the cascade list from step 2 by `(owner, repo) == (config.owner, config.repo)`: local dependents go into `unblocked: Vec<u64>`; cross-repo dependents populate `cross_repo_refs` per §11.4 (deduplicated, sorted by `QualifiedId::Display`).
 10. Update cache
 
+**Post-rebuild cascade-computation failure.** If the post-close rebuild
+leaves the cache empty or otherwise makes the cascade uncomputable
+(transient 503 during rebuild, or the rebuilt graph no longer exposes
+the closed issue's pre-close neighbours in a form the cascade
+computation can traverse), the tool MUST surface a 503-class error
+with a message instructing the caller to re-run `show` rather than
+defaulting `unblocked` to `[]` and `cross_repo_refs` to `None`. The
+`close` mutation is durable on GitHub regardless of this failure —
+the error signals only the inability to compute the cascade locally.
+Preserves §14 invariants 8 and 13 (no fictional cascade/Status claims
+when the graph cannot be consulted).
+
 **Why step 2 before step 3:** After close, `fetch_graph_data()` returns only OPEN issues. The closed issue is excluded from the rebuilt graph. `compute_unblock_cascade` requires the closed issue to be a node to find dependents via Incoming edges.
 
 **Why step 6 uses only two `*_ref` primitives:** Each cross-repo cascade member triggers three side effects — `fetch_issue` (to obtain `issue_node_id`), Projects V2 `update_field` (Status → `ready`), and `add_comment` (unblock note). Of these, only `fetch_issue` and `add_comment` are addressed by `(owner, repo, number)` and therefore need `*_ref` variants (`fetch_issue_ref`, `add_comment_ref`) to route cross-repo. `update_field` does NOT get an `update_field_ref` variant because `updateProjectV2ItemFieldValue` operates on globally-scoped node IDs (`project_id` + `item_id`), not on `(owner, repo, number)` — once `fetch_issue_ref` yields the cross-repo issue's node ID, `get_project_item_id(issue_node_id, project_id)` resolves the item on the configured project's board, and the existing `update_field(project_id, item_id, field_id, value)` applies the Status update directly. See §5.6 "Cascade-primitive asymmetry" for the routing rationale.


### PR DESCRIPTION
Flip the silent-default branch at server.rs:1099-1232 in the close handler
to a let-Some/else early-return 503-class GitHubApi error. When the
post-close cache rebuild leaves `state.cache.get_graph()` returning
None, the handler previously fell through to the `let mut` zero-initialised
defaults and returned `Ok(CloseResult { unblocked: [], cross_repo_refs: None })` —
a fabricated "no cascade" claim indistinguishable from a legitimate
leaf-close. It now returns a 503 with a message instructing the caller
to re-run `show`, mirroring the reopen R3 posture landed by 29p.34.

Also:
- Add `# Errors` rustdoc section to the close handler fn enumerating
  the new failure mode (uses the [GitHubApi] intra-doc link style
  established by the 29p.34 follow-up fix).
- Collapse the pre-existing `let mut unblocked` / `let mut cross_repo_refs`
  defaults into direct `let` bindings on the success path — the
  let-Some/else restructure makes the zero-init pattern unreachable
  and removes the stale-default anti-pattern structurally.
- Add integration test
  `close_surfaces_error_when_rebuilt_cache_missing_closed_issue`
  (parallel to `reopen_surfaces_error_when_post_reopen_rebuild_fails`)
  asserting 503 → INTERNAL_ERROR, "closed"+"show" tokens in the
  message, the close mutation is durable (`close_issue = 1`), and the
  cache is invalidated and not repopulated (`is_fresh() == false`).

Preserves spec §14 invariants 8 (no write leaves cache/Status
inconsistent) and 13 (Status field values match graph computation —
refuse to pretend no dependents exist when we cannot consult the graph).

unblock-29p.59