### PR TITLE
 refactor(mcp): restructure close handler into four PRE-close phases (GAP-15, unblock-29p.62)

### DIFF
--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1000,19 +1000,44 @@ impl UnblockServer {
     /// unblocked issue, updates its Projects V2 fields (Status=Backlog if not
     /// already `InProgress`) and posts an unblock comment.
     ///
-    /// This is a write tool -- uses `execute_write_tool` for the close mutation
-    /// and cache rebuild, then performs cascade updates as a second phase.
+    /// This is a write tool. The handler runs in four explicit phases per
+    /// SPEC §8.2 + §3.4 Critical (GAP-15 remediation):
+    ///
+    /// - **Phase 0 (PRE-close cascade capture):** ensures the cache is
+    ///   primed (cold-cache path calls [`rebuild_cache`][`crate::tools::rebuild_cache`]),
+    ///   reads the graph, and calls
+    ///   [`compute_unblock_cascade`][`unblock_core::graph::DependencyGraph::compute_unblock_cascade`]
+    ///   while the closed issue is still an OPEN node. The resulting
+    ///   `Vec<QualifiedId>` is captured in a handler-local binding and
+    ///   used authoritatively by Phases 2 and 3 — it is NOT re-read from
+    ///   the post-close cache (which excludes the just-closed issue per
+    ///   `fetch_graph_data` `states: OPEN` semantics).
+    /// - **Phase 1 (MUTATION):** `execute_write_tool` runs
+    ///   `fetch_issue` + state validation + `close_issue` + Projects V2
+    ///   `Status → closed` ladder + cache rebuild.
+    /// - **Phase 2 (CASCADE FIELD-UPDATE LOOP):** iterates the Phase-0
+    ///   captured list, dispatching per-dependent side-effects via the
+    ///   `*_ref` primitives (SPEC §8.2 step 6 / §5.6 `close` row).
+    /// - **Phase 3 (RESPONSE PROJECTION):** partitions the Phase-0
+    ///   cascade into `unblocked: Vec<u64>` + `cross_repo_refs`.
     ///
     /// # Errors
     ///
     /// Returns [`ErrorData`] in the following cases:
+    /// - Phase 0 cold-cache prime fails (`fetch_graph_data` 503) → a
+    ///   503-class [`GitHubApi`](unblock_github::errors::Error::GitHubApi)
+    ///   error is surfaced *before* the close mutation. The mutation is
+    ///   NOT attempted on an empty graph.
     /// - `fetch_issue` fails (e.g. 404) → mapped via `github_error_to_mcp`.
     /// - The fetched issue is already Closed → `IssueClosed` domain error.
     /// - `close_issue` fails → mapped via `github_error_to_mcp`.
-    /// - Cache rebuild fails and leaves the cache empty → a 503-class
-    ///   [`GitHubApi`](unblock_github::errors::Error::GitHubApi) error is
-    ///   surfaced so the caller re-runs `show` to observe the final cascade
-    ///   state (R3 — see `tools::close` module-doc).
+    /// - Cache rebuild fails after Phase 1 and leaves the cache empty →
+    ///   a 503-class [`GitHubApi`](unblock_github::errors::Error::GitHubApi)
+    ///   error is surfaced. The cascade list from Phase 0 is durable in
+    ///   memory and the close mutation has already landed; the error
+    ///   signals only that the step 8 `update_status_fields`
+    ///   reconciliation could not run (R3 — see `tools::close`
+    ///   module-doc).
     #[tool(
         name = "close",
         description = "Close an issue and cascade-unblock dependents. Validates the issue is open, closes it, updates project fields (Status=Done), and auto-unblocks any dependent issues whose blockers are now all closed. Returns the list of newly unblocked issue numbers. Triggers graph rebuild."
@@ -1036,6 +1061,62 @@ impl UnblockServer {
             reason = reason.as_deref(),
             "Close tool invoked"
         );
+
+        // Phase 0: PRE-CLOSE cascade capture (SPEC §8.2 step 2 / §3.4
+        // Critical). The cascade MUST be computed against a graph that
+        // still contains the closed issue as an OPEN node — this is the
+        // only chokepoint where the cascade list can be captured soundly.
+        // `fetch_graph_data` uses `states: OPEN` filtering (see
+        // `unblock-github/src/graphql.rs:129`), so any cascade computation
+        // against a POST-close rebuild would short-circuit to `Vec::new()`
+        // at `unblock-core/src/graph.rs:289-291` (the `closed_id` node is
+        // absent from the rebuilt `node_map`), silently reporting
+        // `unblocked = []` regardless of actual dependents. GAP-15 fixed
+        // that correctness defect.
+        //
+        // Cold-cache prime: if the cache is empty (first tool after
+        // server start, or a stale invalidation from a prior write), use
+        // the existing `rebuild_cache` helper to fetch and populate the
+        // graph. If the prime itself fails (transient 503 during
+        // `fetch_graph_data`), the cache stays empty and this handler
+        // cannot proceed — surface a pre-mutation 503 so the caller
+        // knows the close was NOT attempted. Distinct from the
+        // post-close R3 path (rebuild-after-close) which fires only
+        // after `execute_write_tool` lands the mutation on GitHub.
+        let issue_qid =
+            unblock_core::types::QualifiedId::new(client.owner(), client.repo(), issue_number);
+
+        if state.cache.get_graph().await.is_none() {
+            tracing::debug!(
+                issue_number,
+                "Cache cold at Phase 0 — priming via rebuild_cache before cascade capture"
+            );
+            crate::tools::rebuild_cache(state).await;
+        }
+
+        let Some(pre_close_graph) = state.cache.get_graph().await else {
+            tracing::warn!(
+                issue_number,
+                "Cache empty after prime attempt — cannot capture pre-close cascade; aborting close"
+            );
+            return Err(crate::errors::github_error_to_mcp(
+                unblock_github::errors::GitHubApiSnafu {
+                    status: 503_u16,
+                    message: format!(
+                        "Cannot close issue #{issue_number}: failed to prime the dependency graph before cascade capture — please retry or run `prime` first"
+                    ),
+                }
+                .build(),
+            ));
+        };
+
+        // compute_unblock_cascade's _all_issues param is currently unused —
+        // pass an empty slice (see graph.rs:215-220 for rationale).
+        let cascade = pre_close_graph.compute_unblock_cascade(&issue_qid, &[]);
+        // Drop the Arc early so the write-tool rebuild's update() is not
+        // blocked on a lingering reader (cache uses RwLock — see
+        // GraphCache::update).
+        drop(pre_close_graph);
 
         // Phase 1: Validate, close, and rebuild cache via execute_write_tool.
         execute_write_tool(state, || {
@@ -1103,41 +1184,29 @@ impl UnblockServer {
         })
         .await?;
 
-        // Phase 2: Compute cascade from the freshly rebuilt cache.
-        //
-        // R3 — honest partial state (see `tools::close` module-doc):
-        // if the rebuild inside `execute_write_tool` failed, the cache is
-        // empty. The close mutation has already succeeded server-side, but
-        // we cannot compute the cascade here. Surface a 503-class error
-        // instructing the caller to re-run `show`, rather than silently
-        // returning `unblocked = []`, `cross_repo_refs = None` — a
-        // fabricated "no cascade" claim indistinguishable from a
-        // legitimate leaf-close. Preserves §14 invariants 8 and 13.
-        let Some(graph) = state.cache.get_graph().await else {
-            tracing::warn!(
-                issue_number,
-                "Cache not available after close — rebuild failed; caller must re-run `show` to observe final cascade"
-            );
-            return Err(crate::errors::github_error_to_mcp(
-                unblock_github::errors::GitHubApiSnafu {
-                    status: 503_u16,
-                    message: format!(
-                        "Issue #{issue_number} closed successfully, but cache rebuild failed — please re-run `show` to observe the final cascade state"
-                    ),
-                }
-                .build(),
-            ));
-        };
+        // R3 — honest partial state under PRE-close ordering (see
+        // `tools::close` module-doc): if the rebuild inside
+        // `execute_write_tool` failed, the cache is empty. The cascade
+        // list captured in Phase 0 is durable in memory and the close
+        // mutation has already succeeded server-side, so the response
+        // projection below is still authoritative. However, the step 8
+        // `update_status_fields` reconciliation (SPEC §8.2 step 8 —
+        // cross-check Status fields for issues NOT already handled by
+        // the Phase 2 cascade loop) requires the rebuilt graph and
+        // cannot run against an empty cache. Surface a 503-class error
+        // instructing the caller to re-run `show` so the Status
+        // fan-out is reconciled on the next read. Preserves §14
+        // invariants 8 and 13 (no fictional Status-sync claims when
+        // the graph cannot be consulted).
+        let rebuild_graph_available = state.cache.get_graph().await.is_some();
 
-        // compute_unblock_cascade's _all_issues param is currently unused —
-        // pass an empty slice (see graph.rs:215-220 for rationale).
-        let issue_qid =
-            unblock_core::types::QualifiedId::new(client.owner(), client.repo(), issue_number);
-        let cascade = graph.compute_unblock_cascade(&issue_qid, &[]);
-
-        // Phase 3: For each newly unblocked issue, update project fields and
-        // post an unblock comment. Each update is best-effort — failures are
-        // logged but do not abort the cascade.
+        // Phase 2: cascade field-update loop. Iterates the Phase-0
+        // captured list (not the post-close rebuilt cache) so the
+        // correctness contract in SPEC §8.2 step 6 holds even when the
+        // post-close rebuild fails — the dependents we must update are
+        // known at mutation time. Each per-dependent update is
+        // best-effort; individual failures are logged and the cascade
+        // continues.
         //
         // SPEC §8.2 step 6 / §11.4 row 4 / §5.6 row `close`: cross-repo
         // dependents ARE still cascade-updated. The loop dispatches via
@@ -1244,10 +1313,11 @@ impl UnblockServer {
             }
         }
 
-        // SPEC §8.2 flow step 9 / §11.4 row 4: partition the cascade
-        // into local dependents (projected to `unblocked: Vec<u64>`)
-        // vs cross-repo dependents (surfaced via `cross_repo_refs`).
-        // The Phase 3 loop above intentionally does NOT gate on
+        // Phase 3: response projection. SPEC §8.2 flow step 9 / §11.4
+        // row 4: partition the cascade list (captured Phase 0) into
+        // local dependents (projected to `unblocked: Vec<u64>`) vs
+        // cross-repo dependents (surfaced via `cross_repo_refs`).
+        // Phase 2 above intentionally does NOT gate on
         // (owner, repo) == (config.owner, config.repo) — cross-repo
         // dependents ARE still cascade-updated; only the response
         // shape differs here (SPEC §11.4 affected-tools table).
@@ -1258,6 +1328,35 @@ impl UnblockServer {
             cross_repo_accum,
             crate::tools::cross_repo::close_summary,
         );
+
+        // R3 post-close rebuild failure (refocused under PRE-close
+        // ordering per GAP-15 / SPEC §8.2 "Post-rebuild field-sync
+        // failure"): the Phase-0 cascade list is authoritative in the
+        // response envelope, the close mutation is durable on GitHub,
+        // and the Phase 2 cascade field-updates were applied
+        // best-effort. The remaining post-close step is the step 8
+        // `update_status_fields` reconciliation — cross-check Status
+        // fields for issues NOT already handled by the Phase 2
+        // cascade loop — which requires the rebuilt graph. If that
+        // graph is missing (rebuild failed), surface a 503-class
+        // error instructing the caller to re-run `show` to confirm
+        // the Status fan-out. This does NOT invalidate the cascade
+        // list returned above.
+        if !rebuild_graph_available {
+            tracing::warn!(
+                issue_number,
+                "Cache not available after close — rebuild failed; step 8 `update_status_fields` reconciliation could not run"
+            );
+            return Err(crate::errors::github_error_to_mcp(
+                unblock_github::errors::GitHubApiSnafu {
+                    status: 503_u16,
+                    message: format!(
+                        "Issue #{issue_number} closed successfully and cascade field-updates applied best-effort, but Status reconciliation could not complete — re-run `show` to confirm final Status fan-out"
+                    ),
+                }
+                .build(),
+            ));
+        }
 
         Ok(Json(CloseResult {
             issue: issue_number,

--- a/crates/unblock-mcp/src/tools/close.rs
+++ b/crates/unblock-mcp/src/tools/close.rs
@@ -1,39 +1,95 @@
 //! Close tool — closes an issue and triggers cascade unblock.
 //!
-//! Validates the issue is open, closes it via the GitHub API, updates Projects V2
-//! fields (Status=Done), rebuilds the cache, then computes the unblock cascade.
-//! For each newly unblocked issue, updates its Projects V2 fields
-//! (Status=Backlog if not already `InProgress`) and posts an unblock comment.
+//! ## Four-phase execution (SPEC §8.2 + §3.4 Critical, GAP-15 remediation)
 //!
-//! Cross-repo dependents (SPEC §11.4): when the cascade returned by
-//! [`compute_unblock_cascade`][`unblock_core::graph::DependencyGraph::compute_unblock_cascade`]
-//! touches a `QualifiedId` whose `(owner, repo)` differs from the configured
-//! repo, the dependent is STILL cascade-updated (same Status / comment path) —
-//! only the response shape differs. The bare-`u64` [`CloseResult::unblocked`]
-//! vector is scoped to the configured repo; cross-repo dependents are surfaced
-//! in [`CloseResult::cross_repo_refs`] (`Some` iff at least one cross-repo
-//! dependent participated in the cascade, per SPEC §14 Invariant 14(b)).
+//! The close handler runs four explicit phases — ordering is
+//! correctness-critical and MUST NOT be reordered:
 //!
-//! ## R3 caveat — cannot compute unblock cascade after rebuild
+//! 1. **Phase 0 — PRE-close cascade capture.** Ensure the graph is built
+//!    (cold-cache path calls
+//!    [`rebuild_cache`][`crate::tools::rebuild_cache`] to issue one
+//!    `fetch_graph_data` round-trip), then call
+//!    [`compute_unblock_cascade`][`unblock_core::graph::DependencyGraph::compute_unblock_cascade`]
+//!    while the closed issue is still an OPEN node in the graph. The
+//!    resulting `Vec<QualifiedId>` is captured in a handler-local
+//!    binding and used authoritatively by Phases 2 and 3 — it is NOT
+//!    re-read from the post-close cache. This ordering is mandatory
+//!    per SPEC §3.4 Critical: `fetch_graph_data` uses `states: OPEN`
+//!    filtering (see `unblock-github/src/graphql.rs:129`), so a
+//!    POST-close cascade would short-circuit to `Vec::new()` at
+//!    `unblock-core/src/graph.rs:289-291` because the just-closed
+//!    issue is absent from the rebuilt `node_map`. The defensive
+//!    `Vec::new()` branch stays as-is (it is still correct for
+//!    create-then-immediately-close races where `closed_id`
+//!    legitimately is not yet in the graph), but its trigger from the
+//!    close path disappears.
+//! 2. **Phase 1 — MUTATION.** `execute_write_tool` runs `fetch_issue`,
+//!    state validation, `close_issue`, the Projects V2 `Status → closed`
+//!    field ladder on the closed issue, and a cache rebuild. The close
+//!    mutation is durable on GitHub regardless of the rebuild outcome.
+//! 3. **Phase 2 — CASCADE FIELD-UPDATE LOOP.** Iterate the cascade
+//!    list captured in Phase 0 (not the post-close cache). For each
+//!    dependent, dispatch side effects via the `*_ref` primitives —
+//!    [`add_comment_ref`][`unblock_github::GitHubApi::add_comment_ref`]
+//!    (unblock comment) and
+//!    [`fetch_issue_ref`][`unblock_github::GitHubApi::fetch_issue_ref`]
+//!    followed by `update_field` (Projects V2 Status → `ready` if the
+//!    dependent is not already `InProgress`) — so cross-repo dependents
+//!    route to their own `(owner, repo)` rather than silently
+//!    retargeting the configured repo. Per-dependent failures are
+//!    logged and the cascade continues (best-effort per SPEC §8.2
+//!    step 6 / §5.6 `close` row).
+//! 4. **Phase 3 — RESPONSE PROJECTION.** Partition the Phase-0 cascade
+//!    into `unblocked: Vec<u64>` (local dependents) plus
+//!    `cross_repo_refs: Option<CrossRepoRefs>` (cross-repo dependents,
+//!    surfaced per SPEC §11.4) via the shared `project_cascade` and
+//!    `build_cross_repo_refs_with_summary` helpers in
+//!    `crate::tools::cross_repo`.
 //!
-//! After the close mutation lands and `execute_write_tool` rebuilds the
-//! cache, the handler reads [`GraphCache::get_graph`][`unblock_core::cache::GraphCache::get_graph`]
-//! to compute the cascade. When that read returns `None` — either because
-//! the underlying `fetch_graph_data()` call failed (e.g. transient GitHub
-//! 503) and left the cache invalidated, OR because the closed issue was
-//! excluded from the rebuilt graph in a way that makes the cascade
-//! uncomputable — the handler cannot authoritatively answer "which
-//! dependents were unblocked". The close itself has already succeeded
-//! server-side, so the mutation is not lost. The handler surfaces a
-//! 503-class [`GitHubApi`](unblock_github::errors::Error::GitHubApi)
-//! error with a message instructing the caller to re-run `show` to
-//! observe the final cascade state, rather than returning a fabricated
-//! `unblocked = []`, `cross_repo_refs = None` envelope (which would be
-//! indistinguishable from a legitimate leaf-close with no cascade).
-//! Mirrors the reopen R3 posture. Preserves spec §14 invariants 8 (no
-//! write leaves cache or Status fields inconsistent) and 13 (Status
-//! field values match graph computation — we refuse to pretend no
-//! dependents exist when we cannot consult the graph).
+//! Cross-repo dependents (SPEC §11.4): when the cascade touches a
+//! `QualifiedId` whose `(owner, repo)` differs from the configured
+//! repo, the dependent is STILL cascade-updated (same Status / comment
+//! path) — only the response shape differs. The bare-`u64`
+//! [`CloseResult::unblocked`] vector is scoped to the configured repo;
+//! cross-repo dependents are surfaced in
+//! [`CloseResult::cross_repo_refs`] (`Some` iff at least one cross-repo
+//! dependent participated in the cascade, per SPEC §14 Invariant
+//! 14(b)).
+//!
+//! ## R3 caveat — post-rebuild Status reconciliation failure
+//!
+//! Under PRE-close ordering the Phase-0 cascade list is captured
+//! before the mutation, so a post-close rebuild failure no longer
+//! invalidates the cascade list — the response envelope stays
+//! authoritative even when
+//! [`GraphCache::get_graph`][`unblock_core::cache::GraphCache::get_graph`]
+//! returns `None` after `execute_write_tool`. The close mutation is
+//! durable on GitHub and the Phase-2 cascade field-updates are applied
+//! best-effort regardless of the rebuild outcome.
+//!
+//! What a rebuild failure DOES break is the step 8
+//! `update_status_fields` reconciliation (SPEC §8.2 step 8) —
+//! cross-checking Status fields for issues NOT already handled by the
+//! Phase 2 cascade loop (e.g. issues whose blocker status changed but
+//! that were not direct dependents of the closed issue). This step
+//! requires the rebuilt graph and cannot run against an empty cache.
+//! When the rebuild fails, the handler surfaces a 503-class
+//! [`GitHubApi`](unblock_github::errors::Error::GitHubApi) error
+//! with a message instructing the caller to re-run `show` so the
+//! Status fan-out is reconciled on the next read. The cascade list
+//! in the response remains authoritative; the error signals only
+//! that the Status-field reconciliation could not complete.
+//! Preserves spec §14 invariants 8 (no write leaves cache or Status
+//! fields inconsistent) and 13 (Status field values match graph
+//! computation — we refuse to pretend reconciliation succeeded when
+//! we cannot consult the graph).
+//!
+//! A separate 503-class error is surfaced when Phase 0 cold-cache
+//! prime fails (the `fetch_graph_data` call inside `rebuild_cache`
+//! errored and the cache stayed empty). That branch is distinct from
+//! the R3 path — it fires *before* the close mutation is attempted,
+//! and the message instructs the caller to retry or run `prime`
+//! first. The close is NOT attempted on an empty graph.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -366,6 +366,13 @@ async fn claim_with_empty_agent_returns_invalid_params() {
 #[tokio::test]
 async fn close_dispatches_through_dyn_vtable() {
     let mock = new_mock();
+    // GAP-15 PRE-close ordering (unblock-29p.62): Phase 0 prime
+    // issues a `fetch_graph_data` round-trip *before* the mutation
+    // to capture the cascade against the pre-close OPEN graph.
+    // Phase 1 post-close rebuild is the second round-trip (empty
+    // graph — the closed leaf has no dependents so the post-close
+    // rebuild still matches production `states: OPEN` semantics).
+    mock.push_fetch_graph_data(Ok((vec![make_issue(8)], vec![])));
     mock.push_fetch_issue(Ok(make_issue(8)));
     mock.push_close_issue(Ok(()));
     // field_ids=Some enters the project-field update branch. With empty
@@ -377,7 +384,7 @@ async fn close_dispatches_through_dyn_vtable() {
         number: 1,
     }));
     mock.push_get_project_item_id(Ok("PVTI_close".to_owned()));
-    mock.push_fetch_graph_data(Ok((vec![make_issue(8)], vec![])));
+    mock.push_fetch_graph_data(Ok((vec![], vec![])));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server
@@ -403,7 +410,8 @@ async fn close_dispatches_through_dyn_vtable() {
     );
     assert_eq!(mock.calls().fetch_issue(), 1);
     assert_eq!(mock.calls().close_issue(), 1);
-    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // PRE-close prime + POST-close rebuild = 2 round-trips (GAP-15).
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
     assert_eq!(mock.calls().field_ids(), 1);
     assert_eq!(mock.calls().resolve_project_info(), 1);
     assert_eq!(mock.calls().get_project_item_id(), 1);
@@ -415,9 +423,14 @@ async fn close_with_empty_reason_skips_comment() {
     // Regression for unblock-b6b.85: Some("") and whitespace-only reason
     // should be treated as None and NOT post an empty comment before closing.
     let mock = new_mock();
+    // GAP-15 PRE-close ordering (unblock-29p.62): Phase 0 prime +
+    // Phase 1 post-close rebuild = two `fetch_graph_data` round-trips.
+    // Leaf close, no dependents — both fixtures match production
+    // `states: OPEN` semantics.
+    mock.push_fetch_graph_data(Ok((vec![make_issue(9)], vec![])));
     mock.push_fetch_issue(Ok(make_issue(9)));
     mock.push_close_issue(Ok(()));
-    mock.push_fetch_graph_data(Ok((vec![make_issue(9)], vec![])));
+    mock.push_fetch_graph_data(Ok((vec![], vec![])));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
     let Json(result) = server

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -4915,7 +4915,10 @@ async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
     use unblock_mcp::server::UnblockServer;
     use unblock_mcp::tools::close::CloseParams;
 
-    let issues = vec![
+    // Phase 0 pre-close graph: #8 is OPEN, and both #10 and #11 are
+    // blocked by it. This is the graph state the cascade captures
+    // against.
+    let pre_close_issues = vec![
         close_fixture_issue(8),
         close_fixture_issue(10),
         close_fixture_issue(11),
@@ -4931,23 +4934,32 @@ async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
             target: QualifiedId::new("acme", "widgets", 8),
         },
     ];
+    // Phase 1 post-close rebuild: #8 is EXCLUDED (production
+    // `fetch_graph_data` uses `states: OPEN` per
+    // `unblock-github/src/graphql.rs:129`). Under PRE-close ordering
+    // the cascade is already captured; the post-close graph is only
+    // consulted for step 8 `update_status_fields` reconciliation.
+    let post_close_issues = vec![close_fixture_issue(10), close_fixture_issue(11)];
+    // Post-close the edges are dropped (both dependents are now
+    // unblocked, so there are no remaining open blockers on them).
+    let post_close_edges: Vec<BlockingEdge> = vec![];
 
     let mock = new_mock();
-    // Phase 1: fetch #8, close #8, rebuild.
+    // Phase 0 cold-cache prime — pushes the PRE-close graph so the
+    // cascade can resolve #8 as an OPEN node.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, edges)));
+    // Phase 1: fetch #8 (validates it is Open), close #8.
     mock.push_fetch_issue(Ok(close_fixture_issue(8)));
     mock.push_close_issue(Ok(()));
     // Phase 1 field ladder: push None to skip Projects V2 updates.
     mock.push_field_ids(None);
-    // Rebuild pushes the POST-close graph. We keep #8 in the fetch
-    // response so `compute_unblock_cascade` can resolve it as a node
-    // (the mock is a stub — in production fetch_graph_data would
-    // exclude the closed issue, but that path is orthogonal to this
-    // bead's scope).
-    mock.push_fetch_graph_data(Ok((issues, edges)));
-    // Phase 3 loop runs 2×. Each iteration calls add_comment_ref then
-    // field_ids. Post unblock-eos.13 the cascade always dispatches via
-    // the *_ref primitive (SPEC §8.2 step 6 / §5.6 `close` row); local
-    // dependents normalize to `IssueRef::Local(n)`.
+    // Phase 1 post-close rebuild — the closed issue #8 is now
+    // excluded, faithful to production `states: OPEN` semantics.
+    mock.push_fetch_graph_data(Ok((post_close_issues, post_close_edges)));
+    // Phase 2 loop runs 2×. Each iteration calls add_comment_ref
+    // then field_ids. Post unblock-eos.13 the cascade always dispatches
+    // via the *_ref primitive (SPEC §8.2 step 6 / §5.6 `close` row);
+    // local dependents normalize to `IssueRef::Local(n)`.
     // We push add_comment_ref Ok twice and let field_ids default to
     // None (queue empty ⇒ None) so the inner project-field ladder is
     // skipped.
@@ -5015,7 +5027,12 @@ async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
         "all-local cascade must normalize every cascaded_qid to IssueRef::Local; got: {ref_calls:?}"
     );
     assert_eq!(mock.calls().close_issue(), 1);
-    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // Under PRE-close ordering the handler issues two
+    // `fetch_graph_data` round-trips: Phase 0 cold-cache prime
+    // (captures the cascade against the OPEN graph that still
+    // contains #8) and Phase 1 post-close rebuild (faithful
+    // `states: OPEN` semantics, #8 excluded). GAP-15.
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
 }
 
 /// Acceptance (b): mixed cascade — one local dependent + two cross-repo
@@ -5035,12 +5052,15 @@ async fn close_no_cross_repo_dependents_cross_repo_refs_is_none() {
 /// `["alpha/upstream#42", "other/repo#99"]` (lex-sorted per
 /// Invariant 14(b) determinism).
 #[tokio::test]
+#[allow(clippy::too_many_lines)] // Dual pre-close/post-close fixtures + multi-ref assertions.
 async fn close_cross_repo_dependent_populates_cross_repo_refs() {
     use rmcp::handler::server::wrapper::{Json, Parameters};
     use unblock_mcp::server::UnblockServer;
     use unblock_mcp::tools::close::CloseParams;
 
-    let issues = vec![
+    // Phase 0 pre-close graph: #8 is OPEN and all three dependents
+    // are blocked by it (one local, two cross-repo).
+    let pre_close_issues = vec![
         close_fixture_issue(8),
         close_fixture_issue(10),
         close_cross_repo_fixture("other", "repo", 99),
@@ -5060,13 +5080,24 @@ async fn close_cross_repo_dependent_populates_cross_repo_refs() {
             target: QualifiedId::new("acme", "widgets", 8),
         },
     ];
+    // Phase 1 post-close rebuild: #8 excluded (production
+    // `states: OPEN` semantics).
+    let post_close_issues = vec![
+        close_fixture_issue(10),
+        close_cross_repo_fixture("other", "repo", 99),
+        close_cross_repo_fixture("alpha", "upstream", 42),
+    ];
+    let post_close_edges: Vec<BlockingEdge> = vec![];
 
     let mock = new_mock();
+    // Phase 0 cold-cache prime.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, edges)));
     mock.push_fetch_issue(Ok(close_fixture_issue(8)));
     mock.push_close_issue(Ok(()));
     mock.push_field_ids(None); // Phase 1: skip project-field ladder.
-    mock.push_fetch_graph_data(Ok((issues, edges)));
-    // Phase 3 loop runs 3× (#10, other/repo#99, alpha/upstream#42).
+    // Phase 1 post-close rebuild (production-realistic: #8 excluded).
+    mock.push_fetch_graph_data(Ok((post_close_issues, post_close_edges)));
+    // Phase 2 loop runs 3× (#10, other/repo#99, alpha/upstream#42).
     // Each iteration posts an add_comment_ref; field_ids defaults to
     // None when the queue is empty, so the inner project-field ladder
     // is skipped — no further pushes required.
@@ -5164,7 +5195,8 @@ async fn close_cross_repo_dependent_populates_cross_repo_refs() {
     );
 
     assert_eq!(mock.calls().close_issue(), 1);
-    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // PRE-close prime + POST-close rebuild = 2 round-trips (GAP-15).
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
 }
 
 /// Acceptance (c): singular-form summary — a single cross-repo
@@ -5177,7 +5209,8 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
     use unblock_mcp::server::UnblockServer;
     use unblock_mcp::tools::close::CloseParams;
 
-    let issues = vec![
+    // Phase 0 pre-close graph: #8 OPEN, other/repo#99 blocked by it.
+    let pre_close_issues = vec![
         close_fixture_issue(8),
         close_cross_repo_fixture("other", "repo", 99),
     ];
@@ -5185,13 +5218,20 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
         source: QualifiedId::new("other", "repo", 99),
         target: QualifiedId::new("acme", "widgets", 8),
     }];
+    // Phase 1 post-close rebuild: #8 excluded (production
+    // `states: OPEN` semantics).
+    let post_close_issues = vec![close_cross_repo_fixture("other", "repo", 99)];
+    let post_close_edges: Vec<BlockingEdge> = vec![];
 
     let mock = new_mock();
+    // Phase 0 cold-cache prime.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, edges)));
     mock.push_fetch_issue(Ok(close_fixture_issue(8)));
     mock.push_close_issue(Ok(()));
     mock.push_field_ids(None);
-    mock.push_fetch_graph_data(Ok((issues, edges)));
-    // Phase 3: single cross-repo dependent — dispatched through the *_ref
+    // Phase 1 post-close rebuild (production-realistic: #8 excluded).
+    mock.push_fetch_graph_data(Ok((post_close_issues, post_close_edges)));
+    // Phase 2: single cross-repo dependent — dispatched through the *_ref
     // primitive (SPEC §8.2 step 6 / §5.6 `close` row).
     mock.push_add_comment_ref(Ok("c1".to_owned()));
 
@@ -5243,7 +5283,7 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
 
 /// Acceptance (d) — unblock-eos.17 best-effort observability guard.
 ///
-/// The Phase-3 cascade loop at `server.rs:1113-1119` wraps
+/// The Phase-2 cascade loop in the close handler wraps
 /// `add_comment_ref` in `if let Err(e) = ...` and swallows the failure
 /// with a `tracing::warn!` fallback. This path is purely observability
 /// but forms part of the SPEC §8.2 step 6 contract: "cross-repo
@@ -5258,11 +5298,14 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
 /// integration level — this is the gap the unblock-eos.17 QA finding
 /// called out as RISK P3.
 ///
-/// Fixture: local blocker #8 with a single cross-repo dependent
-/// `other/repo#99`. Closing #8 cascades #99. The mock queues an
-/// `Err(CrossRepoAccessDenied)` on the first (and only) `add_comment_ref`
-/// call — modelling the "token lacks write scope on foreign repo"
-/// scenario.
+/// Fixture (GAP-15 PRE-close ordering): local blocker #8 with a single
+/// cross-repo dependent `other/repo#99`. Phase 0 primes the graph
+/// against a PRE-close fixture containing #8 as OPEN. Phase 1 closes
+/// #8 and rebuilds from a POST-close fixture that excludes #8
+/// (production-realistic `states: OPEN` semantics). The mock queues
+/// an `Err(CrossRepoAccessDenied)` on the first (and only)
+/// `add_comment_ref` call — modelling the "token lacks write scope on
+/// foreign repo" scenario.
 ///
 /// Assertions:
 /// 1. The tool returns `Ok` with a well-formed `CloseResult` — the
@@ -5276,15 +5319,17 @@ async fn close_single_cross_repo_dependent_uses_singular_summary() {
 ///    whole point of the unblock-eos.13 migration from bare `u64` to
 ///    `IssueRef` dispatch — closes the last observability gap flagged
 ///    by the unblock-eos.13 QA pass).
-/// 4. The failure message matches the source string emitted at
-///    `server.rs:1117`.
+/// 4. The `warn!` message "Failed to post unblock comment on cascaded
+///    issue" appears verbatim — that phrasing is the observability
+///    contract for the Phase-2 best-effort fallback.
 #[tokio::test]
 async fn close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade() {
     use rmcp::handler::server::wrapper::{Json, Parameters};
     use unblock_mcp::server::UnblockServer;
     use unblock_mcp::tools::close::CloseParams;
 
-    let issues = vec![
+    // Phase 0 pre-close graph: #8 OPEN, other/repo#99 blocked by it.
+    let pre_close_issues = vec![
         close_fixture_issue(8),
         close_cross_repo_fixture("other", "repo", 99),
     ];
@@ -5292,15 +5337,22 @@ async fn close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade() 
         source: QualifiedId::new("other", "repo", 99),
         target: QualifiedId::new("acme", "widgets", 8),
     }];
+    // Phase 1 post-close rebuild: #8 excluded (production
+    // `states: OPEN` semantics).
+    let post_close_issues = vec![close_cross_repo_fixture("other", "repo", 99)];
+    let post_close_edges: Vec<BlockingEdge> = vec![];
 
     let mock = new_mock();
+    // Phase 0 cold-cache prime.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, edges)));
     mock.push_fetch_issue(Ok(close_fixture_issue(8)));
     mock.push_close_issue(Ok(()));
     // Phase 1 field-ladder: None skips the Projects V2 updates on #8.
     mock.push_field_ids(None);
-    mock.push_fetch_graph_data(Ok((issues, edges)));
+    // Phase 1 post-close rebuild (production-realistic: #8 excluded).
+    mock.push_fetch_graph_data(Ok((post_close_issues, post_close_edges)));
     // Induced failure: the sole cascaded dependent is cross-repo, so
-    // the one `add_comment_ref` invocation in the Phase-3 loop receives
+    // the one `add_comment_ref` invocation in the Phase-2 loop receives
     // this `Err`. `CrossRepoAccessDenied { owner, repo }` is the
     // idiomatic wire-level shape a token-without-write-scope returns —
     // see `errors.rs:174-179`. Any `Error` variant would exercise the
@@ -5379,10 +5431,11 @@ async fn close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade() 
 
     // Assertion 3+4: the warn! payload carries the `cascaded_qid`
     // structured field populated with the QUALIFIED ref and the
-    // human-readable message from `server.rs:1117`. Checking the raw
-    // JSON text matches the `tracing_subscriber::fmt::json` layer's
-    // on-wire format exactly — no span/field coupling, so refactors
-    // that keep field name + Display value stable remain covered.
+    // human-readable "Failed to post unblock comment on cascaded issue"
+    // message emitted by the Phase-2 loop. Checking the raw JSON text
+    // matches the `tracing_subscriber::fmt::json` layer's on-wire
+    // format exactly — no span/field coupling, so refactors that keep
+    // field name + Display value stable remain covered.
     let output = capture.output();
     assert!(
         output.contains("\"cascaded_qid\":\"other/repo#99\""),
@@ -5392,7 +5445,7 @@ async fn close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade() 
     );
     assert!(
         output.contains("Failed to post unblock comment on cascaded issue"),
-        "warn! message at server.rs:1117 must appear verbatim; got: {output}",
+        "warn! message emitted by Phase-2 cascade loop must appear verbatim; got: {output}",
     );
     // Surface that the error chain reached the log (Display of
     // `CrossRepoAccessDenied` is `Access denied to cross-repo issue
@@ -5410,48 +5463,93 @@ async fn close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade() 
     // SPEC §8.2 step 6 "surface the denial to operators" intent.
     assert!(
         output.contains("\"level\":\"WARN\""),
-        "Phase-3 fallback MUST log at WARN level; got: {output}",
+        "Phase-2 cascade fallback MUST log at WARN level; got: {output}",
     );
 
     assert_eq!(mock.calls().close_issue(), 1);
-    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // PRE-close prime + POST-close rebuild = 2 round-trips (GAP-15).
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
 }
 
-/// R3 empty-cache arm — when the post-close cache rebuild fails
-/// (transient 503 from GitHub GraphQL), `execute_write_tool` leaves
-/// the cache empty and `state.cache.get_graph()` returns `None`. The
-/// close handler MUST NOT silently default `unblocked = []`,
-/// `cross_repo_refs = None` (which is indistinguishable from a
-/// legitimate leaf-close with no cascade). It must surface a
-/// 503-class error instructing the caller to re-run `show` to
-/// observe the final cascade state. Preserves spec §14 invariants 8
-/// and 13 (no fictional cascade/Status claims when the graph cannot
-/// be consulted). Mirrors the reopen R3 regression guard at
-/// `reopen_surfaces_error_when_post_reopen_rebuild_fails`.
+/// R3 post-close rebuild failure — refocused semantics under PRE-close
+/// ordering (GAP-15 / SPEC §8.2 "Post-rebuild field-sync failure").
+///
+/// Under PRE-close ordering the cascade list is captured in Phase 0
+/// and is durable in memory; the close mutation is durable on GitHub;
+/// the Phase 2 cascade field-updates are applied best-effort. What
+/// the post-close rebuild failure *does* break is the step 8
+/// `update_status_fields` reconciliation — cross-checking Status
+/// fields for issues NOT already handled by the Phase 2 cascade loop.
+/// This step requires the rebuilt graph and cannot run against an
+/// empty cache. The handler MUST surface a 503-class error whose
+/// message instructs the caller to re-run `show` so the Status
+/// fan-out is reconciled on the next read. Preserves spec §14
+/// invariants 8 and 13 (no fictional Status-sync claims when the
+/// graph cannot be consulted). Mirrors the reopen R3 regression
+/// guard at `reopen_surfaces_error_when_post_reopen_rebuild_fails`.
+///
+/// Fixture: Phase 0 prime succeeds (the PRE-close graph is
+/// available), Phase 1 close succeeds on GitHub, and the post-close
+/// rebuild errors with a transient 503. `execute_write_tool` leaves
+/// the cache empty after logging the error, so the close handler's
+/// post-write graph check falls through to the refocused R3 branch.
 #[tokio::test]
-async fn close_surfaces_error_when_rebuilt_cache_missing_closed_issue() {
+async fn close_surfaces_error_when_rebuild_fails_after_pre_cascade() {
     use rmcp::handler::server::wrapper::Parameters;
     use unblock_github::errors::GitHubApiSnafu;
     use unblock_mcp::server::UnblockServer;
     use unblock_mcp::tools::close::CloseParams;
 
+    // Phase 0 pre-close graph: #8 is OPEN with two local dependents
+    // (#10, #11) so the cascade list has content. This proves the
+    // cascade list survives a subsequent rebuild failure — the R3
+    // error signals only Status reconciliation loss, not cascade loss.
+    let pre_close_issues = vec![
+        close_fixture_issue(8),
+        close_fixture_issue(10),
+        close_fixture_issue(11),
+    ];
+    let edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 11),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+    ];
+
     let mock = new_mock();
 
+    // Phase 0 cold-cache prime succeeds — cascade captured against
+    // the PRE-close graph while #8 is still OPEN.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, edges)));
     // Phase 1: fetch + close both succeed.
     mock.push_fetch_issue(Ok(close_fixture_issue(8)));
     mock.push_close_issue(Ok(()));
     // Phase 1 field-ladder: None skips the Projects V2 update on #8
     // so `update_field` is not called from the write-tool closure.
     mock.push_field_ids(None);
-    // Post-close rebuild: simulate a transient 503 — `execute_write_tool`
-    // leaves the cache empty after logging the error, so the close
-    // handler's cache-check falls through to the R3 "surface an error"
-    // early return.
+    // Post-close rebuild: transient 503 — `execute_write_tool` leaves
+    // the cache empty after logging the error. The Phase 2 cascade
+    // field-update loop still runs (best-effort, against the
+    // captured Phase-0 list) and the response-projection step still
+    // executes. The refocused R3 branch fires at the tail to signal
+    // that the step 8 reconciliation could not run.
     mock.push_fetch_graph_data(Err(GitHubApiSnafu {
         status: 503_u16,
         message: "upstream service unavailable".to_owned(),
     }
     .build()));
+    // Phase 2 cascade field-updates for the two local dependents are
+    // attempted best-effort against the Phase-0 captured list. Queue
+    // two add_comment_ref responses so the loop doesn't trip on a
+    // mock-queue underflow; the cascade continues regardless under
+    // the best-effort contract (individual comment failures are
+    // tracing::warn!'d, not propagated).
+    mock.push_add_comment_ref(Ok("c10".to_owned()));
+    mock.push_add_comment_ref(Ok("c11".to_owned()));
 
     let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
 
@@ -5464,42 +5562,224 @@ async fn close_surfaces_error_when_rebuilt_cache_missing_closed_issue() {
         }))
         .await;
     let Err(err) = result else {
-        panic!("cache rebuild failure must surface as a handler error (R3)");
+        panic!("post-close rebuild failure must surface as a handler error (R3 refocused)");
     };
 
     // 503 → INTERNAL_ERROR per github_error_to_mcp.
     assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
-    // Family-consistency with reopen: the error must reference both
-    // `closed` (the mutation verb) and `show` (the recovery hint) so
-    // agents recognise the "re-run show" guidance.
+    // Refocused semantics: the message must reference `closed`
+    // (mutation landed), `cascade field-updates applied` (Phase 2
+    // still ran), `Status reconciliation` (step 8 is what failed),
+    // and `show` (recovery hint). This is the contract from
+    // SPEC §8.2 "Post-rebuild field-sync failure".
     assert!(
-        err.message.contains("closed") && err.message.contains("show"),
+        err.message.contains("closed"),
+        "error message must note the close succeeded: {}",
+        err.message,
+    );
+    assert!(
+        err.message.contains("cascade field-updates"),
+        "error message must note cascade field-updates were applied best-effort: {}",
+        err.message,
+    );
+    assert!(
+        err.message.contains("Status reconciliation"),
+        "error message must identify Status reconciliation as the failed step: {}",
+        err.message,
+    );
+    assert!(
+        err.message.contains("show"),
         "error message must instruct caller to re-run `show`: {}",
         err.message,
     );
 
-    // Despite the rebuild failure, the close mutation DID land — it
-    // is durable on GitHub regardless of the local cache outcome.
+    // Despite the rebuild failure, the close mutation DID land and
+    // the Phase 2 cascade field-updates ran against the Phase-0
+    // list — the whole point of PRE-close ordering.
     assert_eq!(
         mock.calls().close_issue(),
         1,
         "close is durable: mutation persists even if rebuild fails",
     );
     assert_eq!(mock.calls().fetch_issue(), 1);
-    assert_eq!(mock.calls().fetch_graph_data(), 1);
+    // fetch_graph_data was called twice: Phase 0 prime (Ok) + Phase 1
+    // post-close rebuild (Err).
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
+    // Phase 2 cascade loop still ran against the captured Phase-0
+    // list, dispatching add_comment_ref for each of #10 and #11.
+    // This is the correctness contract that PRE-close ordering
+    // buys: the cascade survives a post-close rebuild failure.
+    assert_eq!(
+        mock.calls().add_comment_ref(),
+        2,
+        "Phase 2 cascade field-updates must run against the captured Phase-0 list even when \
+         the post-close rebuild fails — this is the PRE-close correctness contract (GAP-15)",
+    );
     // With `field_ids = None`, the Phase 1 Projects V2 ladder
     // short-circuits at the `tracing::debug!` branch — no
     // `update_field` fires for the closed issue.
     assert_eq!(
         mock.calls().update_field(),
         0,
-        "status update should be skipped under error — no best-effort Phase 1 field updates fire when field_ids=None",
+        "status update should be skipped when field_ids=None — no best-effort Phase 1 field \
+         updates fire",
     );
     // Cache is invalidated by `execute_write_tool` on rebuild failure
-    // and not repopulated; the handler must not claim cascade-level
-    // consistency against an empty cache.
+    // and not repopulated; the refocused R3 error signals that the
+    // step 8 reconciliation cannot run.
     assert!(
         !server.state().cache.is_fresh().await,
         "cache must be invalidated and not repopulated after rebuild failure",
     );
+}
+
+/// GAP-15 PRE-close contract regression guard (unblock-29p.62).
+///
+/// This test locks the PRE-close cascade capture against a future
+/// refactor that might silently re-introduce POST-close lookup. It
+/// uses a production-realistic rebuilt-graph fixture that EXCLUDES
+/// the closed issue (faithful to `fetch_graph_data`'s `states: OPEN`
+/// filter at `unblock-github/src/graphql.rs:129`) and asserts the
+/// cascade list is still correctly populated from the Phase-0
+/// pre-close capture.
+///
+/// Under the legacy POST-close ordering this test would fail:
+/// `compute_unblock_cascade` would short-circuit to `Vec::new()` at
+/// `unblock-core/src/graph.rs:289-291` because the just-closed issue
+/// is absent from the rebuilt `node_map`. Under PRE-close ordering
+/// the cascade is captured in Phase 0 against the pre-close graph
+/// where #8 is still an OPEN node — the post-close rebuild's graph
+/// shape is irrelevant to the response envelope.
+///
+/// Fixture: #8 blocks #10 and #11. Phase 0 primes against
+/// `{#8 open, #10, #11}` with edges `#10 → #8`, `#11 → #8`; Phase 1
+/// closes #8 and rebuilds against `{#10, #11}` (no edges — the
+/// blocker is gone). The response MUST still carry
+/// `unblocked = [10, 11]` (set membership) and `cross_repo_refs =
+/// None`, identical to the warm-cache happy path.
+///
+/// Call-pattern assertions are intentionally duplicated with the
+/// first happy-path test — keeping them locked here guards the
+/// PRE-close contract against a regression that only manifests
+/// when the rebuild topology diverges from the prime topology.
+#[tokio::test]
+async fn close_cascade_survives_open_only_rebuild() {
+    use rmcp::handler::server::wrapper::{Json, Parameters};
+    use unblock_mcp::server::UnblockServer;
+    use unblock_mcp::tools::close::CloseParams;
+
+    // Phase 0 pre-close graph: #8 is OPEN, #10 and #11 both blocked.
+    let pre_close_issues = vec![
+        close_fixture_issue(8),
+        close_fixture_issue(10),
+        close_fixture_issue(11),
+    ];
+    let pre_close_edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 11),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+    ];
+    // Phase 1 post-close rebuild: #8 is EXCLUDED (production
+    // `states: OPEN` semantics — this is the key departure from the
+    // pre-GAP-15 cheat-fixture that retained #8 in the rebuild
+    // response to artificially satisfy the POST-close lookup). Under
+    // PRE-close ordering the cascade has already been captured, so
+    // this faithful topology is the correct production model. The
+    // edges are gone too because the blocker no longer exists in the
+    // OPEN-only graph.
+    let post_close_issues = vec![close_fixture_issue(10), close_fixture_issue(11)];
+    let post_close_edges: Vec<BlockingEdge> = vec![];
+
+    let mock = new_mock();
+    // Phase 0 cold-cache prime — captures cascade against the
+    // PRE-close graph while #8 is still an OPEN node.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, pre_close_edges)));
+    // Phase 1 mutation.
+    mock.push_fetch_issue(Ok(close_fixture_issue(8)));
+    mock.push_close_issue(Ok(()));
+    mock.push_field_ids(None); // Skip Projects V2 ladder.
+    // Phase 1 post-close rebuild — production-realistic fixture:
+    // #8 EXCLUDED, no edges. This is the topology where the legacy
+    // POST-close cascade would silently return Vec::new(); under
+    // PRE-close ordering it is irrelevant to the response.
+    mock.push_fetch_graph_data(Ok((post_close_issues, post_close_edges)));
+    // Phase 2 cascade field-updates for the two local dependents.
+    mock.push_add_comment_ref(Ok("c10".to_owned()));
+    mock.push_add_comment_ref(Ok("c11".to_owned()));
+
+    let server = UnblockServer::new(state_with_mock(Arc::clone(&mock)));
+    let Json(result) = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await
+        .expect(
+            "GAP-15 PRE-close contract: cascade MUST be captured from the pre-close graph, \
+             so the close succeeds with a fully-populated `unblocked` even when the post-close \
+             rebuild excludes the closed issue",
+        );
+
+    assert_eq!(result.issue, 8);
+
+    // THE CORE REGRESSION GUARD: despite the rebuild fixture
+    // excluding #8 (production `states: OPEN` semantics), the
+    // response carries both pre-close dependents. Under the legacy
+    // POST-close ordering this assertion would FAIL with
+    // `unblocked == []` because the rebuilt `node_map` lacks #8 and
+    // `compute_unblock_cascade` would short-circuit. GAP-15 makes
+    // this topology irrelevant to the response.
+    let unblocked_set: std::collections::HashSet<u64> = result.unblocked.iter().copied().collect();
+    assert_eq!(
+        unblocked_set,
+        std::collections::HashSet::from([10_u64, 11]),
+        "GAP-15 PRE-close contract: cascade must contain both pre-close dependents even when \
+         the post-close rebuilt graph EXCLUDES the closed issue (production `states: OPEN` \
+         semantics). Legacy POST-close ordering would silently return []; got: {:?}",
+        result.unblocked,
+    );
+    // All-local cascade → cross_repo_refs MUST be None.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "all-local cascade → cross_repo_refs None even under production-realistic rebuild; \
+         got: {:?}",
+        result.cross_repo_refs,
+    );
+
+    // Phase 2 dispatched add_comment_ref twice (once per dependent)
+    // via the *_ref primitive — both normalize to IssueRef::Local
+    // for the configured-repo dependents.
+    assert_eq!(mock.calls().add_comment_ref(), 2);
+    let ref_calls = mock.add_comment_ref_calls();
+    let ref_numbers: std::collections::HashSet<u64> = ref_calls
+        .iter()
+        .map(|r| match r {
+            unblock_core::types::IssueRef::Local(n) => *n,
+            unblock_core::types::IssueRef::CrossRepo { number, .. } => *number,
+        })
+        .collect();
+    assert_eq!(
+        ref_numbers,
+        std::collections::HashSet::from([10_u64, 11]),
+        "Phase 2 cascade MUST dispatch one add_comment_ref per captured dependent: \
+         got: {ref_calls:?}",
+    );
+    assert!(
+        ref_calls
+            .iter()
+            .all(|r| matches!(r, unblock_core::types::IssueRef::Local(_))),
+        "all dependents are configured-repo → every ref normalizes to IssueRef::Local; \
+         got: {ref_calls:?}",
+    );
+
+    assert_eq!(mock.calls().close_issue(), 1);
+    // Two fetch_graph_data round-trips: Phase 0 prime + Phase 1
+    // post-close rebuild. The second one returns a production-
+    // realistic OPEN-only graph that EXCLUDES the closed issue.
+    assert_eq!(mock.calls().fetch_graph_data(), 2);
 }


