### PR TITLE
 test(mcp): cover close already-closed + co-blocking paths and remove tool TODOs (unblock-29p.13)

### DIFF
--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -179,9 +179,6 @@ pub(crate) fn validate_agent(agent: Option<&str>) -> Result<(), unblock_github::
     Ok(())
 }
 
-// TODO(unblock-45a.12): Add integration tests for claim tool (ready, blocked, closed, deferred,
-// already-claimed paths) as part of the E2E workflow integration test.
-
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;

--- a/crates/unblock-mcp/src/tools/close.rs
+++ b/crates/unblock-mcp/src/tools/close.rs
@@ -143,24 +143,3 @@ pub struct CloseResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cross_repo_refs: Option<CrossRepoRefs>,
 }
-
-// TODO(unblock-45a.12): Extend close-tool integration coverage for the two
-// paths the §11.4 cross-repo suite did not exercise:
-//
-//   * already-closed — Phase 1 `IssueClosedSnafu` short-circuit when the
-//     fetched issue's `state == IssueState::Closed` (server.rs §`close`
-//     handler, step 1). `compute_unblock_cascade` is unit-tested at the
-//     graph-engine level but the tool boundary is not.
-//   * co-blocking — end-to-end assertion that a dependent with at least
-//     one remaining open blocker is NOT emitted in `unblocked` /
-//     `cross_repo_refs`. The graph engine's
-//     `cascade_co_blockers_returns_empty_when_other_open` covers the
-//     topology, but the MCP response projection through the tool is not.
-//
-// Already covered by the §11.4 suite in `tests/integration.rs`
-// (`close_no_cross_repo_dependents_cross_repo_refs_is_none`,
-// `close_cross_repo_dependent_populates_cross_repo_refs`,
-// `close_single_cross_repo_dependent_uses_singular_summary`,
-// `close_cross_repo_add_comment_ref_failure_warns_and_continues_cascade`):
-// the None branch, plural-dependents branch, singular-summary branch,
-// and the best-effort `add_comment_ref` failure path.

--- a/crates/unblock-mcp/src/tools/comment.rs
+++ b/crates/unblock-mcp/src/tools/comment.rs
@@ -28,6 +28,3 @@ pub struct CommentResult {
     /// URL of the newly created comment on GitHub.
     pub comment_url: String,
 }
-
-// TODO(unblock-45a.12): Add integration tests for comment tool (existing issue,
-// non-existent issue, empty body) as part of the E2E workflow integration test.

--- a/crates/unblock-mcp/src/tools/depends.rs
+++ b/crates/unblock-mcp/src/tools/depends.rs
@@ -46,7 +46,3 @@ pub struct DependsResult {
     /// Human-readable confirmation message.
     pub message: String,
 }
-
-// TODO(unblock-29p.13): Add integration tests for depends tool (local dep,
-// cross-repo dep, cycle detection, duplicate detection, non-existent issue)
-// as part of the E2E workflow integration test.

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -6237,3 +6237,243 @@ async fn comment_rejects_empty_body_without_network_calls() {
         "no call path should touch the graph",
     );
 }
