### PR TITLE
test(mcp): cluster 2 test hygiene — Default on ListParams, Blocked so…

### DIFF
--- a/crates/unblock-mcp/src/tools/list.rs
+++ b/crates/unblock-mcp/src/tools/list.rs
@@ -52,7 +52,18 @@ const SORT_UPDATED: &str = "updated";
 ///
 /// String filters that are empty or whitespace-only are treated as
 /// absent — `{"agent": ""}` behaves identically to `{"agent": null}`.
-#[derive(Debug, Deserialize, JsonSchema)]
+///
+/// `Default` is derived so that test call-sites (and any future builder
+/// shorthand) can construct a fully-unset `ListParams` and override only
+/// the fields they care about with struct-update syntax:
+///
+/// ```ignore
+/// ListParams { assignee: Some("alice".into()), ..Default::default() }
+/// ```
+///
+/// This makes adding a new optional field additive at the call-site
+/// layer instead of mechanically breaking every literal construction.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListParams {
     /// Filter by workflow status (case-insensitive). Accepts `"Ready"`,
     /// `"InProgress"`, `"Blocked"`, `"Deferred"`, or `"Closed"`.

--- a/crates/unblock-mcp/tests/common/mod.rs
+++ b/crates/unblock-mcp/tests/common/mod.rs
@@ -39,12 +39,25 @@ pub fn test_config() -> Config {
 }
 
 /// Creates a [`ServerState`] with a real client and empty cache.