### PR DESCRIPTION
Resolves GAP-15 remediation per docs/plans/01-plan-mcp-foundation.md and
SPEC §3.4 Critical + §8.2 full close contract. Refactors the close tool
handler into four explicit phases with correctness-critical ordering:

  Phase 0 — PRE-close cascade capture: ensure graph is built (cold-cache
    prime via rebuild_cache), then call compute_unblock_cascade while the
    closed issue is still an OPEN node. Captured list is handler-local
    and authoritative for Phases 2 and 3.
  Phase 1 — MUTATION: execute_write_tool runs fetch_issue, state
    validation, close_issue, the Projects V2 Status->closed field ladder,
    and a cache rebuild.
  Phase 2 — CASCADE FIELD-UPDATE LOOP: iterate the Phase-0 cascade list
    (NOT the post-close cache) and dispatch unblock comments + Status
    field updates via the *_ref primitives, routing cross-repo dependents
    to their own (owner, repo).
  Phase 3 — RESPONSE PROJECTION: partition the Phase-0 cascade into
    `unblocked: Vec<u64>` + optional `cross_repo_refs` via the shared
    project_cascade / build_cross_repo_refs_with_summary helpers.

Why PRE-close is correctness-critical: FETCH_GRAPH_DATA_QUERY uses
`states: OPEN` filtering (unblock-github/src/graphql.rs:129), so a
POST-close cascade would short-circuit to Vec::new() at
unblock-core/src/graph.rs:289-291 because the just-closed issue is
absent from the rebuilt node_map. Under PRE-close ordering the cascade
is captured against the OPEN graph before the mutation, so it survives
the rebuild regardless of which issues the rebuild includes.

R3 503-class error refocused: under PRE-close ordering the cascade list
is no longer tied to the post-close rebuild outcome. The error now
signals step 8 update_status_fields reconciliation failure (SPEC §8.2
step 8) — cross-checking Status fields for issues NOT already handled
by the Phase 2 cascade loop. The close mutation is durable on GitHub
and Phase 2 cascade field-updates are applied best-effort regardless
of the rebuild outcome. A separate 503 branch fires before the close
mutation when Phase 0 cold-cache prime fails (close NOT attempted on
empty graph).

Preserves SPEC §14 Invariants 8 (no write leaves cache or Status
fields inconsistent), 11 (error surfacing), and 13 (Status field
values match graph computation).