### PR TITLE
chore(github,mcp): introduce PostMutationRebuildFailed variant + cros…

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -9,6 +9,7 @@
 
 use snafu::prelude::*;
 use unblock_core::errors::DomainError;
+use unblock_core::types::QualifiedId;
 
 use chrono::{DateTime, Utc};
 
@@ -106,6 +107,51 @@ pub enum Error {
         since: std::time::Instant,
     },
 
+    /// A GitHub mutation succeeded but the subsequent cache rebuild failed,
+    /// leaving the tool unable to compute post-mutation fields locally.
+    ///
+    /// Emitted by write-tool handlers (`close`, `dep_remove`, `reopen`) when
+    /// the mutation is durable on GitHub but a transient 503, rate-limit,
+    /// or network error during the `execute_write_tool` rebuild leaves the
+    /// cache empty (or — for `reopen` — present but missing the mutated
+    /// issue due to a concurrent re-close race). Preserves spec §8.5 /
+    /// §8.7 R3: the handler MUST NOT fabricate `has_open_blockers` /
+    /// `blocked` / Status claims against a missing graph; instead it
+    /// surfaces this variant and instructs the caller to re-run `show` to
+    /// observe the final post-mutation state.
+    ///
+    /// Maps to HTTP 503 via [`Error::status_code`]; `github_error_to_mcp`
+    /// in `unblock-mcp` then maps 503 → `ErrorCode::INTERNAL_ERROR`. The
+    /// `mutation` field names the preceding mutation (`"reopen"`,
+    /// `"remove_blocked_by"`, `"close_cascade"`, …) for log/trace
+    /// disambiguation; `qid` carries the [`QualifiedId`] of the mutated
+    /// issue (or the source endpoint for `dep_remove`) so same-numbered
+    /// local vs. cross-repo issues render unambiguously in the rendered
+    /// message.
+    ///
+    /// This is a transient wiring-class failure — NOT a domain-meaningful
+    /// outcome — which is why it lives on the infrastructure `Error` enum
+    /// rather than on [`DomainError`]. Matches the `infrastructure`-typed
+    /// error-contract rows at spec §8.5 / §8.7 R3.
+    ///
+    /// [`DomainError`]: unblock_core::errors::DomainError
+    #[snafu(display(
+        "{mutation} mutation on {qid} succeeded, but the post-mutation cache rebuild failed — please re-run `show` to observe the final state"
+    ))]
+    PostMutationRebuildFailed {
+        /// Identifier of the mutation that preceded the rebuild failure
+        /// (e.g. `"reopen"`, `"remove_blocked_by"`, `"close_cascade"`).
+        /// Free-form for log/trace diagnostics; no downstream code
+        /// branches on this value.
+        mutation: String,
+        /// The [`QualifiedId`] of the mutated issue (or of the source
+        /// endpoint, for `dep_remove`). Rendered via `Display`
+        /// (`owner/repo#n` form) so cross-repo vs. local same-number
+        /// collisions surface unambiguously in logs and in the message
+        /// forwarded to the MCP caller.
+        qid: QualifiedId,
+    },
+
     /// No Projects V2 project is configured or discoverable.
     #[snafu(display("Projects V2 not configured — run `setup` first"))]
     ProjectNotConfigured,