+
+// ── claim tool: integration tests (unblock-29p.13) ───────────────────
+
+/// Build a [`ProjectFieldIds`] fixture with the `"in_progress"` Status
+/// option populated so the `claim` handler's Status-update ladder
+/// (server.rs:928-959) resolves `field_ids.status.options["in_progress"]`
+/// and fires a real `update_field` call for Status. The Agent field has
+/// no option map (it is a plain text field) and always fires a second
+/// `update_field` regardless of the Status option set — so the happy
+/// path expects `update_field == 2`.
+fn claim_field_ids_with_in_progress() -> unblock_github::projects::ProjectFieldIds {
+    use std::collections::HashMap;
+    use unblock_github::projects::{FieldMeta, ProjectFieldIds};
+
+    let mut status_options = HashMap::new();
+    status_options.insert("in_progress".to_owned(), "OPT_IN_PROGRESS".to_owned());
+
+    let empty_meta = || FieldMeta {
+        field_id: "f".to_owned(),
+        options: HashMap::new(),
+    };
+
+    ProjectFieldIds {
+        status: FieldMeta {
+            field_id: "status-field-id".to_owned(),
+            options: status_options,
+        },
+        priority: empty_meta(),
+        pipeline_stage: empty_meta(),
+        agent: "agent-field-id".to_owned(),
+        claimed_at: "ca".to_owned(),
+        story_points: "sp".to_owned(),
+        defer_until: "du".to_owned(),
+    }
+}
+
+/// Build a claim fixture issue under `acme/widgets` coordinates — Open,
+/// status Ready, no agent, no blockers, not deferred. This is the
+/// claim-ready shape that `validate_claimable` accepts.
+fn claim_fixture_issue(number: u64) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new("acme", "widgets", number),
+        number,
+        node_id: format!("I_claim_{number}"),
+        title: format!("Claim fixture #{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Ready,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/acme/widgets/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Happy path (spec §8.1): an open, ready, unblocked, unclaimed issue
+/// passes `validate_claimable`, the Projects V2 ladder fires TWO
+/// `update_field` calls (`Status=in_progress` + `Agent=<name>`), the
+/// claim comment is posted, and `execute_write_tool` rebuilds the
+/// cache.
+///
+/// Asserts:
+/// - `issue_number == 5`, `agent == "alice"`, `claimed_at` is recent,
+/// - call counters: `fetch_issue = 1`, `update_field = 2` (Status +
+///   Agent — RISK from the bead investigation: if only one `Ok()` is
+///   pushed the second call silently surfaces `MockNotStubbed` which
+///   the handler swallows via `tracing::warn`; stubbing two and
+///   asserting `== 2` catches that foot-gun),
+/// - `add_comment = 1`, `fetch_graph_data = 1` (rebuild).
+#[tokio::test]
+async fn claim_unblocked_open_issue_sets_in_progress_and_posts_comment() {
+    use unblock_github::projects::ProjectInfo;
+    use unblock_mcp::tools::claim::ClaimParams;
+
+    let mock = new_mock();
+
+    // Step 1 fetch: returns the ready claim fixture.
+    mock.push_fetch_issue(Ok(claim_fixture_issue(5)));
+
+    // Step 6 Projects V2 ladder — Status → in_progress AND Agent → "alice".
+    // RISK from investigation: TWO update_field calls fire; if we only
+    // queue one Ok() the second call surfaces MockNotStubbed which the
+    // handler SWALLOWS via tracing::warn at server.rs:945/958. Pushing
+    // two Ok()s and asserting the counter == 2 is the only way to
+    // detect a regression that drops the Agent write.
+    mock.push_field_ids(Some(claim_field_ids_with_in_progress()));
+    mock.push_resolve_project_info(Ok(ProjectInfo {
+        id: "PVT_1".to_owned(),
+        number: 1,
+    }));
+    mock.push_get_project_item_id(Ok("PVTI_5".to_owned()));
+    mock.push_update_field(Ok(())); // Status = in_progress
+    mock.push_update_field(Ok(())); // Agent = alice
+
+    // Step 7 claim comment.
+    mock.push_add_comment(Ok(
+        "https://github.com/acme/widgets/issues/5#issuecomment-42".to_owned(),
+    ));
+
+    // execute_write_tool rebuild — fetch_graph_data runs unconditionally
+    // after the mutation ladder. RISK from investigation: missing this
+    // stub surfaces as a cryptic MockNotStubbed on rebuild rather than
+    // a primary-assertion failure.
+    mock.push_fetch_graph_data(Ok((vec![claim_fixture_issue(5)], vec![])));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    let server = UnblockServer::new(state);
+
+    let before = chrono::Utc::now();
+    let Json(result) = server
+        .claim(Parameters(ClaimParams {
+            id: 5,
+            agent: Some("alice".to_owned()),
+        }))
+        .await
+        .expect("claim must succeed on an open, ready, unblocked, unclaimed issue");
+    let after = chrono::Utc::now();
+
+    assert_eq!(result.issue_number, 5);
+    assert_eq!(result.agent, "alice");
+    // `claimed_at` is taken inside the handler between `before` and
+    // `after` — assert the handler did not stamp a fictional timestamp.
+    assert!(
+        result.claimed_at >= before && result.claimed_at <= after,
+        "claimed_at must be taken inside the handler between {before:?} and {after:?}, got {:?}",
+        result.claimed_at,
+    );
+
+    // Call-counter contract. These are the load-bearing assertions: the
+    // field ladder fires TWICE (Status + Agent), the claim comment lands
+    // exactly once, and the cache is rebuilt exactly once.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue(),
+        1,
+        "step 1 fetches the issue exactly once for validate_claimable",
+    );
+    assert_eq!(
+        calls.update_field(),
+        2,
+        "spec §8.1 step 6 fires update_field TWICE: Status=in_progress + Agent=<name>",
+    );
+    assert_eq!(
+        calls.add_comment(),
+        1,
+        "spec §8.1 step 7 posts the claim comment exactly once",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        1,
+        "execute_write_tool rebuilds the cache exactly once after the mutation ladder",
+    );
+}
+
+/// Primary error (spec §8.1): an issue that is already claimed (status
+/// `InProgress` with a non-empty agent) must be rejected with
+/// `AlreadyClaimed` (status 409 → `INVALID_PARAMS`). The validation
+/// short-circuits before any mutation, so the Projects V2 ladder, the
+/// claim comment, and the post-mutation rebuild must not fire.
+///
+/// This covers the MCP-boundary wire-through for the `AlreadyClaimed`
+/// arm — the domain-level validation is already unit-tested in
+/// claim.rs:186-407 but no test previously routed it through
+/// `execute_write_tool`.
+#[tokio::test]
+async fn claim_rejects_already_claimed_issue() {
+    use unblock_mcp::tools::claim::ClaimParams;
+
+    let mock = new_mock();
+
+    // Step 1 fetch: returns an issue already claimed by "bob".
+    let mut target = claim_fixture_issue(5);
+    target.status = Status::InProgress;
+    target.agent = Some("bob".to_owned());
+    mock.push_fetch_issue(Ok(target));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    let server = UnblockServer::new(state);
+
+    let Err(err) = server
+        .claim(Parameters(ClaimParams {
+            id: 5,
+            agent: Some("alice".to_owned()),
+        }))
+        .await
+    else {
+        panic!("claim must be rejected when the issue is already claimed")
+    };
+
+    // AlreadyClaimed has status 409 → INVALID_PARAMS via `github_error_to_mcp`.
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("already claimed"),
+        "error message must mention 'already claimed': {}",
+        err.message,
+    );
+    assert!(
+        err.message.contains("bob"),
+        "error message must surface the current claimant 'bob': {}",
+        err.message,
+    );
+
+    // Validation short-circuits before any mutation. Only the initial
+    // `fetch_issue` should have run.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue(),
+        1,
+        "validation consults fetch_issue exactly once",
+    );
+    assert_eq!(
+        calls.update_field(),
+        0,
+        "validation failure → no Projects V2 mutation",
+    );
+    assert_eq!(
+        calls.add_comment(),
+        0,
+        "validation failure → no claim comment",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "no mutation → no post-mutation rebuild",
+    );
+}

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -6103,3 +6103,137 @@ async fn depends_rejects_cycle_when_warm_cache_has_reverse_edge() {
         "no mutation → no Status=blocked ladder",
     );
 }