+///
+/// Prefers [`GitHubClient::with_repo`] when the config carries an
+/// explicit `repo` (i.e. `UNBLOCK_REPO=owner/repo` is set) so the helper
+/// does not depend on a reachable `.git/config` to resolve the
+/// repository. This mirrors the fix in `unblock-c4h` for
+/// `crates/unblock-github/tests/integration.rs`: prior to the migration,
+/// running `cargo test -p unblock-mcp` from the member crate directory
+/// with `GITHUB_TOKEN` set but without `.git/config` reachable surfaced
+/// the same latent `.git/config` relative-path failure (masked today by
+/// the `has_github_token()` gate, but a regression vector for any test
+/// that drops the gate).
+///
+/// When `UNBLOCK_REPO` is not set, falls back to [`GitHubClient::new`]
+/// so the production `UNBLOCK_REPO` + git-remote resolution path is
+/// still exercised end-to-end when only `GITHUB_TOKEN` is provided.
 #[allow(dead_code)]
 pub async fn test_server_state() -> ServerState {
     let config = test_config();
-    let client = GitHubClient::new(&config)
-        .await
-        .expect("GitHubClient::new() should succeed");
+    let client = build_github_client(&config).await;
     ServerState {
         config: Arc::new(config),
         github: Arc::new(client),
@@ -53,6 +66,35 @@ pub async fn test_server_state() -> ServerState {
         agent_client: OnceLock::new(),
         connected_at: OnceLock::new(),
     }
+}
+
+/// Build a real [`GitHubClient`] from `config`, preferring
+/// [`GitHubClient::with_repo`] when an explicit `owner/repo` is present
+/// in `config.repo`.
+///
+/// Bypasses `.git/config` resolution whenever possible so that integration
+/// tests run from the member crate directory (`cargo test -p unblock-mcp`)
+/// do not depend on a reachable git working tree to resolve the
+/// repository. Falls back to [`GitHubClient::new`] when `config.repo` is
+/// `None`, preserving the production resolution path for callers that
+/// only set `GITHUB_TOKEN`.
+///
+/// The `owner/repo` parsing here intentionally matches
+/// [`unblock_core::config::Config::repo`]'s validation invariant — the
+/// string is guaranteed to contain exactly one `/` with non-empty
+/// segments on each side at config-load time, so `split_once('/')` is
+/// total here without further validation.
+async fn build_github_client(config: &Config) -> GitHubClient {
+    if let Some(repo) = config.repo.as_deref()
+        && let Some((owner, name)) = repo.split_once('/')
+    {
+        return GitHubClient::with_repo(config, owner, name)
+            .await
+            .expect("GitHubClient::with_repo() should succeed with parsed UNBLOCK_REPO");
+    }
+    GitHubClient::new(config)
+        .await
+        .expect("GitHubClient::new() should succeed")
 }
 
 // ── Mock helpers ──────────────────────────────────────────────────────

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -1372,16 +1372,8 @@ async fn list_returns_filtered_sorted_paginated_issues_via_mock_client() {
     let result1 = handle_list(
         &state,
         ListParams {
-            status: None,
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
             label: Some("urgent".to_owned()),
-            assignee: None,
-            sort: None,
-            limit: None,
-            offset: None,
+            ..Default::default()
         },
     )
     .await
@@ -1403,16 +1395,8 @@ async fn list_returns_filtered_sorted_paginated_issues_via_mock_client() {
     let result2 = handle_list(
         &state,
         ListParams {
-            status: None,
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
-            label: None,
-            assignee: None,
             sort: Some("created".to_owned()),
-            limit: None,
-            offset: None,
+            ..Default::default()
         },
     )
     .await
@@ -1428,16 +1412,8 @@ async fn list_returns_filtered_sorted_paginated_issues_via_mock_client() {
     let result3 = handle_list(
         &state,
         ListParams {
-            status: None,
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
-            label: None,
-            assignee: None,
             sort: Some("updated".to_owned()),
-            limit: None,
-            offset: None,
+            ..Default::default()
         },
     )
     .await
@@ -1458,16 +1434,9 @@ async fn list_returns_filtered_sorted_paginated_issues_via_mock_client() {
     let result4 = handle_list(
         &state,
         ListParams {
-            status: None,
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
-            label: None,
-            assignee: None,
-            sort: None,
             limit: Some(2),
             offset: Some(2),
+            ..Default::default()
         },
     )
     .await
@@ -1587,15 +1556,7 @@ async fn list_status_closed_returns_closed_issues_and_status_ready_excludes_them
         &state,
         ListParams {
             status: Some("Closed".to_owned()),
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
-            label: None,
-            assignee: None,
-            sort: None,
-            limit: None,
-            offset: None,
+            ..Default::default()
         },
     )
     .await
@@ -1625,15 +1586,7 @@ async fn list_status_closed_returns_closed_issues_and_status_ready_excludes_them
         &state,
         ListParams {
             status: Some("Ready".to_owned()),
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
-            label: None,
-            assignee: None,
-            sort: None,
-            limit: None,
-            offset: None,
+            ..Default::default()
         },
     )
     .await
@@ -1678,16 +1631,8 @@ async fn list_rejects_limit_out_of_range_without_fetching() {
     let err = handle_list(
         &state,
         ListParams {
-            status: None,
-            priority: None,
-            issue_type: None,
-            milestone: None,
-            agent: None,
-            label: None,
-            assignee: None,
-            sort: None,
             limit: Some(0),
-            offset: None,
+            ..Default::default()
         },
     )
     .await
@@ -2730,7 +2675,17 @@ async fn dep_remove_local_edge_transitions_source_to_ready() {
 
     // Post-mutation rebuild: source #42 and target #99, but NO remaining
     // edges — so #42 is now unblocked after the removal.
-    let rebuilt_source = dep_remove_fixture_issue(42);
+    //
+    // The rebuilt source is seeded as `Status::Blocked` (rather than the
+    // generic-fixture default of `Status::Ready`) so this test asserts the
+    // Blocked→Ready transition explicitly. Per spec §8.5 step 5 the
+    // status-update ladder in `dep_remove.rs` fires unconditionally when
+    // `has_open_blockers` returns false; with a Ready source this
+    // assertion would only validate a Ready→Ready no-op. A Blocked source
+    // catches any future regression where the ladder is made conditional
+    // on the current Projects V2 Status value (see bead unblock-29p.39).
+    let mut rebuilt_source = dep_remove_fixture_issue(42);
+    rebuilt_source.status = Status::Blocked;
     let rebuilt_target = dep_remove_fixture_issue(99);
     mock.push_fetch_graph_data(Ok((vec![rebuilt_source, rebuilt_target], vec![])));
 
@@ -4615,13 +4570,26 @@ async fn setup_no_project_returns_project_not_configured() {
     })
     .expect("Config should load without UNBLOCK_PROJECT");
 
-    // Intentional concrete `GitHubClient::new` (not the `GitHubApi` trait):
+    // Intentional concrete `GitHubClient` (not the `GitHubApi` trait):
     // this test asserts the real client's project-resolution path returns
     // `ProjectNotConfigured` when `UNBLOCK_PROJECT` is unset, which is a
     // property of the concrete implementation, not the trait abstraction.
-    let client = GitHubClient::new(&config)
-        .await
-        .expect("GitHubClient::new should succeed");
+    //
+    // Prefer `with_repo` when `UNBLOCK_REPO` is set so the constructor
+    // does not depend on a reachable `.git/config` to resolve the
+    // repository (mirrors the unblock-c4h fix in `unblock-github`'s
+    // integration tests; see bead unblock-29p.51). Fall back to `new`
+    // otherwise so the production resolution path is still exercised.
+    let client = if let Some((owner, name)) = config.repo.as_deref().and_then(|r| r.split_once('/'))
+    {
+        GitHubClient::with_repo(&config, owner, name)
+            .await
+            .expect("GitHubClient::with_repo should succeed")
+    } else {
+        GitHubClient::new(&config)
+            .await
+            .expect("GitHubClient::new should succeed")
+    };
 
     // resolve_project_info should fail with ProjectNotConfigured.
     let result = client.resolve_project_info().await;


### PR DESCRIPTION
…urce in dep_remove happy-path, with_repo migration

Three test-only refinements landed together as test hygiene cluster 2 of epic unblock-29p:

- unblock-29p.27 — derive Default on ListParams so test call-sites can construct it via `..Default::default()`. Migrates the seven literal ListParams sites in tests/integration.rs to struct-update form, making any future optional field additive at the test layer instead of mechanically breaking every call-site.

- unblock-29p.39 — strengthen dep_remove_local_edge_transitions_source_to_ready by seeding the rebuilt source as Status::Blocked instead of the generic fixture default of Status::Ready. The status-update ladder in dep_remove.rs:298-302 fires unconditionally when has_open_blockers returns false; with a Ready source the test was only validating a Ready→Ready no-op. A Blocked source asserts the Blocked→Ready transition per spec §8.5 step 5 explicitly and catches any future regression where the ladder is made conditional on the current Projects V2 Status value.

- unblock-29p.51 — migrate unblock-mcp test helpers (common/mod.rs and the inline GitHubClient::new in integration.rs's setup_no_project_returns_project_not_configured test) to prefer GitHubClient::with_repo when UNBLOCK_REPO is set, falling back to GitHubClient::new when not. Mirrors the unblock-c4h fix in unblock-github's integration tests: removes the latent .git/config relative-path failure mode that was masked by the has_github_token() gate when running `cargo test -p unblock-mcp` from the member crate directory with GITHUB_TOKEN set but without .git/config reachable.

API: ListParams now derives Default (additive — unblock-mcp is a binary crate so this is informational only per the project's pub-API tracking convention).

Quality gate: cargo fmt --check --all, cargo clippy --workspace --all-targets -- -D warnings, cargo test --workspace, and cargo doc --no-deps --workspace all pass with zero diffs/warnings.