### PR TITLE
feat(core): harden RelatedIssue API surface with #[non_exhaustive] + …

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -186,11 +186,24 @@ pub struct Issue {
 ///
 /// Separate from our workflow [`Status`] — GitHub only tracks Open/Closed,
 /// while `Status` provides finer-grained workflow states.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// # Default
+///
+/// `Default::default()` returns [`IssueState::Closed`]. This is a fail-safe
+/// choice: if a default is accidentally produced (e.g. via serde round-trip
+/// of a partial frame or [`RelatedIssue::default()`]), treating the issue as
+/// closed prevents downstream workflow code from claiming or acting on an
+/// issue it should not. Defaulting to `Open` would risk false workflow
+/// activation.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum IssueState {
     /// The issue is open and active.
     Open,
     /// The issue has been closed.
+    ///
+    /// Chosen as the [`Default`] variant — see the enum-level docs for the
+    /// fail-safe rationale.
+    #[default]
     Closed,
 }
 
@@ -368,6 +381,22 @@ impl fmt::Display for PipelineStage {
 /// parent issues, and sub-issues returned by `fetch_issue()`.
 /// Contains only the fields available from nested GraphQL fragments.
 ///
+/// # Construction
+///
+/// This struct is `#[non_exhaustive]`, so callers cannot build it with
+/// struct-literal syntax. Use one of the provided helpers:
+///
+/// - [`RelatedIssue::local`] — same-repo-as-enclosing-issue case (leaves
+///   `repo_owner` / `repo_name` as `None`). Matches the ~90% of call
+///   sites that don't need repo disambiguation.
+/// - [`RelatedIssue::cross_repo`] — cross-repository relation with an
+///   explicit `owner` / `name` pair.
+///
+/// [`Default`] is implemented for extension points (FRU via
+/// `..Default::default()`) and for serde round-trip of partial frames.
+/// Prefer the named helpers at construction sites — `Default` is a
+/// safety net, not the recommended path.
+///
 /// # Repo identity (`repo_owner` / `repo_name`)
 ///
 /// The GitHub `trackedByIssues` connection can return blockers from a
@@ -380,7 +409,8 @@ impl fmt::Display for PipelineStage {
 /// GraphQL selection omits `repository { ... }`, these fields remain
 /// `None` — the caller MUST treat `None` as "unknown / assume
 /// same-repo-as-enclosing-issue" to preserve backwards compatibility.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct RelatedIssue {
     /// GitHub issue number.
     pub number: u64,
@@ -398,6 +428,57 @@ pub struct RelatedIssue {
     /// "same repo as the containing issue".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo_name: Option<String>,
+}
+
+impl RelatedIssue {
+    /// Build a same-repo-as-enclosing-issue relation.
+    ///
+    /// Leaves `repo_owner` and `repo_name` as `None`, encoding the
+    /// "None = same repo as the containing issue" convention at the
+    /// type level. Use this for parent / sub-issue / `trackedInIssues`
+    /// relations and for any blocker whose GraphQL selection omitted
+    /// `repository { ... }`.
+    ///
+    /// For a cross-repository relation with explicit owner/name, use
+    /// [`RelatedIssue::cross_repo`] instead.
+    #[must_use]
+    pub fn local(number: u64, title: impl Into<String>, state: IssueState) -> Self {
+        Self {
+            number,
+            title: title.into(),
+            state,
+            repo_owner: None,
+            repo_name: None,
+        }
+    }
+
+    /// Build a cross-repository relation with explicit `owner` and
+    /// `name`.
+    ///
+    /// Use this when the parser observed a `repository { owner { login }
+    /// name }` subfield set on the related-issue node (e.g. a
+    /// `trackedByIssues` blocker) and the relation must be
+    /// disambiguated from a same-number same-repo relation.
+    ///
+    /// For a relation where `owner` / `name` are absent and the "same
+    /// repo as enclosing issue" convention applies, use
+    /// [`RelatedIssue::local`] instead.
+    #[must_use]
+    pub fn cross_repo(
+        number: u64,
+        title: impl Into<String>,
+        state: IssueState,
+        owner: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            number,
+            title: title.into(),
+            state,
+            repo_owner: Some(owner.into()),
+            repo_name: Some(name.into()),
+        }
+    }
 }
 
 /// A blocking edge in the dependency graph.
@@ -921,6 +1002,64 @@ mod tests {
         }
         assert_eq!(IssueState::Open.to_string(), "Open");
         assert_eq!(IssueState::Closed.to_string(), "Closed");
+    }
+
+    /// `IssueState::default()` MUST return `Closed` — the fail-safe
+    /// choice documented on the enum. Defaulting to `Open` would risk
+    /// downstream workflow code claiming or acting on an issue that
+    /// was actually never populated. See unblock-29p.66.
+    #[test]
+    fn issue_state_default_is_closed() {
+        assert_eq!(IssueState::default(), IssueState::Closed);
+    }
+
+    // ── RelatedIssue construction helpers (unblock-29p.66) ─────────────
+
+    /// [`RelatedIssue::local`] MUST leave `repo_owner` / `repo_name`
+    /// as `None` — the "None = same-repo-as-enclosing-issue"
+    /// convention.
+    #[test]
+    fn related_issue_local_leaves_repo_identity_none() {
+        let ri = RelatedIssue::local(42, "Local blocker", IssueState::Open);
+        assert_eq!(ri.number, 42);
+        assert_eq!(ri.title, "Local blocker");
+        assert_eq!(ri.state, IssueState::Open);
+        assert!(ri.repo_owner.is_none());
+        assert!(ri.repo_name.is_none());
+    }
+
+    /// [`RelatedIssue::cross_repo`] MUST fill `repo_owner` /
+    /// `repo_name` with `Some(owner)` / `Some(name)` so cross-repo
+    /// relations are disambiguated from same-repo relations with
+    /// the same number.
+    #[test]
+    fn related_issue_cross_repo_sets_both_repo_identity_fields() {
+        let ri = RelatedIssue::cross_repo(
+            7,
+            "Cross-repo blocker",
+            IssueState::Open,
+            "other-owner",
+            "other-repo",
+        );
+        assert_eq!(ri.number, 7);
+        assert_eq!(ri.title, "Cross-repo blocker");
+        assert_eq!(ri.state, IssueState::Open);
+        assert_eq!(ri.repo_owner.as_deref(), Some("other-owner"));
+        assert_eq!(ri.repo_name.as_deref(), Some("other-repo"));
+    }
+
+    /// [`RelatedIssue::default`] MUST produce a fail-safe value:
+    /// `IssueState::Closed` (so `Default::default()` used via FRU at
+    /// extension points cannot accidentally advertise a reference as
+    /// open and trigger false workflow activation).
+    #[test]
+    fn related_issue_default_state_is_closed_fail_safe() {
+        let ri = RelatedIssue::default();
+        assert_eq!(ri.number, 0);
+        assert_eq!(ri.title, "");
+        assert_eq!(ri.state, IssueState::Closed);
+        assert!(ri.repo_owner.is_none());
+        assert!(ri.repo_name.is_none());
     }
 
     fn _assert_all_status_variants_covered(v: Status) {

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -876,15 +876,23 @@ fn parse_comments(value: &serde_json::Value) -> Vec<IssueComment> {
 /// Parses a related-issues connection (blockedBy, blocking, subIssues) into
 /// [`RelatedIssue`] instances.
 ///
-/// When an individual node carries a `repository { owner { login } name }`
-/// subfield set, those values populate the resulting
-/// [`RelatedIssue::repo_owner`] / [`RelatedIssue::repo_name`]. The
-/// `trackedByIssues` connection inside [`FETCH_ISSUE_QUERY`] selects
-/// those fields so blocker edges can disambiguate cross-repo blockers
-/// from same-repo blockers (required by `dep_remove` single-issue edge
-/// validation on cross-repo paths — see `unblock-29p.43`). Connections
-/// that omit the `repository` selection (e.g. `subIssues`,
-/// `trackedInIssues`, `parent`) simply leave the fields as `None`.
+/// When an individual node carries a complete `repository { owner { login }
+/// name }` subfield set, those values populate the resulting
+/// [`RelatedIssue::repo_owner`] / [`RelatedIssue::repo_name`] via
+/// [`RelatedIssue::cross_repo`]. The `trackedByIssues` connection inside
+/// [`FETCH_ISSUE_QUERY`] selects those fields so blocker edges can
+/// disambiguate cross-repo blockers from same-repo blockers (required by
+/// `dep_remove` single-issue edge validation on cross-repo paths — see
+/// `unblock-29p.43`).
+///
+/// Connections that omit the `repository` selection (e.g. `subIssues`,
+/// `trackedInIssues`, `parent`) and nodes whose `repository` subfield is
+/// partial (only `owner` or only `name` present — a malformed GraphQL
+/// response) route through [`RelatedIssue::local`], leaving both repo
+/// identity fields `None`. A partial subfield cannot disambiguate a
+/// cross-repo reference (identification requires the full `(owner, name)`
+/// pair) so treating it as "no identity" is the semantically coherent
+/// fallback.
 fn parse_related_issues(value: &serde_json::Value, key: &str) -> Vec<RelatedIssue> {
     value
         .get(key)
@@ -892,12 +900,19 @@ fn parse_related_issues(value: &serde_json::Value, key: &str) -> Vec<RelatedIssu
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .map(|node| RelatedIssue {
-                    number: json_u64(node, "number"),
-                    title: json_string(node, "title"),
-                    state: parse_issue_state(node),
-                    repo_owner: parse_related_repo_owner(node),
-                    repo_name: parse_related_repo_name(node),
+                .map(|node| {
+                    let number = json_u64(node, "number");
+                    let title = json_string(node, "title");
+                    let state = parse_issue_state(node);
+                    match (
+                        parse_related_repo_owner(node),
+                        parse_related_repo_name(node),
+                    ) {
+                        (Some(owner), Some(name)) => {
+                            RelatedIssue::cross_repo(number, title, state, owner, name)
+                        }
+                        _ => RelatedIssue::local(number, title, state),
+                    }
                 })
                 .collect()
         })
@@ -926,19 +941,21 @@ fn parse_related_repo_name(node: &serde_json::Value) -> Option<String> {
 }
 
 /// Parses the parent issue field into an optional [`RelatedIssue`].
+///
+/// The parent selection does not include `repository { ... }`, so the
+/// result always routes through [`RelatedIssue::local`] — callers
+/// interpret the resulting `None` `repo_owner` / `repo_name` as
+/// "same repo as the containing issue" per the `RelatedIssue` docs.
 fn parse_parent_issue(value: &serde_json::Value) -> Option<RelatedIssue> {
     let parent = value.get("parent")?;
     if parent.is_null() {
         return None;
     }
-    Some(RelatedIssue {
-        number: json_u64(parent, "number"),
-        title: json_string(parent, "title"),
-        state: parse_issue_state(parent),
-        // Parent does not select `repository { ... }` — same-repo semantics.
-        repo_owner: None,
-        repo_name: None,
-    })
+    Some(RelatedIssue::local(
+        json_u64(parent, "number"),
+        json_string(parent, "title"),
+        parse_issue_state(parent),
+    ))
 }
 
 /// Extracts all Projects V2 field values into a name-to-value map.
@@ -1679,12 +1696,22 @@ mod tests {
         assert!(subs[0].repo_name.is_none());
     }
 
-    /// A partial `repository` subfield (owner missing or name missing)
-    /// degrades the corresponding field to `None` without taking the
-    /// other side down with it — defensive parsing, matches the rest of
-    /// the graphql module's "missing field = default" posture.
+    /// A partial `repository` subfield (owner without name, or name
+    /// without owner) cannot identify a cross-repo reference — that
+    /// requires the full `(owner, name)` pair — so the parser routes
+    /// partial nodes through [`RelatedIssue::local`], normalising BOTH
+    /// repo identity fields to `None`. Callers then treat the result
+    /// as "same repo as the containing issue" per `RelatedIssue` docs.
+    ///
+    /// Behaviour change: prior to unblock-29p.66 the parser retained
+    /// the parsed half of a partial subfield (e.g. `repository:
+    /// {name: "only-name"}` → `repo_owner: None, repo_name:
+    /// Some("only-name")`). That state was incoherent because cross-
+    /// repo disambiguation needs both halves; the hardened API surface
+    /// (strict `local` / `cross_repo` helpers, see `unblock-29p.66`)
+    /// makes the normalisation explicit.
     #[test]
-    fn parse_related_issues_partial_repository_leaves_missing_field_none() {
+    fn parse_related_issues_partial_repository_normalises_to_local() {
         let json = serde_json::json!({
             "trackedBy": {
                 "nodes": [
@@ -1706,8 +1733,8 @@ mod tests {
         let blockers = parse_related_issues(&json, "trackedBy");
         assert_eq!(blockers.len(), 2);
         assert!(blockers[0].repo_owner.is_none());
-        assert_eq!(blockers[0].repo_name.as_deref(), Some("only-name"));
-        assert_eq!(blockers[1].repo_owner.as_deref(), Some("only-owner"));
+        assert!(blockers[0].repo_name.is_none());
+        assert!(blockers[1].repo_owner.is_none());
         assert!(blockers[1].repo_name.is_none());
     }
 

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -199,17 +199,13 @@ mod tests {
     }
 
     /// Build a `RelatedIssue` for testing blockers.
+    ///
+    /// Claim tests target local blockers under the configured repo, so
+    /// this uses [`RelatedIssue::local`] — leaving `repo_owner` /
+    /// `repo_name` as `None` (the "same-repo-as-enclosing" convention
+    /// per `RelatedIssue` docs).
     fn blocker(number: u64, state: IssueState) -> RelatedIssue {
-        RelatedIssue {
-            number,
-            title: format!("Blocker #{number}"),
-            state,
-            // Claim tests target local blockers under the configured repo —
-            // leave repo identity unset (None = same-repo-as-enclosing per
-            // `RelatedIssue` docs).
-            repo_owner: None,
-            repo_name: None,
-        }
+        RelatedIssue::local(number, format!("Blocker #{number}"), state)
     }
 
     fn today() -> NaiveDate {

--- a/crates/unblock-mcp/src/tools/show.rs
+++ b/crates/unblock-mcp/src/tools/show.rs
@@ -203,15 +203,13 @@ mod tests {
 
     use super::ShowRelatedIssue;
 
-    /// Helper to build a `RelatedIssue` with the given state.
+    /// Helper to build a same-repo `RelatedIssue` with the given state.
+    ///
+    /// Uses [`RelatedIssue::local`] — `repo_owner` / `repo_name` stay
+    /// `None` (the "same-repo-as-enclosing" convention per
+    /// `RelatedIssue` docs).
     fn related_issue(state: IssueState) -> RelatedIssue {
-        RelatedIssue {
-            number: 1,
-            title: String::from("test"),
-            state,
-            repo_owner: None,
-            repo_name: None,
-        }
+        RelatedIssue::local(1, "test", state)
     }
 
     /// The `From<&RelatedIssue>` conversion writes `IssueState::Open` as
@@ -235,13 +233,7 @@ mod tests {
     /// Verify that the conversion copies `number` and `title` unchanged.
     #[test]
     fn related_issue_copies_number_and_title() {
-        let ri = RelatedIssue {
-            number: 42,
-            title: String::from("Important task"),
-            state: IssueState::Open,
-            repo_owner: None,
-            repo_name: None,
-        };
+        let ri = RelatedIssue::local(42, "Important task", IssueState::Open);
         let show = ShowRelatedIssue::from(&ri);
         assert_eq!(show.number, 42);
         assert_eq!(show.title, "Important task");

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -2834,31 +2834,27 @@ fn dep_remove_fixture_issue_with_blockers(
     issue
 }
 
-/// Helper: local (same-repo-as-configured) blocker — `repo_owner` /
-/// `repo_name` left as `None` so callers exercise the default-to-
+/// Helper: local (same-repo-as-configured) blocker — delegates to
+/// [`unblock_core::types::RelatedIssue::local`], leaving `repo_owner`
+/// / `repo_name` as `None` so callers exercise the default-to-
 /// enclosing-repo branch in `probe_edge_via_fetch`.
 fn local_blocker(number: u64) -> unblock_core::types::RelatedIssue {
-    unblock_core::types::RelatedIssue {
-        number,
-        title: format!("Blocker #{number}"),
-        state: IssueState::Open,
-        repo_owner: None,
-        repo_name: None,
-    }
+    unblock_core::types::RelatedIssue::local(number, format!("Blocker #{number}"), IssueState::Open)
 }
 
-/// Helper: cross-repo blocker — explicit `repo_owner` / `repo_name` so
-/// the probe can distinguish a cross-repo blocker from a same-repo
-/// blocker of the same number (the `FETCH_ISSUE_QUERY` subselection
-/// extension in `unblock-29p.43`).
+/// Helper: cross-repo blocker — delegates to
+/// [`unblock_core::types::RelatedIssue::cross_repo`] with explicit
+/// `owner` / `name` so the probe can distinguish a cross-repo blocker
+/// from a same-repo blocker of the same number (the
+/// `FETCH_ISSUE_QUERY` subselection extension in `unblock-29p.43`).
 fn cross_repo_blocker(owner: &str, repo: &str, number: u64) -> unblock_core::types::RelatedIssue {
-    unblock_core::types::RelatedIssue {
+    unblock_core::types::RelatedIssue::cross_repo(
         number,
-        title: format!("{owner}/{repo}#{number}"),
-        state: IssueState::Open,
-        repo_owner: Some(owner.to_owned()),
-        repo_name: Some(repo.to_owned()),
-    }
+        format!("{owner}/{repo}#{number}"),
+        IssueState::Open,
+        owner,
+        repo,
+    )
 }
 
 /// Cold cache, edge DOES exist → the handler calls `fetch_issue_ref`

--- a/docs/plans/01-plan-mcp-foundation.md
+++ b/docs/plans/01-plan-mcp-foundation.md
@@ -291,7 +291,7 @@ Types:
 - `BodySections { description, design_notes, acceptance_criteria }` — `from_markdown()`, `to_markdown()`
 - `TraversalDirection { Upstream, Downstream, Both }`
 - `IssueComment { author, body, created_at }`
-- `RelatedIssue { number, title, state }`
+- `RelatedIssue { number, title, state, repo_owner: Option<String>, repo_name: Option<String> }` — `#[non_exhaustive]`; construct via `RelatedIssue::local()` (same-repo-as-enclosing) or `RelatedIssue::cross_repo()` (explicit owner/name). See SPEC §2.12; hardened in unblock-29p.66.
 - `CrossRepoRefs { omitted: Vec<String>, summary: Option<String> }` — cross-repo response contract (SPEC §2.16, §11.4)
 
 ### Task 02.02 — Domain errors

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -260,12 +260,35 @@ pub struct IssueComment {
 ### 2.12 `RelatedIssue`
 
 ```rust
+#[non_exhaustive]
 pub struct RelatedIssue {
     pub number: u64,
     pub title: String,
     pub state: IssueState,
+    pub repo_owner: Option<String>,
+    pub repo_name: Option<String>,
+}
+
+impl RelatedIssue {
+    pub fn local(number: u64, title: impl Into<String>, state: IssueState) -> Self;
+    pub fn cross_repo(
+        number: u64,
+        title: impl Into<String>,
+        state: IssueState,
+        owner: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self;
 }
 ```
+
+**Construction.** `RelatedIssue` is `#[non_exhaustive]`; callers build
+instances through the `local` / `cross_repo` helpers (or via
+`..Default::default()` at extension points). `local` leaves `repo_owner`
+/ `repo_name` as `None`, which callers MUST interpret as "same repo as
+the containing issue" (the "None = same-repo-as-enclosing" convention).
+`cross_repo` takes an explicit `(owner, name)` pair for cross-repository
+relations that need to be disambiguated from same-repo relations with the
+same number (SPEC §11.4, unblock-29p.43).
 
 ### 2.13 `TraversalDirection`
 


### PR DESCRIPTION
…constructor helpers (unblock-29p.66)

Marks `RelatedIssue` as `#[non_exhaustive]` and adds `#[derive(Default)]` plus two explicit constructor helpers (`local` / `cross_repo`) so downstream callers can no longer construct the struct with struct-literal syntax. The helpers encode the "None = same-repo-as-enclosing" convention at the type level: `local` leaves `repo_owner` / `repo_name` as `None`, `cross_repo` requires an explicit `(owner, name)` pair. `IssueState` gains `Default` with `Closed` as the fail-safe default variant so any accidental `Default::default()` produces a value that cannot trigger false workflow activation.

Migrates all six in-tree construction sites to the helpers (`parse_related_issues` and `parse_parent_issue` in `unblock-github`, plus the `blocker` / `related_issue` / `local_blocker` / `cross_repo_blocker` test fixtures in `unblock-mcp`). The partial- subfield parser path now normalises incomplete `repository { ... }` responses to `local()` (both identity fields `None`) — a partial subfield cannot disambiguate a cross-repo reference, so the prior "retain the parsed half" behaviour was semantically incoherent.

Also fixes pre-existing spec/plan drift: §2.12 of the MCP foundation spec and the corresponding bullet in the plan now show the current 5-field `RelatedIssue` shape (including `repo_owner` / `repo_name`, landed in `unblock-29p.43` without a spec refresh).

BREAKING CHANGE: `RelatedIssue` is now `#[non_exhaustive]`. Downstream callers cannot construct it with struct-literal syntax; use `RelatedIssue::local()` for same-repo relations or `RelatedIssue::cross_repo()` for cross-repository relations. Added `impl Default for RelatedIssue` and `impl Default for IssueState` (defaults to `Closed` — fail-safe) for extension-point ergonomics and serde round-trip of partial frames.