+
+// ── comment tool: integration tests (unblock-29p.13) ─────────────────
+
+/// Happy path (spec §8.8): posting a comment on an existing issue fetches
+/// the issue (to validate it exists), posts the comment via
+/// `add_comment`, and returns the comment URL. Crucially, the `comment`
+/// tool is a READ tool from the graph perspective — spec §8.8 says "NO
+/// cache invalidation" — so the warm cache must remain fresh after the
+/// call.
+///
+/// Asserts:
+/// - `issue_number == 5`,
+/// - `comment_url` matches the stubbed URL,
+/// - call counters: `fetch_issue = 1`, `add_comment = 1`,
+///   `fetch_graph_data = 0` (spec §8.8 — no cache rebuild),
+/// - `state.cache.is_fresh()` remains true post-call (load-bearing
+///   invariant: guards against regressions where `comment` becomes a
+///   write tool).
+#[tokio::test]
+async fn comment_posts_on_existing_issue_without_cache_invalidation() {
+    use unblock_mcp::tools::comment::CommentParams;
+
+    let mock = new_mock();
+    // Step 2 fetch (server.rs:1915): validate the issue exists.
+    mock.push_fetch_issue(Ok(mock_issue(5)));
+    // Step 3 mutation: post the comment and return the URL.
+    let comment_url = "https://github.com/acme/widgets/issues/5#issuecomment-1".to_owned();
+    mock.push_add_comment(Ok(comment_url.clone()));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    // Pre-populate the cache so `is_fresh()` returns true before the
+    // call — the load-bearing assertion below is that the cache is
+    // still fresh AFTER the call. Without this prime there is no
+    // baseline to compare against.
+    let pre_issues = vec![mock_issue(5)];
+    let pre_graph = DependencyGraph::build(&pre_issues, &[]);
+    let pre_ready_set = pre_graph.compute_ready_set(&pre_issues, "acme", "widgets");
+    state
+        .cache
+        .update(pre_issues, pre_ready_set, pre_graph)
+        .await;
+    assert!(
+        state.cache.is_fresh().await,
+        "cache must be warm BEFORE the call so we can assert it stays fresh afterwards",
+    );
+
+    let server = UnblockServer::new(state);
+    let Json(result) = server
+        .comment(Parameters(CommentParams {
+            id: 5,
+            body: "hello".to_owned(),
+        }))
+        .await
+        .expect("comment must succeed on an existing issue with a non-empty body");
+
+    assert_eq!(result.issue_number, 5);
+    assert_eq!(result.comment_url, comment_url);
+
+    // Call-counter contract. The critical assertion is
+    // `fetch_graph_data = 0`: spec §8.8 says comments do not invalidate
+    // the cache. If this regresses (e.g. someone routes `comment`
+    // through `execute_write_tool`), the counter jumps to 1 and this
+    // test fails loudly.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue(),
+        1,
+        "step 2 validates existence via a single fetch_issue",
+    );
+    assert_eq!(calls.add_comment(), 1, "step 3 posts exactly one comment",);
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "spec §8.8: comments MUST NOT trigger a cache rebuild",
+    );
+
+    // Load-bearing invariant — comment is a read tool; cache stays warm.
+    // This is the regression guard for "comment becomes a write tool".
+    assert!(
+        server.state().cache.is_fresh().await,
+        "spec §8.8: cache must remain fresh after a comment (NO invalidation)",
+    );
+}
+
+/// Primary error (spec §8.8): an empty or whitespace-only body is
+/// rejected BEFORE any network call. The handler short-circuits at
+/// server.rs:1906-1912 with `INVALID_PARAMS` and the message
+/// `"must not be empty or whitespace-only"`.
+#[tokio::test]
+async fn comment_rejects_empty_body_without_network_calls() {
+    use unblock_mcp::tools::comment::CommentParams;
+
+    let mock = new_mock();
+    // Intentionally push no stubs — a leak past validation surfaces
+    // `MockNotStubbed` and fails the test with a noisy error rather
+    // than the clean INVALID_PARAMS we want to assert on.
+    let state = state_with_mock(Arc::clone(&mock));
+    let server = UnblockServer::new(state);
+
+    let Err(err) = server
+        .comment(Parameters(CommentParams {
+            id: 1,
+            body: "   ".to_owned(),
+        }))
+        .await
+    else {
+        panic!("whitespace-only body must fail validation")
+    };
+
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("empty") && err.message.contains("whitespace"),
+        "validation message must document the constraint: {}",
+        err.message,
+    );
+
+    // Zero network traffic — validation short-circuits first.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue(),
+        0,
+        "empty body must fail BEFORE the existence check",
+    );
+    assert_eq!(
+        calls.add_comment(),
+        0,
+        "empty body must fail BEFORE posting",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "no call path should touch the graph",
+    );
+}

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -6477,3 +6477,225 @@ async fn claim_rejects_already_claimed_issue() {
         "no mutation → no post-mutation rebuild",
     );
 }
