### PR TITLE
docs(spec): align §8.5/§8.7 error-contract rows and promote source!=t…

### DIFF
--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -1466,6 +1466,7 @@ pub struct DepRemoveResult {
 **Validation:**
 - `source`: valid IssueRef
 - `target`: valid IssueRef
+- `source != target`
 
 **Flow:**
 1. Resolve both IssueRefs
@@ -1533,7 +1534,7 @@ and the tool-handler dispatch in §8):
 | Either endpoint is `Closed` | Mutation skipped, error surfaced | `DomainError::EndpointClosed { qid }` | 409 | `INVALID_PARAMS` |
 | Edge missing (both endpoints Open) | Mutation skipped, `removed: false` | — (success) | — | — |
 | Edge present (both endpoints Open) | Mutation runs | — (success) | — | — |
-| Mutation ran + cache rebuild failed (cache empty) | 503-class error surfaced; mutation durable on GitHub | `unblock_github::errors::Error` (transport) | 503 | `INTERNAL_ERROR` |
+| Mutation ran + cache rebuild failed (cache empty) | 503-class error surfaced; mutation durable on GitHub | `unblock_github::errors::Error` (infrastructure) | 503 | `INTERNAL_ERROR` |
 
 **Post-rebuild cache-empty failure.** If the `remove_blocked_by`
 mutation in step 3 succeeds but the subsequent `execute_write_tool`
@@ -1624,6 +1625,13 @@ pub struct ReopenResult {
 4. If issue has open blockers: Status → `blocked`
 5. If no open blockers: Status → `ready`
 6. Update cache
+
+**Error-contract row** (consumed by the cross-tool error mapping in §11.1
+and the tool-handler dispatch in §8):
+
+| Condition | Outcome | Error variant | HTTP | MCP code |
+|---|---|---|---|---|
+| Post-rebuild re-evaluation failure (rebuild succeeded but reopened issue missing) | 503-class error surfaced; mutation durable on GitHub | `unblock_github::errors::Error` (infrastructure) | 503 | `INTERNAL_ERROR` |
 
 **Post-rebuild re-evaluation failure.** If the rebuild succeeds but the
 reopened issue cannot be located in the rebuilt graph (transient 503, or


### PR DESCRIPTION
…arget to §8.5 validation (unblock-29p.68, unblock-29p.40)

Three doc-only refinements to docs/specs/01-spec-mcp-foundation.md, resolving two review findings in a single atomic patch:

.68 S1-A — Transport label disambiguation (§8.5 line 1537). Rename `(transport)` to `(infrastructure)` on the §8.5 R3 error-contract row so the parenthetical label aligns with the `unblock-github` crate's own self-identification ("Infrastructure error types" at crates/unblock-github/src/errors.rs:1). The cache-mode "transport" terminology at §8.5:1524 (memory vs. one GraphQL RTT) is idiomatic and stays unchanged; only the error-variant label is renamed, so the two usages of "transport" in §8.5 no longer overload one another.

.68 S2 — §8.7 R3 error-contract row formalisation. Add a literal error-contract table row to §8.7 (reopen) above the "Post-rebuild re-evaluation failure" prose block, mirroring the shape of the §8.5 row (Condition / Outcome / Error variant / HTTP / MCP code). The prose stays — it narrates the semantics; the row formalises the contract. This brings §8.7 to parity with §8.5 so future readers see uniform tabular R3 contracts across both write tools with durable-on-GitHub posture.

.40-A — Promote source != target to §8.5 Validation. Add `- source != target` bullet to the §8.5 Validation list, symmetric with §8.4 (depends) at line 1433. The `dep_remove.rs` implementation (crates/unblock-mcp/src/tools/dep_remove.rs:700-711) already enforces this guard by lifting a `DomainError::Validation { message }` through `github_error_to_mcp` (400 → INVALID_PARAMS); this change closes the spec↔code drift without introducing new error variants. §11.1's generic `Validation` variant already covers both §8.4 and §8.5 — no §11.1 patch required.

Zero code changes. Zero behavioural change. Quality gate re-run to prove no collateral damage: fmt clean, clippy clean, 92/92 tests pass, doc warnings zero.