### PR TITLE
 refactor(github): extract from_parts helper to deduplicate client constructors (unblock-29p.52)

### DIFF
--- a/crates/unblock-github/src/client.rs
+++ b/crates/unblock-github/src/client.rs
@@ -54,10 +54,17 @@ impl GitHubClient {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::GitRemote`] if repo resolution fails, or if the HTTP
-    /// client cannot be built (e.g. the token is not a valid HTTP header
-    /// value — the invalid-header path is surfaced via `build_http_client`
-    /// as [`Error::GitRemote`] with status 500).
+    /// Returns one of the following, depending on which step fails:
+    ///
+    /// - [`Error::GitRemote`] if repo resolution fails (missing/invalid
+    ///   `UNBLOCK_REPO`, unreadable `.git/config`, or an origin URL that does
+    ///   not match the configured GitHub host).
+    /// - [`Error::GitRemote`] if the token bytes are not a valid HTTP header
+    ///   value — `HeaderValue::from_str` rejects the `Authorization: Bearer
+    ///   {token}` assembly inside `build_http_client`.
+    /// - [`Error::GitHubUnavailable`] if `reqwest::Client::builder().build()`
+    ///   fails inside `build_http_client` (TLS backend initialisation or other
+    ///   HTTP-client configuration error).
     #[allow(clippy::unused_async)] // Async signature required by callers; resolve_project_info() is separate.
     pub async fn new(config: &Config) -> Result<Self, Error> {
         let http = Self::build_http_client(&config.token)?;
@@ -94,10 +101,19 @@ impl GitHubClient {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::GitRemote`] if the HTTP client cannot be built
-    /// (e.g. the token is not a valid HTTP header value — the
-    /// invalid-header path is surfaced via `build_http_client` as
-    /// [`Error::GitRemote`] with status 500).
+    /// Returns one of the following, depending on which step fails inside
+    /// `build_http_client`:
+    ///
+    /// - [`Error::GitRemote`] if the token bytes are not a valid HTTP header
+    ///   value — `HeaderValue::from_str` rejects the `Authorization: Bearer
+    ///   {token}` assembly.
+    /// - [`Error::GitHubUnavailable`] if `reqwest::Client::builder().build()`
+    ///   fails (TLS backend initialisation or other HTTP-client configuration
+    ///   error).
+    ///
+    /// Unlike [`GitHubClient::new`], this constructor never touches the
+    /// repo-resolution path, so it does not surface [`Error::GitRemote`] for
+    /// missing/invalid `UNBLOCK_REPO` or unreadable `.git/config`.
     #[allow(clippy::unused_async)] // Async signature kept symmetric with `new`.
     pub async fn with_repo(
         config: &Config,

--- a/crates/unblock-github/src/client.rs
+++ b/crates/unblock-github/src/client.rs
@@ -64,22 +64,13 @@ impl GitHubClient {
         let (owner, repo) = Self::resolve_repo(config)?;
         let project_number = Self::resolve_project(config);
 
-        info!(
-            owner = %owner,
-            repo = %repo,
-            project_number = ?project_number,
-            api_base_url = %config.api_base_url,
-            "GitHubClient initialized"
-        );
-
-        Ok(Self {
+        Ok(Self::from_parts(
             http,
-            api_base_url: config.api_base_url.clone(),
+            config.api_base_url.clone(),
             owner,
             repo,
             project_number,
-            field_ids: Mutex::new(None),
-        })
+        ))
     }
 
     /// Creates a new `GitHubClient` with an explicitly supplied repository,
@@ -118,22 +109,47 @@ impl GitHubClient {
         let repo = repo.into();
         let project_number = Self::resolve_project(config);
 
+        Ok(Self::from_parts(
+            http,
+            config.api_base_url.clone(),
+            owner,
+            repo,
+            project_number,
+        ))
+    }
+
+    /// Assembles a `GitHubClient` from its pre-resolved parts.
+    ///
+    /// This private helper centralises the struct-literal construction shared
+    /// by [`GitHubClient::new`] and [`GitHubClient::with_repo`], so both public
+    /// constructors route through a single code path for the `api_base_url`
+    /// field assignment, the initialisation-complete `tracing::info!` span, and
+    /// the final `Self { .. }` build. Callers are responsible for producing the
+    /// HTTP client (via [`Self::build_http_client`]) and resolving owner / repo
+    /// / project number before invoking this helper.
+    fn from_parts(
+        http: reqwest::Client,
+        api_base_url: String,
+        owner: String,
+        repo: String,
+        project_number: Option<u64>,
+    ) -> Self {
         info!(
             owner = %owner,
             repo = %repo,
             project_number = ?project_number,
-            api_base_url = %config.api_base_url,
-            "GitHubClient initialized via with_repo"
+            api_base_url = %api_base_url,
+            "GitHubClient initialized"
         );
 
-        Ok(Self {
+        Self {
             http,
-            api_base_url: config.api_base_url.clone(),
+            api_base_url,
             owner,
             repo,
             project_number,
             field_ids: Mutex::new(None),
-        })
+        }
     }
 
     /// Builds the shared `reqwest::Client` with the default headers used by


### PR DESCRIPTION
Both `GitHubClient::new` and `GitHubClient::with_repo` shared ~10 lines of
struct-literal construction (api_base_url clone, tracing::info! span, and the
final `Self { .. }` build). Extract a private `from_parts(http, api_base_url,
owner, repo, project_number) -> Self` helper so both public constructors
route through a single code path.

No public API change (helper is private). Zero caller-observable behaviour
change. Log message is now the neutral "GitHubClient initialized" on both
paths (previously with_repo carried a "via with_repo" suffix); structured
fields (owner, repo, project_number, api_base_url) remain identical.