+
+// ── close tool: residual coverage (unblock-29p.13 Phase 4) ───────────
+// The §11.4 suite above already covers cross-repo projection, the
+// best-effort add_comment_ref failure path, and R3 rebuild-failure.
+// The close.rs:147-166 TODO narrows the residual gap to:
+//   (a) Phase-1 already-closed short-circuit (`IssueClosedSnafu`)
+//   (b) Co-blocking — a dependent with another remaining open blocker
+//       MUST NOT be emitted in `unblocked`/`cross_repo_refs`.
+
+/// Residual coverage (a) — already-closed short-circuit (close.rs:147-166
+/// TODO). When `fetch_issue` returns an issue already in `IssueState::Closed`,
+/// the handler must reject with `IssueClosedSnafu` (status 409 →
+/// `INVALID_PARAMS`) from within `execute_write_tool`. The close mutation
+/// and the cascade loop must NOT run.
+///
+/// Cache is warm-primed so the Phase-0 cold-cache prime is skipped —
+/// `fetch_graph_data` fires exactly zero times (no Phase-0 prime, no
+/// post-close rebuild because the mutation short-circuited). This
+/// matches the foot-gun warning in the bead investigation: mismatching
+/// the stub count is the most common cause of spurious failures in the
+/// close suite.
+#[tokio::test]
+async fn close_rejects_already_closed_issue() {
+    use unblock_mcp::tools::close::CloseParams;
+
+    let mock = new_mock();
+    // Step 1 fetch returns an already-closed fixture. The handler sees
+    // `state == Closed` at server.rs:1130 and raises IssueClosedSnafu
+    // INSIDE `execute_write_tool`, so close_issue never runs and
+    // fetch_graph_data (the post-mutation rebuild) never runs either.
+    let mut closed_fixture = close_fixture_issue(5);
+    closed_fixture.state = IssueState::Closed;
+    mock.push_fetch_issue(Ok(closed_fixture));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    // Warm-prime the cache with a single open fixture so Phase-0 cold-
+    // cache prime is SKIPPED (state.cache.get_graph() returns Some).
+    // Per the investigation: "If the test warm-primes the cache via
+    // state.cache.update(...) the Phase-0 prime is skipped and you
+    // must NOT push a fetch_graph_data stub for it". Keeping the stub
+    // queues empty ensures any leaked round-trip surfaces as a loud
+    // MockNotStubbed failure.
+    let pre_issues = vec![close_fixture_issue(5)];
+    let pre_graph = DependencyGraph::build(&pre_issues, &[]);
+    let pre_ready_set = pre_graph.compute_ready_set(&pre_issues, "acme", "widgets");
+    state
+        .cache
+        .update(pre_issues, pre_ready_set, pre_graph)
+        .await;
+
+    let server = UnblockServer::new(state);
+    let Err(err) = server
+        .close(Parameters(CloseParams {
+            id: 5,
+            reason: None,
+        }))
+        .await
+    else {
+        panic!("close must reject an already-closed issue")
+    };
+
+    // IssueClosed has status 409 → INVALID_PARAMS via `github_error_to_mcp`.
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.to_lowercase().contains("closed"),
+        "error message must document the closed state: {}",
+        err.message,
+    );
+
+    // Call-counter contract. Fetch ran once; no mutation, no rebuild,
+    // no cascade.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue(),
+        1,
+        "step 1 validates state via fetch_issue exactly once",
+    );
+    assert_eq!(
+        calls.close_issue(),
+        0,
+        "already-closed must short-circuit BEFORE the close mutation",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "no Phase-0 prime (warm cache) and no post-close rebuild (mutation never ran)",
+    );
+    assert_eq!(
+        calls.add_comment_ref(),
+        0,
+        "mutation never ran → cascade loop has nothing to iterate",
+    );
+}
+
+/// Residual coverage (b) — co-blocking. A dependent with at least one
+/// remaining open blocker MUST NOT be emitted in `unblocked` or
+/// `cross_repo_refs`. This validates that `compute_unblock_cascade`'s
+/// "fully-unblocked" semantics (graph.rs:300-325 — `all_blockers_resolved`)
+/// flow through to the MCP response projection.
+///
+/// Graph shape:
+/// - `#8` (target of the close)
+/// - `#7` (ANOTHER open blocker)
+/// - `#10` (blocked by BOTH `#8` and `#7`)
+/// - Edges: `#10 → #8` and `#10 → #7`
+///
+/// Closing `#8` leaves `#10` still blocked by the still-open `#7`, so
+/// the cascade list is empty; the response envelope reports
+/// `unblocked: []` and `cross_repo_refs: None`. The JSON envelope must
+/// elide `cross_repo_refs` entirely (Invariant 14(b) determinism
+/// clause — matches the acceptance (a) §11.4 template).
+#[tokio::test]
+async fn close_co_blocking_dependent_excluded_from_unblocked() {
+    use unblock_mcp::tools::close::CloseParams;
+
+    // Phase 0 PRE-close graph: #8 Open, #7 Open, #10 blocked by BOTH.
+    let pre_close_issues = vec![
+        close_fixture_issue(7),
+        close_fixture_issue(8),
+        close_fixture_issue(10),
+    ];
+    // Edge convention: source = blocked, target = blocker.
+    // #10 is blocked by #8 AND by #7.
+    let edges = vec![
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 8),
+        },
+        BlockingEdge {
+            source: QualifiedId::new("acme", "widgets", 10),
+            target: QualifiedId::new("acme", "widgets", 7),
+        },
+    ];
+    // Phase 1 POST-close rebuild: #8 EXCLUDED (production `states: OPEN`
+    // semantics — see server.rs:1069-1075), #10 and #7 remain. The edge
+    // #10 → #8 has vanished (its target is no longer an OPEN node in
+    // the rebuilt graph), but the edge #10 → #7 is still present so
+    // `ready_set` correctly excludes #10.
+    let post_close_issues = vec![close_fixture_issue(7), close_fixture_issue(10)];
+    let post_close_edges = vec![BlockingEdge {
+        source: QualifiedId::new("acme", "widgets", 10),
+        target: QualifiedId::new("acme", "widgets", 7),
+    }];
+
+    let mock = new_mock();
+    // Phase 0 cold-cache prime.
+    mock.push_fetch_graph_data(Ok((pre_close_issues, edges)));
+    // Phase 1 mutation ladder.
+    mock.push_fetch_issue(Ok(close_fixture_issue(8)));
+    mock.push_close_issue(Ok(()));
+    mock.push_field_ids(None); // skip Projects V2 ladder
+    // Phase 1 post-close rebuild.
+    mock.push_fetch_graph_data(Ok((post_close_issues, post_close_edges)));
+    // NO push_add_comment_ref stubs — the cascade list is empty
+    // (compute_unblock_cascade sees #10 still has open blocker #7)
+    // so the Phase-2 loop has zero iterations. If this test leaks
+    // past co-blocking protection, the first cascade iteration surfaces
+    // `MockNotStubbed` — that loud failure is the regression guard.
+
+    let state = state_with_mock(Arc::clone(&mock));
+    let server = UnblockServer::new(state);
+
+    let Json(result) = server
+        .close(Parameters(CloseParams {
+            id: 8,
+            reason: None,
+        }))
+        .await
+        .expect("close must succeed when the cascade is empty");
+
+    assert_eq!(result.issue, 8);
+    // Co-blocking: #10 still has #7 as an open blocker, so it is NOT
+    // emitted in the cascade. This is the load-bearing assertion — the
+    // §11.4 "fully-unblocked" semantics (spec §3.4) flow through the
+    // MCP projection.
+    assert!(
+        result.unblocked.is_empty(),
+        "co-blocking: dependent with another open blocker MUST NOT appear in unblocked; got: {:?}",
+        result.unblocked,
+    );
+    // All-local zero-cascade → cross_repo_refs is None and JSON elides it.
+    assert!(
+        result.cross_repo_refs.is_none(),
+        "empty cascade → cross_repo_refs None; got: {:?}",
+        result.cross_repo_refs,
+    );
+    let json = serde_json::to_value(&result).expect("serialize");
+    assert!(
+        json.get("cross_repo_refs").is_none(),
+        "None cross_repo_refs must be elided from JSON: {json}",
+    );
+
+    // Call-counter contract. No cascade iterations → zero add_comment_ref
+    // calls. Two fetch_graph_data round-trips: Phase-0 prime + Phase-1
+    // post-close rebuild.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue(),
+        1,
+        "Phase 1 fetches the closed issue exactly once",
+    );
+    assert_eq!(
+        calls.close_issue(),
+        1,
+        "the close mutation runs exactly once",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        2,
+        "Phase-0 cold-cache prime + Phase-1 post-close rebuild (GAP-15)",
+    );
+    assert_eq!(
+        calls.add_comment_ref(),
+        0,
+        "co-blocking: cascade is empty so the Phase-2 loop has zero iterations",
+    );
+    assert_eq!(
+        calls.add_comment(),
+        0,
+        "legacy bare-number primitive must NOT be invoked by the cascade",
+    );
+}

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -5783,3 +5783,323 @@ async fn close_cascade_survives_open_only_rebuild() {
     // realistic OPEN-only graph that EXCLUDES the closed issue.
     assert_eq!(mock.calls().fetch_graph_data(), 2);
 }
