### PR TITLE
refactor(mcp): eliminate clone in dep_cycles projection + consolidate…

### DIFF
--- a/crates/unblock-mcp/src/tools/cross_repo.rs
+++ b/crates/unblock-mcp/src/tools/cross_repo.rs
@@ -103,16 +103,26 @@ pub(crate) fn project_cycle(
 /// local-projection length is `< 2` (mixed cycles where all but ≤1 member
 /// are cross-repo). The agent must know the cycle exists; the missing
 /// members land in `cross_repo_refs`.
-pub(crate) fn project_all_cycles(
-    raw: &[Vec<QualifiedId>],
+///
+/// The `raw` slice is generic over any element that borrows as
+/// `[QualifiedId]`. This accepts both `&[Vec<QualifiedId>]` (the
+/// cache-owned shape used by `prime`) and `&[&[QualifiedId]]` (the
+/// zero-copy shape produced by `dep_cycles`'s `filter_cycles_containing`
+/// / `id`-less passthrough) without forcing the caller to clone the
+/// SCC vectors — see bead `unblock-29p.45`.
+pub(crate) fn project_all_cycles<S>(
+    raw: &[S],
     configured_owner: &str,
     configured_repo: &str,
-) -> (Vec<Vec<u64>>, BTreeSet<String>) {
+) -> (Vec<Vec<u64>>, BTreeSet<String>)
+where
+    S: AsRef<[QualifiedId]>,
+{
     let mut cycles: Vec<Vec<u64>> = Vec::with_capacity(raw.len());
     let mut cross_repo_accum: BTreeSet<String> = BTreeSet::new();
     for cycle in raw {
         let local = project_cycle(
-            cycle,
+            cycle.as_ref(),
             configured_owner,
             configured_repo,
             &mut cross_repo_accum,

--- a/crates/unblock-mcp/src/tools/dep_cycles.rs
+++ b/crates/unblock-mcp/src/tools/dep_cycles.rs
@@ -178,11 +178,22 @@ pub struct DepCyclesResult {
 ///
 /// Pulled out of [`handle_dep_cycles`] so it can be covered by
 /// hermetic unit tests without constructing a [`ServerState`].
-fn project_all(
-    raw: &[Vec<QualifiedId>],
+///
+/// The `raw` parameter is generic over `AsRef<[QualifiedId]>` so the
+/// caller can pass either owned `Vec<QualifiedId>` SCCs (the shape of
+/// `detect_all_cycles`'s return) or borrowed `&[QualifiedId]` slices
+/// (the zero-copy shape produced by [`filter_cycles_containing`] and
+/// the `id`-less passthrough in [`handle_dep_cycles`]). Removes the
+/// owned-clone that previously bridged the two shapes — see bead
+/// `unblock-29p.45`.
+fn project_all<S>(
+    raw: &[S],
     configured_owner: &str,
     configured_repo: &str,
-) -> (Vec<Vec<u64>>, Option<CrossRepoRefs>) {
+) -> (Vec<Vec<u64>>, Option<CrossRepoRefs>)
+where
+    S: AsRef<[QualifiedId]>,
+{
     let (cycles, accum) = cross_repo::project_all_cycles(raw, configured_owner, configured_repo);
     let cross_repo_refs =
         cross_repo::build_cross_repo_refs_with_summary(accum, cross_repo::cycles_summary);
@@ -195,11 +206,20 @@ fn project_all(
 /// SPEC §7.7 flow step 2. Comparison is on full [`QualifiedId`] equality,
 /// so the caller is responsible for resolving the bare `id` against
 /// `(client.owner(), client.repo())` before calling.
+///
+/// Returns borrowed `&[QualifiedId]` slices rather than borrowed
+/// `&Vec<QualifiedId>` so callers can hand the result straight to
+/// [`project_all`] (or [`crate::tools::cross_repo::project_all_cycles`])
+/// without an intermediate clone of the SCC contents — see bead
+/// `unblock-29p.45`.
 fn filter_cycles_containing<'a>(
     raw: &'a [Vec<QualifiedId>],
     target: &QualifiedId,
-) -> Vec<&'a Vec<QualifiedId>> {
-    raw.iter().filter(|scc| scc.contains(target)).collect()
+) -> Vec<&'a [QualifiedId]> {
+    raw.iter()
+        .filter(|scc| scc.contains(target))
+        .map(Vec::as_slice)
+        .collect()
 }
 
 /// Execute the `dep_cycles` tool handler.
@@ -278,22 +298,24 @@ pub async fn handle_dep_cycles(
     // Step 3: apply the optional `id` filter. The parameter is a local
     // issue number (SPEC §7.7 types it as `u64`, not `IssueRef`), so
     // resolve it against `(configured_owner, configured_repo)` before
-    // comparing.
-    let filtered_refs: Vec<&Vec<QualifiedId>> = if let Some(id) = params.id {
+    // comparing. Both branches yield `Vec<&[QualifiedId]>` — a
+    // zero-copy slice-of-slice view over the SCCs owned by
+    // `raw_cycles`. `project_all` accepts this shape directly via its
+    // `AsRef<[QualifiedId]>` bound, so no clone of the SCC contents
+    // is required (bead `unblock-29p.45`).
+    let filtered_refs: Vec<&[QualifiedId]> = if let Some(id) = params.id {
         let target = QualifiedId::new(configured_owner.clone(), configured_repo.clone(), id);
         filter_cycles_containing(&raw_cycles, &target)
     } else {
-        raw_cycles.iter().collect()
+        raw_cycles.iter().map(Vec::as_slice).collect()
     };
 
     // Step 4: project each cycle into its (local, cross-repo) partitions
-    // per SPEC §11.4. Clone the filtered slices into owned vectors so the
-    // projection helper can consume an owned slice without lifetime
-    // gymnastics — the cost is bounded by the total cycle node count,
-    // which is small in practice (Tarjan returns disjoint SCCs).
-    let filtered_owned: Vec<Vec<QualifiedId>> = filtered_refs.into_iter().cloned().collect();
+    // per SPEC §11.4. `project_all` borrows each SCC as a `&[QualifiedId]`
+    // slice — the previous owned-Vec clone that bridged this boundary is
+    // eliminated (bead `unblock-29p.45`).
     let (cycles, cross_repo_refs) =
-        project_all(&filtered_owned, &configured_owner, &configured_repo);
+        project_all(&filtered_refs, &configured_owner, &configured_repo);
 
     let count = cycles.len();
     Ok(DepCyclesResult {
@@ -402,7 +424,9 @@ mod tests {
         let target = qid("acme", "widgets", 3);
         let hits = filter_cycles_containing(&raw, &target);
         assert_eq!(hits.len(), 1);
-        assert_eq!(*hits[0], c2);
+        // `hits[0]` is a `&[QualifiedId]` borrowed from `raw`; compare
+        // against the owned `c2` via slice equality.
+        assert_eq!(hits[0], c2.as_slice());
     }
 
     #[test]

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -4836,53 +4836,28 @@ async fn reconcile_with_injected_drift_and_fix() {
 
 // ── DepCycles tool: integration tests (SPEC §7.7, §11.4) ──────────────
 
-/// Build a fixture issue under the `MockGitHubClient` coordinates
-/// (`acme/widgets`) for `dep_cycles` tests. Every optional field is set
-/// to a minimal value — `dep_cycles` only consumes the graph topology,
-/// not the per-issue fields.
-fn dep_cycles_fixture_issue(number: u64) -> unblock_core::types::Issue {
-    unblock_core::types::Issue {
-        qualified_id: QualifiedId::new("acme", "widgets", number),
-        number,
-        node_id: format!("I_{number}"),
-        title: format!("DepCycles fixture #{number}"),
-        issue_type: Some(IssueType::Task),
-        status: Status::Ready,
-        priority: Priority::P2,
-        agent: None,
-        claimed_at: None,
-        pipeline_stage: None,
-        story_points: None,
-        defer_until: None,
-        labels: vec![],
-        milestone: None,
-        assignees: vec![],
-        state: IssueState::Open,
-        body: None,
-        created_at: chrono::Utc::now(),
-        updated_at: chrono::Utc::now(),
-        url: format!("https://github.com/acme/widgets/issues/{number}"),
-        comments: vec![],
-        blocked_by: vec![],
-        blocking: vec![],
-        parent: None,
-        sub_issues: vec![],
-    }
-}
-
-/// Build a cross-repo fixture issue for `dep_cycles` mixed-cycle tests.
-/// The resulting `QualifiedId` points OUTSIDE the configured
-/// `acme/widgets` repo so the cross-repo projection can strip it.
-fn dep_cycles_cross_repo_fixture(
-    owner: &str,
-    repo: &str,
-    number: u64,
-) -> unblock_core::types::Issue {
+/// Build a fixture issue for `dep_cycles` tests, parameterised by full
+/// `(owner, repo, number)` coordinates.
+///
+/// `dep_cycles` only consumes the graph topology (not per-issue fields),
+/// so every optional field is set to a minimal value. The per-issue
+/// `node_id`, `title`, and `url` strings are derived uniformly from the
+/// coordinates so the helper covers both the local (`acme/widgets`)
+/// variant used by `detect_all_cycles` over the configured repo AND the
+/// cross-repo variant that seeds SCCs with nodes OUTSIDE the configured
+/// repo for §11.4 projection coverage — see bead `unblock-29p.44`.
+///
+/// Callers should prefer the thin wrappers below
+/// ([`dep_cycles_fixture_issue`], [`dep_cycles_cross_repo_fixture`]) so
+/// call-site readability stays tight: the shorthand conveys intent
+/// (local-only topology vs. cross-repo mixing) without spelling out
+/// `"acme", "widgets"` at every call site.
+fn dep_cycles_fixture_at(owner: &str, repo: &str, number: u64) -> unblock_core::types::Issue {
     unblock_core::types::Issue {
         qualified_id: QualifiedId::new(owner, repo, number),
         number,
         node_id: format!("I_{owner}_{repo}_{number}"),
-        title: format!("DepCycles cross-repo fixture {owner}/{repo}#{number}"),
+        title: format!("DepCycles fixture {owner}/{repo}#{number}"),
         issue_type: Some(IssueType::Task),
         status: Status::Ready,
         priority: Priority::P2,
@@ -4905,6 +4880,25 @@ fn dep_cycles_cross_repo_fixture(
         parent: None,
         sub_issues: vec![],
     }
+}
+
+/// Build a fixture issue under the `MockGitHubClient` coordinates
+/// (`acme/widgets`) for `dep_cycles` tests. Thin wrapper over
+/// [`dep_cycles_fixture_at`] for local-only topology coverage.
+fn dep_cycles_fixture_issue(number: u64) -> unblock_core::types::Issue {
+    dep_cycles_fixture_at("acme", "widgets", number)
+}
+
+/// Build a cross-repo fixture issue for `dep_cycles` mixed-cycle tests.
+/// The resulting `QualifiedId` points OUTSIDE the configured
+/// `acme/widgets` repo so the cross-repo projection can strip it.
+/// Thin wrapper over [`dep_cycles_fixture_at`].
+fn dep_cycles_cross_repo_fixture(
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> unblock_core::types::Issue {
+    dep_cycles_fixture_at(owner, repo, number)
 }
 
 /// Acceptance (a): local-only cycle — `cross_repo_refs == None`, bare


### PR DESCRIPTION
… fixture helpers (unblock-29p.45, unblock-29p.44)

Two co-located dep_cycles refactors landed together because both touch the `dep_cycles` tool/test surface:

1. unblock-29p.45 — eliminate documented clone in `project_all` `project_all_cycles` (cross_repo.rs) and `project_all` (dep_cycles.rs) now take `&[S] where S: AsRef<[QualifiedId]>`, accepting both owned `Vec<QualifiedId>` SCCs (prime.rs's cache-owned shape, unchanged caller) and borrowed `&[QualifiedId]` slices (dep_cycles.rs's filtered / passthrough shape). `filter_cycles_containing` now returns `Vec<&'a [QualifiedId]>` so the handler can pass zero-copy slice borrows directly into the projection helper. The owned-Vec clone at dep_cycles.rs:294 that bridged the two shapes is removed; both `id`-present and `id`-absent branches produce a `Vec<&[QualifiedId]>` view over `raw_cycles` without copying SCC contents. Observable behaviour (cycle ordering, cross-repo projection, summary rendering) is unchanged.
2. unblock-29p.44 — consolidate dep_cycles integration fixtures `dep_cycles_fixture_issue` and `dep_cycles_cross_repo_fixture` collapse into a single private `dep_cycles_fixture_at(owner, repo, number)` with the per-variant shorthand preserved as thin wrappers. Call-site readability (`dep_cycles_fixture_issue(6)` vs `dep_cycles_cross_repo_fixture("alpha", "upstream", 42)`) is unchanged. The `node_id` / `title` / `url` strings now derive uniformly from `(owner, repo, number)` — no test asserts on these fields, so coverage is identical (both local-only and cross-repo topology scenarios remain exercised by the existing integration tests).

Quality gate: cargo fmt / clippy -D warnings / test --workspace / doc --no-deps all green. `project_all` and `project_all_cycles` remain private / crate-private symbols inside the `unblock-mcp` binary crate — no library-crate pub-API change, no API/BREAKING-CHANGE footer needed per CLAUDE.md.