@@ -179,7 +225,9 @@ impl Error {
             // reaches the MCP layer with the right status-code bucket
             // so `github_error_to_mcp` maps it to INVALID_PARAMS.
             Self::GitHubGraphQLForbidden { .. } => 403,
-            Self::GitHubUnavailable { .. } | Self::CircuitBreakerOpen { .. } => 503,
+            Self::GitHubUnavailable { .. }
+            | Self::CircuitBreakerOpen { .. }
+            | Self::PostMutationRebuildFailed { .. } => 503,
             Self::RateLimited { .. } => 429,
             Self::ProjectNotConfigured => 412,
             Self::GitRemote { .. } => 500,
@@ -461,5 +509,47 @@ mod tests {
         }
         .build();
         assert_eq!(err.status_code(), 500);
+    }
+
+    #[test]
+    fn status_code_post_mutation_rebuild_failed() {
+        // SPEC §8.5 / §8.7 R3: post-mutation-rebuild failure is a
+        // 503-class infrastructure error (transient wiring-class
+        // failure). The MCP layer's `github_error_to_mcp` maps 503 →
+        // `ErrorCode::INTERNAL_ERROR`; pinning the status_code here
+        // guards the spec's error-contract rows against drift.
+        let err = PostMutationRebuildFailedSnafu {
+            mutation: "reopen".to_owned(),
+            qid: unblock_core::types::QualifiedId::new("acme", "widgets", 42),
+        }
+        .build();
+        assert_eq!(err.status_code(), 503);
+    }
+
+    #[test]
+    fn post_mutation_rebuild_failed_display_is_agent_actionable() {
+        // Display output MUST name the preceding mutation, render the
+        // QualifiedId unambiguously (`owner/repo#n` form), and instruct
+        // the caller to re-run `show`. This is the agent-actionable
+        // contract the `github_error_to_mcp` layer forwards to MCP
+        // clients — weakening it would regress spec §8.5 / §8.7 R3.
+        let err = PostMutationRebuildFailedSnafu {
+            mutation: "remove_blocked_by".to_owned(),
+            qid: unblock_core::types::QualifiedId::new("acme", "widgets", 42),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("remove_blocked_by"),
+            "display must name the mutation: {msg}"
+        );
+        assert!(
+            msg.contains("acme/widgets#42"),
+            "display must render the QualifiedId in `owner/repo#n` form: {msg}"
+        );
+        assert!(
+            msg.contains("re-run `show`"),
+            "display must guide the caller to re-run `show`: {msg}"
+        );
     }
 }

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1141,6 +1141,21 @@ impl UnblockServer {
                 issue_number,
                 "Cache empty after prime attempt — cannot capture pre-close cascade; aborting close"
             );