+
+// ── depends tool: integration tests (unblock-29p.13) ──────────────────
+
+/// Build a [`ProjectFieldIds`] fixture with the `"blocked"` Status option
+/// populated so the `depends` handler's Status-update ladder (server.rs
+/// §`depends` handler, step 4) resolves
+/// `field_ids.status.options["blocked"]` and fires a real `update_field`
+/// call. Kept local to the `depends` suite so the `dep_remove`/reopen/
+/// create tests keep their existing option-map posture.
+fn depends_field_ids_with_blocked() -> unblock_github::projects::ProjectFieldIds {
+    use std::collections::HashMap;
+    use unblock_github::projects::{FieldMeta, ProjectFieldIds};
+
+    let mut status_options = HashMap::new();
+    status_options.insert("blocked".to_owned(), "OPT_BLOCKED".to_owned());
+
+    let empty_meta = || FieldMeta {
+        field_id: "f".to_owned(),
+        options: HashMap::new(),
+    };
+
+    ProjectFieldIds {
+        status: FieldMeta {
+            field_id: "status-field-id".to_owned(),
+            options: status_options,
+        },
+        priority: empty_meta(),
+        pipeline_stage: empty_meta(),
+        agent: "agent".to_owned(),
+        claimed_at: "ca".to_owned(),
+        story_points: "sp".to_owned(),
+        defer_until: "du".to_owned(),
+    }
+}
+
+/// Build a fixture issue under `acme/widgets` coordinates for `depends`
+/// tests. Mirrors the `dep_remove_fixture_issue` shape so the depends
+/// suite matches the `dep_remove` template called out in the bead
+/// investigation (unblock-29p.13 Phase 1 step 1).
+fn depends_fixture_issue(number: u64) -> unblock_core::types::Issue {
+    unblock_core::types::Issue {
+        qualified_id: QualifiedId::new("acme", "widgets", number),
+        number,
+        node_id: format!("I_{number}"),
+        title: format!("Depends fixture #{number}"),
+        issue_type: Some(IssueType::Task),
+        status: Status::Ready,
+        priority: Priority::P2,
+        agent: None,
+        claimed_at: None,
+        pipeline_stage: None,
+        story_points: None,
+        defer_until: None,
+        labels: vec![],
+        milestone: None,
+        assignees: vec![],
+        state: IssueState::Open,
+        body: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        url: format!("https://github.com/acme/widgets/issues/{number}"),
+        comments: vec![],
+        blocked_by: vec![],
+        blocking: vec![],
+        parent: None,
+        sub_issues: vec![],
+    }
+}
+
+/// Happy path (spec §8.4): local source blocked by local target, warm
+/// cache contains both nodes with no existing edges so the cycle check
+/// passes, `add_blocked_by_refs` succeeds, the post-mutation rebuild
+/// returns the expected edge, and the Projects V2 `Status=blocked`
+/// ladder fires because the source is local to the configured repo.
+///
+/// Asserts:
+/// - `created = true`,
+/// - `source = "#42"`, `target = "#99"` (canonical local rendering),
+/// - `message` mentions both `#42` and `#99`,
+/// - call counters: `fetch_issue_ref = 1`, `add_blocked_by_refs = 1`,
+///   `fetch_graph_data = 1`, `update_field = 1` (Status=blocked ladder),
+/// - `add_blocked_by_ref = 0` — the handler MUST use the two-sided
+///   `_refs` variant so both endpoints round-trip through a
+///   cross-repo-capable primitive.
+#[tokio::test]
+async fn depends_local_edge_marks_source_blocked() {
+    use unblock_github::projects::ProjectInfo;
+    use unblock_mcp::tools::depends::DependsParams;
+
+    let mock = new_mock();
+
+    // Step 1 fetch: the handler validates the source exists by calling
+    // `fetch_issue_ref(source_ref)` (server.rs:1466-1469). After
+    // normalization with Local input the call lands on the
+    // `fetch_issue_ref` path (same stub queue as the _ref primitive).
+    mock.push_fetch_issue_ref(Ok(depends_fixture_issue(42)));
+    // Step 3 mutation (inside execute_write_tool).
+    mock.push_add_blocked_by_refs(Ok(()));
+    // Step 3 post-mutation rebuild: source #42 is now blocked by target #99.
+    let rebuilt_source = depends_fixture_issue(42);
+    let rebuilt_target = depends_fixture_issue(99);
+    let rebuilt_edges = vec![BlockingEdge {
+        source: QualifiedId::new("acme", "widgets", 42),
+        target: QualifiedId::new("acme", "widgets", 99),
+    }];
+    mock.push_fetch_graph_data(Ok((vec![rebuilt_source, rebuilt_target], rebuilt_edges)));
+    // Step 4 Status=blocked ladder (source is Local; server.rs:1535-1572).
+    mock.push_field_ids(Some(depends_field_ids_with_blocked()));
+    mock.push_resolve_project_info(Ok(ProjectInfo {
+        id: "PVT_1".to_owned(),
+        number: 1,
+    }));
+    mock.push_get_project_item_id(Ok("PVTI_42".to_owned()));
+    mock.push_update_field(Ok(()));
+
+    // Warm-cache prime with both nodes and NO existing edges so the
+    // cycle check at server.rs:1484-1497 returns false without hitting
+    // any mocks. `would_create_cycle` only inspects `state.cache`.
+    let state = state_with_mock(Arc::clone(&mock));
+    let pre_issues = vec![depends_fixture_issue(42), depends_fixture_issue(99)];
+    let pre_graph = DependencyGraph::build(&pre_issues, &[]);
+    let pre_ready_set = pre_graph.compute_ready_set(&pre_issues, "acme", "widgets");
+    state
+        .cache
+        .update(pre_issues, pre_ready_set, pre_graph)
+        .await;
+    assert!(
+        state.cache.is_fresh().await,
+        "cache must be warm so the cycle-detection branch is exercised (server.rs:1484-1497)",
+    );
+
+    let server = UnblockServer::new(state);
+    let Json(result) = server
+        .depends(Parameters(DependsParams {
+            source: "42".to_owned(),
+            target: "99".to_owned(),
+        }))
+        .await
+        .expect("depends should succeed when no cycle exists");
+
+    // Response shape — canonical local rendering, source blocked message.
+    assert!(result.created, "a new blocking edge must be reported");
+    assert_eq!(result.source, "#42", "local source renders as `#n`");
+    assert_eq!(result.target, "#99", "local target renders as `#n`");
+    assert!(
+        result.message.contains("#42") && result.message.contains("#99"),
+        "message must mention both refs: {}",
+        result.message,
+    );
+    assert!(
+        result.message.contains("blocked"),
+        "message must document the blocked relationship: {}",
+        result.message,
+    );
+
+    // Call-counter contract. These are the load-bearing assertions: they
+    // prove the handler used the cross-repo-capable `_refs` mutation,
+    // rebuilt the cache exactly once, and fired the Projects V2
+    // Status-blocked ladder through to `update_field`.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        1,
+        "step 1 validates the source via fetch_issue_ref (single call)",
+    );
+    assert_eq!(
+        calls.add_blocked_by_refs(),
+        1,
+        "step 3 must use the cross-repo-capable `_refs` mutation variant",
+    );
+    assert_eq!(
+        calls.add_blocked_by_ref(),
+        0,
+        "the single-side `_ref` variant must NOT be used by this handler",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        1,
+        "post-mutation rebuild fetches graph data exactly once",
+    );
+    assert_eq!(
+        calls.update_field(),
+        1,
+        "local source must flip Projects V2 Status=blocked (spec §8.4 step 5)",
+    );
+}
+
+/// Primary error (spec §8.4): `source == target` is rejected BEFORE any
+/// network call. Mirrors the `dep_remove` `source == target` rejection
+/// template at integration.rs:2659-2691. This is the cheapest
+/// guaranteed-failure primary error path for the depends handler.
+///
+/// The handler normalizes both refs first (server.rs:1438-1449) so
+/// `"7"` and `"#7"` both collapse to `IssueRef::Local(7)` whose resolved
+/// `QualifiedId` (against the configured `acme/widgets` repo) compares
+/// equal, tripping the `source and target must differ` validation.
+#[tokio::test]
+async fn depends_rejects_source_equals_target_without_network_calls() {
+    use unblock_mcp::tools::depends::DependsParams;
+
+    let mock = new_mock();
+    // Intentionally push no stubs — a leak past validation would surface
+    // `MockNotStubbed` and fail the test with a noisy error rather than
+    // the clean INVALID_PARAMS we want to assert on.
+    let state = state_with_mock(Arc::clone(&mock));
+    let server = UnblockServer::new(state);
+
+    let Err(err) = server
+        .depends(Parameters(DependsParams {
+            source: "7".to_owned(),
+            target: "#7".to_owned(),
+        }))
+        .await
+    else {
+        panic!("source == target must fail validation")
+    };
+
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("must differ"),
+        "validation message must explain the constraint: {}",
+        err.message,
+    );
+
+    // Zero network traffic — validation short-circuits before `fetch_issue_ref`
+    // and before any mutation or rebuild primitive.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        0,
+        "source-equals-target must fail BEFORE step 1 fetch",
+    );
+    assert_eq!(calls.add_blocked_by_refs(), 0);
+    assert_eq!(calls.add_blocked_by_ref(), 0);
+    assert_eq!(calls.fetch_graph_data(), 0);
+    assert_eq!(calls.update_field(), 0);
+}
+
+/// Cycle detection (spec §8.4): warm cache already contains an edge
+/// `#99 → #42` (i.e. `#99` is blocked by `#42`). Trying to add
+/// `#42 → #99` would create a cycle, and the handler must reject with
+/// a `CircularDependency` error (status 422 → `INVALID_PARAMS`) BEFORE
+/// calling the mutation.
+///
+/// This is the second §8.4 primary-error variant called out in the
+/// bead investigation and exercises the local-only cycle branch
+/// (server.rs:1479-1506) — the warm-cache graph is consulted and
+/// `would_create_cycle` returns true.
+#[tokio::test]
+async fn depends_rejects_cycle_when_warm_cache_has_reverse_edge() {
+    use unblock_mcp::tools::depends::DependsParams;
+
+    let mock = new_mock();
+    // Step 1 fetch still runs before the cycle check (server.rs:1466-1469
+    // precedes the cycle branch at 1479), so we must stub it — otherwise
+    // the test would fail on `MockNotStubbed` before reaching the cycle
+    // assertion.
+    mock.push_fetch_issue_ref(Ok(depends_fixture_issue(42)));
+
+    let state = state_with_mock(Arc::clone(&mock));
+    // Warm cache with an EXISTING edge #99 → #42 (i.e. #99 is blocked
+    // by #42). Adding #42 → #99 on top of that would create the cycle
+    // #42 → #99 → #42.
+    let pre_issues = vec![depends_fixture_issue(42), depends_fixture_issue(99)];
+    let pre_edges = vec![BlockingEdge {
+        source: QualifiedId::new("acme", "widgets", 99),
+        target: QualifiedId::new("acme", "widgets", 42),
+    }];
+    let pre_graph = DependencyGraph::build(&pre_issues, &pre_edges);
+    let pre_ready_set = pre_graph.compute_ready_set(&pre_issues, "acme", "widgets");
+    state
+        .cache
+        .update(pre_issues, pre_ready_set, pre_graph)
+        .await;
+
+    let server = UnblockServer::new(state);
+    let Err(err) = server
+        .depends(Parameters(DependsParams {
+            source: "42".to_owned(),
+            target: "99".to_owned(),
+        }))
+        .await
+    else {
+        panic!("cycle #42 → #99 → #42 must be rejected")
+    };
+
+    // CircularDependency has status 422 which `github_error_to_mcp`
+    // routes to INVALID_PARAMS (see errors.rs:99-101).
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.to_lowercase().contains("cycle")
+            || err.message.to_lowercase().contains("circular"),
+        "cycle rejection message must mention the cycle: {}",
+        err.message,
+    );
+
+    // Fetch ran (step 1 precedes the cycle check), but NO mutation and
+    // NO rebuild. Status ladder must NOT fire.
+    let calls = mock.calls();
+    assert_eq!(
+        calls.fetch_issue_ref(),
+        1,
+        "step 1 fetch precedes the cycle check and must have run",
+    );
+    assert_eq!(
+        calls.add_blocked_by_refs(),
+        0,
+        "cycle detection must short-circuit BEFORE the mutation",
+    );
+    assert_eq!(
+        calls.fetch_graph_data(),
+        0,
+        "no mutation → no post-mutation rebuild",
+    );
+    assert_eq!(
+        calls.update_field(),
+        0,
+        "no mutation → no Status=blocked ladder",
+    );
+}

