### PR TITLE
docs(core,github,mcp): document type inventory, search_issues placeme…

### DIFF
--- a/crates/unblock-core/src/lib.rs
+++ b/crates/unblock-core/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! This crate is pure Rust with zero network dependencies. It provides:
 //!
-//! - **Types** — `Issue`, `Status`, `Priority`, `PipelineStage`, `BlockingEdge`, `BodySections`
+//! - **Types** — `Issue`, `Status`, `Priority`, `PipelineStage`, `BlockingEdge`, `TreeNode`, `DependencyTree`, `BodySections`
 //! - **Graph** — petgraph-based dependency graph with ready set computation and cascade
 //! - **Cache** — in-memory graph cache with TTL and invalidation
 //! - **Config** — environment-based configuration
@@ -25,7 +25,7 @@
 /// `std::sync` import.
 pub use std::sync::Arc;
 
-/// Domain types: `Issue`, `IssueComment`, `RelatedIssue`, `Status`, `Priority`, `PipelineStage`, `BlockingEdge`, `BodySections`.
+/// Domain types: `Issue`, `IssueComment`, `RelatedIssue`, `Status`, `Priority`, `PipelineStage`, `BlockingEdge`, `TreeNode`, `DependencyTree`, `BodySections`.
 pub mod types;
 
 /// Dependency graph engine: build, ready set, cascade, cycle detection.

--- a/crates/unblock-github/src/api.rs
+++ b/crates/unblock-github/src/api.rs
@@ -165,6 +165,10 @@ pub trait GitHubApi: Send + Sync {
     /// Reopens a previously closed issue.
     async fn reopen_issue(&self, number: u64) -> Result<(), Error>;
 
+    // Note: `search_issues` is a read-only operation but is grouped under
+    // `── Mutations ──` per spec §5.4, which lists it alongside the write
+    // mutations rather than the GraphQL reads. Do not relocate it without a
+    // matching spec edit — the placement is intentional, not accidental.
     /// Full-text search of issues via GitHub's REST Search API.
     ///
     /// Scoped to the configured `owner/repo`. Bypasses any caller-side cache.

--- a/crates/unblock-mcp/src/tools/list.rs
+++ b/crates/unblock-mcp/src/tools/list.rs
@@ -76,7 +76,16 @@ pub struct ListParams {
     /// Case-insensitive.
     pub label: Option<String>,
     /// Filter by assignee. Returns issues that have this GitHub login as
-    /// an assignee (any match). Exact match.
+    /// an assignee (any match).
+    ///
+    /// **Case-sensitive** exact match — `"Alice"` and `"alice"` are
+    /// treated as distinct values even though GitHub logins are
+    /// case-insensitive platform-side (so both refer to the same user).
+    /// This mirrors the [`agent`](Self::agent) filter precedent and is
+    /// covered by the `assignee_filter_is_case_sensitive` unit test in
+    /// this module. Callers should pass the canonical login casing as
+    /// it appears on the issue. A future refinement may switch to
+    /// [`str::eq_ignore_ascii_case`] once a product decision is made.
     pub assignee: Option<String>,
     /// Sort order. One of `"priority"` (default), `"created"`, or
     /// `"updated"`. Empty/whitespace-only strings normalise to the
@@ -298,8 +307,14 @@ fn filter_sort_paginate(
         .filter(|r| agent_filter.is_none_or(|f| r.agent.as_deref() == Some(f)))
         // label: any label case-insensitive match (matching ready.rs:153).
         .filter(|r| label_filter.is_none_or(|f| r.labels.iter().any(|l| l.eq_ignore_ascii_case(f))))
-        // assignee: any assignee exact match — GitHub stores logins as
-        // canonical strings, and exact match mirrors the agent filter.
+        // assignee: any assignee CASE-SENSITIVE exact match — mirrors the
+        // agent filter precedent above and intentionally diverges from
+        // GitHub's platform-side case-insensitive login semantics
+        // ("Alice" and "alice" identify the same user on GitHub but are
+        // treated as distinct here). See the doc on
+        // `ListParams::assignee` for the full rationale; if the product
+        // decision flips, swap to `eq_ignore_ascii_case` and update the
+        // `assignee_filter_is_case_sensitive` test.
         .filter(|r| assignee_filter.is_none_or(|f| r.assignees.iter().any(|a| a == f)))
         .collect();
 


### PR DESCRIPTION
…nt, assignee case-sensitivity (unblock-29p.17, unblock-29p.21, unblock-29p.28)

unblock-core/src/lib.rs: list TreeNode and DependencyTree alongside the other domain types in both the crate-level module doc and the pub mod types doc-comment, restoring inventory completeness after the structured dependency tree refactor.

unblock-github/src/api.rs: add an inline comment above search_issues clarifying that the operation is read-only but grouped under the `── Mutations ──` block per spec §5.4 — placement is intentional and tied to the spec.

unblock-mcp/src/tools/list.rs: document the assignee filter as case-sensitive (intentional divergence from GitHub case-insensitive login semantics) on both the ListParams::assignee rustdoc and the inline filter comment, and reference the assignee_filter_is_case_sensitive regression test.