+            // This is a PRE-mutation prime failure — the close mutation
+            // has NOT been attempted yet. Intentionally stays on the
+            // synthetic `GitHubApi { status: 503 }` surface rather than
+            // migrating to `PostMutationRebuildFailed`, whose semantic
+            // ("mutation landed on GitHub but we cannot compute
+            // post-mutation fields") does not fit here: the message
+            // guides the caller to "retry or run `prime` first", which
+            // only makes sense when the close has not happened. Bead
+            // `unblock-29p.35` deliberately scoped the new variant to
+            // POST-mutation sites; introducing a sibling
+            // `PreMutationPrimeFailed` is tracked as a follow-up
+            // question on that bead. Spec §8.2 does not yet pin an
+            // explicit error-contract row for the prime-failure path
+            // (the §8.5 / §8.7 R3 rows are strictly post-mutation), so
+            // no spec drift either.
             return Err(crate::errors::github_error_to_mcp(
                 unblock_github::errors::GitHubApiSnafu {
                     status: 503_u16,
@@ -1390,11 +1405,9 @@ impl UnblockServer {
                 "Cache not available after close — rebuild failed; step 8 `update_status_fields` reconciliation could not run"
             );
             return Err(crate::errors::github_error_to_mcp(
-                unblock_github::errors::GitHubApiSnafu {
-                    status: 503_u16,
-                    message: format!(
-                        "Issue #{issue_number} closed successfully and cascade field-updates applied best-effort, but Status reconciliation could not complete — re-run `show` to confirm final Status fan-out"
-                    ),
+                unblock_github::errors::PostMutationRebuildFailedSnafu {
+                    mutation: "close_cascade".to_owned(),
+                    qid: issue_qid.clone(),
                 }
                 .build(),
             ));

--- a/crates/unblock-mcp/src/tools/dep_remove.rs
+++ b/crates/unblock-mcp/src/tools/dep_remove.rs
@@ -490,17 +490,21 @@ async fn reevaluate_source_after_remove(
     let (Some(graph), Some(issues)) = (graph_arc, issues_arc) else {
         warn!(
             source_number,
+            %source_qid,
+            %target_qid,
             "Cache empty after dep_remove — rebuild failed; caller must re-run `show` to observe final status"
         );
         // R3: surface a 503-class error so MCP clients see INTERNAL_ERROR
         // and can retry or fall back to a `show` call. The mutation is
-        // durable on GitHub regardless.
+        // durable on GitHub regardless. The `target_qid` is logged above
+        // for diagnostics — the surfaced `Display` output names the
+        // `source_qid` (the endpoint whose Status fan-out could not be
+        // re-evaluated) and the mutation, matching the `EndpointClosed`
+        // precedent of carrying a single disambiguating QualifiedId.
         return Err(github_error_to_mcp(
-            unblock_github::errors::GitHubApiSnafu {
-                status: 503_u16,
-                message: format!(
-                    "Blocking edge removed between {source_qid} and {target_qid}, but cache rebuild failed — please re-run `show` to observe the final blocked status"
-                ),
+            unblock_github::errors::PostMutationRebuildFailedSnafu {
+                mutation: "remove_blocked_by".to_owned(),
+                qid: source_qid.clone(),
             }
             .build(),
         ));
@@ -798,10 +802,36 @@ pub async fn handle_dep_remove(
     if let IssueRef::Local(source_number) = &source_ref {
         reevaluate_source_after_remove(state, *source_number, &source_qid, &target_qid).await?;
     } else {
-        tracing::debug!(
-            source = %source_ref,
-            "Cross-repo source: skipping Projects V2 Status update after dep_remove (source is outside the configured project)."
-        );
+        // Cross-repo source: the Projects V2 Status update is
+        // intentionally skipped (spec §5.6 footnote — the field-update
+        // ladder is scoped to the configured project). Observability
+        // split:
+        //   * Cache populated after `execute_write_tool` — normal
+        //     skip path; `debug!` is enough.
+        //   * Cache empty after `execute_write_tool` — the rebuild
+        //     failed; we're returning `removed: true` with a stale
+        //     (empty) local cache and no 503 signal. Emit `warn!` so
+        //     operators can correlate this with the `rebuild_cache`
+        //     warn emitted at `tools/mod.rs:180-183`. This mirrors the
+        //     Local-source observability pattern in
+        //     `reevaluate_source_after_remove` but without surfacing a
+        //     503: cross-repo callers do not rely on the local cache
+        //     for Status, so the mutation-durability contract is
+        //     preserved and no error is warranted. Bead
+        //     `unblock-29p.38` scopes this to observability only.
+        if state.cache.get_graph().await.is_none() {
+            tracing::warn!(
+                source = %source_ref,
+                %source_qid,
+                %target_qid,
+                "dep_remove: cross-repo source cache rebuild failed — returning success with stale cache"
+            );
+        } else {
+            tracing::debug!(
+                source = %source_ref,
+                "Cross-repo source: skipping Projects V2 Status update after dep_remove (source is outside the configured project)."
+            );
+        }
     }
 
     // Step 6: render canonical forms of the normalized refs. Matches the

--- a/crates/unblock-mcp/src/tools/reopen.rs
+++ b/crates/unblock-mcp/src/tools/reopen.rs
@@ -385,13 +385,19 @@ pub async fn handle_reopen(
         );
         // Surface as a 503-class error so MCP clients see INTERNAL_ERROR
         // and can retry or fall back to a `show` call. The mutation is
-        // durable on GitHub regardless of this failure.
+        // durable on GitHub regardless of this failure. `reopen` operates
+        // only on local issues (cross-repo reopen is out of scope per
+        // spec §5.6), so the QualifiedId is constructed from the
+        // configured repo's `(owner, repo)`.
+        let qid = unblock_core::types::QualifiedId::new(
+            state.github.owner(),
+            state.github.repo(),
+            issue_number,
+        );
         return Err(github_error_to_mcp(
-            unblock_github::errors::GitHubApiSnafu {
-                status: 503_u16,
-                message: format!(
-                    "Issue #{issue_number} reopened successfully, but cache rebuild failed — please re-run `show` to observe the final blocked status"
-                ),
+            unblock_github::errors::PostMutationRebuildFailedSnafu {
+                mutation: "reopen".to_owned(),
+                qid,
             }
             .build(),
         ));
@@ -416,12 +422,22 @@ pub async fn handle_reopen(
             issue_number,
             "Reopened issue not present in rebuilt cache (possible concurrent re-close) — surfacing partial-state error"
         );
+        // Same `PostMutationRebuildFailed` surface as the empty-cache
+        // arm above — the mutation is still `"reopen"` (the cause differs
+        // but the preceding mutation is the same). `Display` and
+        // `status_code` are identical; the call-site log line
+        // disambiguates "cache empty" from "cache present, issue
+        // missing" for diagnostic traces. Spec §8.7 R3 row covers both
+        // cases under the same 503 → INTERNAL_ERROR mapping.
+        let qid = unblock_core::types::QualifiedId::new(
+            state.github.owner(),
+            state.github.repo(),
+            issue_number,
+        );
         return Err(github_error_to_mcp(
-            unblock_github::errors::GitHubApiSnafu {
-                status: 503_u16,
-                message: format!(
-                    "Issue #{issue_number} reopened successfully, but the rebuilt cache does not contain it (possible concurrent close by another agent) — please re-run `show` to observe the final blocked status"
-                ),
+            unblock_github::errors::PostMutationRebuildFailedSnafu {
+                mutation: "reopen".to_owned(),
+                qid,
             }
             .build(),
         ));

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -2530,10 +2530,17 @@ async fn reopen_surfaces_error_when_post_reopen_rebuild_fails() {
         .expect_err("cache rebuild failure must surface as a handler error (R3)");
 
     // The error must reference the partial-state guidance so agents
-    // know to retry `show`.
+    // know to retry `show`, name the preceding mutation, and include
+    // the fully-qualified issue reference. After unblock-29p.35 the
+    // surfaced message comes from
+    // `PostMutationRebuildFailed::Display`; it names the mutation
+    // (`"reopen"`) rather than the past participle `"reopened"` used by
+    // the prior synthetic message.
     assert!(
-        err.message.contains("reopened") && err.message.contains("show"),
-        "error message must instruct caller to re-run `show`: {}",
+        err.message.contains("reopen")
+            && err.message.contains("show")
+            && err.message.contains("#42"),
+        "error message must name the mutation, include the QID, and instruct re-run of `show`: {}",
         err.message,
     );
 
@@ -2592,10 +2599,16 @@ async fn reopen_surfaces_error_when_rebuilt_cache_missing_reopened_issue() {
     // 503 → INTERNAL_ERROR per github_error_to_mcp.
     assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
     // The error must reference the partial-state guidance so agents
-    // know to retry `show`.
+    // know to retry `show`, name the preceding mutation, and include
+    // the fully-qualified issue reference. Same
+    // `PostMutationRebuildFailed` surface as the empty-cache arm — the
+    // two race-window arms produce identical wire output; call-site
+    // log lines disambiguate the cause in traces.
     assert!(
-        err.message.contains("reopened") && err.message.contains("show"),
-        "error message must instruct caller to re-run `show`: {}",
+        err.message.contains("reopen")
+            && err.message.contains("show")
+            && err.message.contains("#42"),
+        "error message must name the mutation, include the QID, and instruct re-run of `show`: {}",
         err.message,
     );
 
@@ -2961,10 +2974,22 @@ async fn dep_remove_surfaces_error_when_post_mutation_rebuild_fails() {
     .await
     .expect_err("rebuild failure must surface as a handler error (R3)");
 
-    // Must instruct the caller to re-run `show` and identify both refs.
+    // Must instruct the caller to re-run `show`, name the preceding
+    // mutation, and identify the source endpoint whose Status
+    // re-evaluation was skipped. Target endpoint (`#99`) is no longer
+    // surfaced in the rendered message (the `PostMutationRebuildFailed`
+    // variant carries a single QualifiedId — the source, matching the
+    // `EndpointClosed` precedent) but is still logged via the
+    // `reevaluate_source_after_remove` `warn!` as a structured field;
+    // see `tools/dep_remove.rs:490-500`. Spec §8.5 R3 row is about the
+    // handler's ability to compute `has_open_blockers` for the source,
+    // so the source is the semantically-authoritative QualifiedId for
+    // this error.
     assert!(
-        err.message.contains("show") && err.message.contains("#42") && err.message.contains("#99"),
-        "R3 error must reference `show` and both endpoints: {}",
+        err.message.contains("show")
+            && err.message.contains("remove_blocked_by")
+            && err.message.contains("acme/widgets#42"),
+        "R3 error must reference `show`, the preceding mutation, and the source endpoint QID: {}",
         err.message,
     );
 
@@ -6122,24 +6147,27 @@ async fn close_surfaces_error_when_rebuild_fails_after_pre_cascade() {
 
     // 503 → INTERNAL_ERROR per github_error_to_mcp.
     assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
-    // Refocused semantics: the message must reference `closed`
-    // (mutation landed), `cascade field-updates applied` (Phase 2
-    // still ran), `Status reconciliation` (step 8 is what failed),
-    // and `show` (recovery hint). This is the contract from
-    // SPEC §8.2 "Post-rebuild field-sync failure".
+    // After unblock-29p.35 the post-close R3 surface uses the shared
+    // `PostMutationRebuildFailed` variant. The surfaced message is
+    // deliberately leaner than the pre-refactor wording: it names the
+    // preceding mutation (`"close_cascade"`), includes the mutated
+    // issue's fully-qualified reference (`acme/widgets#8`), and
+    // instructs the caller to re-run `show`. The pre-refactor details
+    // ("cascade field-updates applied", "Status reconciliation") are
+    // preserved as a `tracing::warn!` at `server.rs:1388-1391` for
+    // operator diagnostics — they're no longer part of the MCP wire
+    // contract. SPEC §8.2 "Post-rebuild field-sync failure" and §8.2
+    // step-8 "update_status_fields reconciliation" semantics are
+    // encoded in the preserved `warn!` plus the mutation label and
+    // unchanged 503 → INTERNAL_ERROR mapping.
     assert!(
-        err.message.contains("closed"),
-        "error message must note the close succeeded: {}",
+        err.message.contains("close_cascade"),
+        "error message must name the preceding mutation (`close_cascade`): {}",
         err.message,
     );
     assert!(
-        err.message.contains("cascade field-updates"),
-        "error message must note cascade field-updates were applied best-effort: {}",
-        err.message,
-    );
-    assert!(
-        err.message.contains("Status reconciliation"),
-        "error message must identify Status reconciliation as the failed step: {}",
+        err.message.contains("acme/widgets#8"),
+        "error message must include the mutated issue's fully-qualified reference: {}",
         err.message,
     );
     assert!(


### PR DESCRIPTION
…s-repo dep_remove observability (unblock-29p.35, unblock-29p.38)

Replaces four synthetic `GitHubApi { status: 503, ... }` constructions in the post-mutation-rebuild failure paths of `close`, `dep_remove`, and `reopen` with a dedicated `PostMutationRebuildFailed { mutation, qid }` variant on `unblock_github::errors::Error`. The new variant makes the "mutation landed on GitHub but we cannot compute post-mutation fields locally" semantic explicit in the type system, improves log/trace output via the structured `mutation` + `qid` fields, and stops masquerading transient rebuild failures as generic REST API errors.

Migrated sites (all truly post-mutation):
  * server.rs:~1395 (close, post-cascade Status reconciliation fail) — label `"close_cascade"`.
  * tools/dep_remove.rs:~498 (dep_remove R3, post-rebuild cache empty) — label `"remove_blocked_by"`.
  * tools/reopen.rs:~389 (reopen R3, post-rebuild cache empty) — label `"reopen"`.
  * tools/reopen.rs:~419 (reopen R3, rebuilt cache missing reopened issue — concurrent close race) — label `"reopen"` (same mutation, different cause).

Deliberately NOT migrated: server.rs:~1144 (close, PRE-mutation Phase 0 prime failure). That surface fires BEFORE the close mutation attempts — the close has NOT landed on GitHub when the prime fails, so `PostMutationRebuildFailed` would misrepresent the semantic (the existing message correctly guides the caller to "retry or run `prime` first", which only makes sense when no mutation has run). The call-site now carries an inline comment flagging this and pointing at `unblock-29p.35` for the follow-up `PreMutationPrimeFailed` question. The GAP-15 dual-surface regression guard (`close_surfaces_error_when_phase0_prime_fails`) continues to enforce the pre-vs-post-mutation distinction against any future collapsing refactor.

Spec preservation:
  * §8.5 / §8.7 R3 error-contract rows (just formalised in cluster P3-D) stay byte-identical — infrastructure-typed, 503 → INTERNAL_ERROR.
  * `Error::status_code()` gains a `Self::PostMutationRebuildFailed { .. } => 503` arm, grouped with `GitHubUnavailable` and `CircuitBreakerOpen` in the 503-class block. `github_error_to_mcp` at `unblock-mcp/src/errors.rs:98` is unchanged; 503 continues to map to `ErrorCode::INTERNAL_ERROR`.
  * Display output names the mutation and renders the `QualifiedId` in `owner/repo#n` form (mirroring the `EndpointClosed { qid }` precedent from bead `unblock-a36`), then instructs the caller to re-run `show`. The pre-refactor detailed wording ("cascade field-updates applied", "Status reconciliation") is preserved as a `tracing::warn!` at `server.rs:1388-1391` for operator diagnostics — no observable information is lost, only the MCP wire contract is leaner.

Tests added:
  * `status_code_post_mutation_rebuild_failed` — pins the 503 status-code contract.
  * `post_mutation_rebuild_failed_display_is_agent_actionable` — round-trip test asserting the Display output names the mutation, renders the QID in `owner/repo#n` form, and guides the caller to re-run `show`.

Tests updated (substring assertions re-anchored to the new Display contract):
  * `reopen_surfaces_error_when_post_reopen_rebuild_fails`
  * `reopen_surfaces_error_when_rebuilt_cache_missing_reopened_issue`
  * `dep_remove_surfaces_error_when_post_mutation_rebuild_fails`
  * `close_surfaces_error_when_rebuild_fails_after_pre_cascade`

Companion `unblock-29p.38` — cross-repo dep_remove observability: the `else` arm at `tools/dep_remove.rs:802-805` now differentiates the normal cross-repo skip (`debug!`) from the cache-rebuild-failed case (`warn!` with `source_qid` and `target_qid` structured fields). The cross-repo path intentionally does NOT surface a 503 (cross-repo callers do not rely on the configured-project cache for Status, per spec §5.6 footnote), but the observability gap called out in bead `unblock-29p.38` is closed — operators can now correlate the stale-cache return path with the `rebuild_cache` warn emitted at `tools/mod.rs:180-183`.

`Error` is not `#[non_exhaustive]`, so adding a variant is technically a breaking change for downstream exhaustive matchers. `unblock-github` is workspace-internal only (no external consumers), so the additive footer captures this accurately; adding `#[non_exhaustive]` is tracked as a potential follow-up but out of scope here.

API: unblock_github::errors::Error — added PostMutationRebuildFailed { mutation, qid } variant for post-mutation-rebuild failure surface (replaces 4x synthetic GitHubApi { status: 503 } constructions in close/dep_remove/reopen tools; a 5th pre-mutation prime-failure call-site in close remains on GitHubApi by design). status_code() returns 503; spec §8.5/§8.7 R3 rows unchanged (infrastructure-typed, 503 → INTERNAL_ERROR preserved).