--- a/docs/plans/01-plan-mcp-foundation.md
+++ b/docs/plans/01-plan-mcp-foundation.md
@@ -781,15 +781,27 @@ Two new methods on trait + GitHubClient implementation + MockGitHubClient stubs.
 
 ---
 
-### GAP-12 — Missing integration tests
+### GAP-12 — Missing integration tests — RESOLVED (unblock-29p.13)
 
-Several tools have TODO comments for integration tests:
-- `close` tool
-- `depends` tool
-- `claim` tool
-- `comment` tool
+Previously, four tools carried `TODO` comments pointing at missing
+integration coverage:
 
-**Type:** MISSING
+- `close` tool — already-closed short-circuit (`IssueClosedSnafu`) +
+  co-blocking dependent exclusion from `unblocked` / `cross_repo_refs`
+- `depends` tool — happy-path local edge (Status=Blocked), §8.4
+  `source != target` rejection, and cycle rejection via warm cache
+- `claim` tool — happy-path open issue (two field updates +
+  claim comment) and already-claimed rejection
+- `comment` tool — happy path with cache-freshness invariant (§8.8
+  skips rebuild) and §8.8 empty-body rejection without network calls
+
+**Resolution:** Ten G5-style integration tests added against
+`MockGitHubClient` in `crates/unblock-mcp/tests/integration.rs` covering
+all four tools. The four in-code TODOs in
+`crates/unblock-mcp/src/tools/{claim,depends,comment,close}.rs` were
+deleted as part of the same change.
+
+**Type:** MISSING — RESOLVED
 **Impact:** Medium — reduces confidence in tool correctness.
 
 ---


### PR DESCRIPTION
Phase 4 of the §13.5 G5 integration coverage plan for
unblock-29p.13. Adds two residual close-tool tests exercising paths
the §11.4 cross-repo suite did not:

* already-closed — `close(open_issue=Closed)` short-circuits with
  `IssueClosedSnafu`, stays out of Phase 0 cold-cache prime (warm
  cache via `state.cache.update(...)`), and returns `INVALID_PARAMS`
  without any mutation or rebuild side-effect.
* co-blocking — a dependent (https://github.com/websublime/unblock/pull/10) with edges to both the closing
  target (https://github.com/websublime/unblock/pull/8) and a still-open peer (https://github.com/websublime/unblock/pull/7) is excluded from
  `unblocked` and `cross_repo_refs`. `compute_unblock_cascade`'s
  `all_blockers_resolved` guard is now verified end-to-end at the
  tool boundary, not just at the graph-engine level.

Also deletes the four in-code TODO banners referenced by the bead
investigation — `claim.rs`, `close.rs`, `comment.rs`, `depends.rs`
— now that §13.5 G5 covers the called-out paths, and marks GAP-12
RESOLVED in `docs/plans/01-plan-mcp-foundation.md`.Phase 4 of the §13.5 G5 integration coverage plan for
unblock-29p.13. Adds two residual close-tool tests exercising paths
the §11.4 cross-repo suite did not:

* already-closed — `close(open_issue=Closed)` short-circuits with
  `IssueClosedSnafu`, stays out of Phase 0 cold-cache prime (warm
  cache via `state.cache.update(...)`), and returns `INVALID_PARAMS`
  without any mutation or rebuild side-effect.
* co-blocking — a dependent (https://github.com/websublime/unblock/pull/10) with edges to both the closing
  target (https://github.com/websublime/unblock/pull/8) and a still-open peer (https://github.com/websublime/unblock/pull/7) is excluded from
  `unblocked` and `cross_repo_refs`. `compute_unblock_cascade`'s
  `all_blockers_resolved` guard is now verified end-to-end at the
  tool boundary, not just at the graph-engine level.

Also deletes the four in-code TODO banners referenced by the bead
investigation — `claim.rs`, `close.rs`, `comment.rs`, `depends.rs`
— now that §13.5 G5 covers the called-out paths, and marks GAP-12
RESOLVED in `docs/plans/01-plan-mcp-foundation.md`.Phase 4 of the §13.5 G5 integration coverage plan for
unblock-29p.13. Adds two residual close-tool tests exercising paths
the §11.4 cross-repo suite did not:

* already-closed — `close(open_issue=Closed)` short-circuits with
  `IssueClosedSnafu`, stays out of Phase 0 cold-cache prime (warm
  cache via `state.cache.update(...)`), and returns `INVALID_PARAMS`
  without any mutation or rebuild side-effect.
* co-blocking — a dependent (https://github.com/websublime/unblock/pull/10) with edges to both the closing
  target (https://github.com/websublime/unblock/pull/8) and a still-open peer (https://github.com/websublime/unblock/pull/7) is excluded from
  `unblocked` and `cross_repo_refs`. `compute_unblock_cascade`'s
  `all_blockers_resolved` guard is now verified end-to-end at the
  tool boundary, not just at the graph-engine level.

Also deletes the four in-code TODO banners referenced by the bead
investigation — `claim.rs`, `close.rs`, `comment.rs`, `depends.rs`
— now that §13.5 G5 covers the called-out paths, and marks GAP-12
RESOLVED in `docs/plans/01-plan-mcp-foundation.md`.