### PR TITLE
refactor(mcp): extract shared refresh_cache_from() + build_graph_and_…

### DIFF
--- a/crates/unblock-mcp/src/tools/dep_cycles.rs
+++ b/crates/unblock-mcp/src/tools/dep_cycles.rs
@@ -98,6 +98,7 @@
 //! data types [`DepCyclesParams`] / [`DepCyclesResult`] so the sibling
 //! bead can wire the router without touching cycle-detection logic.
 //!
+//! [`DependencyGraph`]: unblock_core::graph::DependencyGraph
 //! [`DependencyGraph::detect_all_cycles`]: unblock_core::graph::DependencyGraph::detect_all_cycles
 //! [`GraphCache::get_graph`]: unblock_core::cache::GraphCache::get_graph
 //! [`QualifiedId`]: unblock_core::types::QualifiedId
@@ -111,7 +112,6 @@ use rmcp::model::ErrorData;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
-use unblock_core::graph::DependencyGraph;
 use unblock_core::types::{CrossRepoRefs, QualifiedId};
 
 use crate::errors::github_error_to_mcp;
@@ -244,6 +244,9 @@ fn filter_cycles_containing<'a>(
 /// GitHub network failure). The error surface matches the
 /// [`crate::tools::stats`] R6 posture — `DepCyclesResult` has no
 /// `stale` field, so failure must be signalled via the error channel.
+///
+/// [`DependencyGraph`]: unblock_core::graph::DependencyGraph
+/// [`DependencyGraph::detect_all_cycles`]: unblock_core::graph::DependencyGraph::detect_all_cycles
 #[instrument(
     skip(state, params),
     name = "handle_dep_cycles",
@@ -284,12 +287,21 @@ pub async fn handle_dep_cycles(
         // The retry unexpectedly succeeded — populate the cache so a
         // follow-up call is warm, then compute cycles against the
         // freshly built graph without re-reading the cache.
-        let graph_built = DependencyGraph::build(&issues_vec, &edges_vec);
-        // SPEC §3.3 Filter 3 / §14 Invariant 14(a): scope the cached ready
-        // set to the configured (owner, repo) so downstream consumers
-        // inherit the local-only guarantee by construction.
-        let ready_set =
-            graph_built.compute_ready_set(&issues_vec, &configured_owner, &configured_repo);
+        //
+        // SPEC §3.3 Filter 3 / §14 Invariant 14(a): the helper threads the
+        // configured (owner, repo) through the engine so the cached ready
+        // set is local-only and downstream consumers inherit the guarantee
+        // by construction. This is a "retains references" site — we keep
+        // `&graph_built` between the build/compute pair and `cache.update`
+        // to call `detect_all_cycles()` without a double-build, deep clone,
+        // or post-update cache re-read (see `crate::tools::refresh_cache_from`
+        // rustdoc for the call-site taxonomy).
+        let (graph_built, ready_set) = crate::tools::build_graph_and_ready_set(
+            &issues_vec,
+            &edges_vec,
+            state.github.owner(),
+            state.github.repo(),
+        );
         let cycles = graph_built.detect_all_cycles();
         state.cache.update(issues_vec, ready_set, graph_built).await;
         cycles

--- a/crates/unblock-mcp/src/tools/list.rs
+++ b/crates/unblock-mcp/src/tools/list.rs
@@ -22,7 +22,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
 use unblock_core::errors::ValidationSnafu;
-use unblock_core::graph::DependencyGraph;
 use unblock_core::types::{Issue, Priority, QualifiedId, Status};
 
 use crate::errors::github_error_to_mcp;
@@ -512,13 +511,12 @@ pub async fn handle_list(state: &ServerState, params: ListParams) -> Result<List
             // was warm or cold. `issues` is cloned because the local copy
             // is still consumed below by `build_list_rows` for the list
             // projection — the cache holds an independent snapshot.
-            let graph = DependencyGraph::build(&issues, &edges);
-            // SPEC §3.3 Filter 3 / §14 Invariant 14(a): scope the cached
-            // ready set to the configured (owner, repo) so subsequent
-            // `ready`/`prime` reads inherit the local-only guarantee.
-            let ready_set =
-                graph.compute_ready_set(&issues, state.github.owner(), state.github.repo());
-            state.cache.update(issues.clone(), ready_set, graph).await;
+            //
+            // SPEC §3.3 Filter 3 / §14 Invariant 14(a): the helper
+            // forwards the configured (owner, repo) to the engine so the
+            // cached ready set is scoped to local-only sources, which
+            // subsequent `ready`/`prime` reads inherit.
+            crate::tools::refresh_cache_from(state, issues.clone(), &edges).await;
             tracing::debug!("Cache refreshed by list handler");
             issues
         }

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -56,6 +56,7 @@ use std::future::Future;
 use rmcp::model::ErrorData;
 use tracing::instrument;
 use unblock_core::graph::DependencyGraph;
+use unblock_core::types::{BlockingEdge, Issue, IssueSummary};
 
 use crate::errors::github_error_to_mcp;
 use crate::server::ServerState;
@@ -69,6 +70,80 @@ use crate::server::ServerState;
 #[must_use]
 pub(crate) fn normalize_filter(value: Option<&str>) -> Option<&str> {
     value.filter(|s| !s.trim().is_empty())
+}
+
+/// Build a fresh [`DependencyGraph`] and ready-set projection from raw
+/// `fetch_graph_data()` outputs.
+///
+/// Centralises the build → `compute_ready_set` pair that every
+/// cache-population site (the [`rebuild_cache`] success branch and the
+/// fresh-fetch sequences in `prime`, `reconcile`, `list`, and the `stats`
+/// retry path) would otherwise duplicate verbatim.
+///
+/// SPEC §3.3 Filter 3 / §14 Invariant 14(a): forwarding the configured
+/// `(owner, repo)` to [`DependencyGraph::compute_ready_set`] is the single
+/// chokepoint that scopes the cached ready set to local-only source issues.
+/// Concentrating the call here means `(owner, repo)` is threaded through
+/// the engine in exactly one place per fresh-fetch flow, making the
+/// scoping invariant easy to audit and impossible to bypass by accident.
+///
+/// Pure / synchronous: no I/O, no allocations beyond the `Vec<IssueSummary>`
+/// and the underlying `DiGraph`. Inputs are borrowed so callers retain
+/// ownership of the issue/edge slices when they need to use them again
+/// (e.g. for downstream categorisation, drift analysis, or aggregation
+/// before the cache is updated).
+#[must_use]
+pub(crate) fn build_graph_and_ready_set(
+    issues: &[Issue],
+    edges: &[BlockingEdge],
+    configured_owner: &str,
+    configured_repo: &str,
+) -> (DependencyGraph, Vec<IssueSummary>) {
+    let graph = DependencyGraph::build(issues, edges);
+    let ready_set = graph.compute_ready_set(issues, configured_owner, configured_repo);
+    (graph, ready_set)
+}
+
+/// Refresh the cache from a freshly-fetched `(issues, edges)` pair.
+///
+/// Builds a [`DependencyGraph`] and ready set via
+/// [`build_graph_and_ready_set`] (using `state.github.owner()` /
+/// `state.github.repo()` as the SPEC §3.3 Filter 3 chokepoint) and stores
+/// all three artefacts in [`crate::server::ServerState::cache`] via
+/// [`unblock_core::cache::GraphCache::update`].
+///
+/// Used by call sites that **fully delegate** the build → compute → store
+/// sequence — i.e. they do not need the freshly-built graph or ready set
+/// for any intermediate work between `compute_ready_set` and
+/// `cache.update`. Those are:
+///
+/// - [`rebuild_cache`] — post-mutation cache rebuild after `execute_write_tool`.
+/// - The success branch of the `list` handler — refreshes the cache as a
+///   side effect of the fresh fetch the handler already needed.
+///
+/// **Sites that retain intermediate references** (`prime`, `reconcile`, the
+/// `stats` retry path) instead call [`build_graph_and_ready_set`]
+/// directly, then invoke `state.cache.update(...)` once they have finished
+/// consuming the local references. Coupling the build/compute pair into a
+/// shared helper while leaving the cache-update line at the call site
+/// avoids both (a) double-builds (calling the full helper after a local
+/// build) and (b) post-update cache re-reads (which would introduce a new
+/// race window with concurrent invalidators relative to today's
+/// behaviour).
+///
+/// **Observably equivalent.** Callers that adopt this helper match the
+/// pre-refactor sequence one-for-one: same allocations, same lock
+/// acquisition order, same SPEC scoping. The site-specific `tracing::debug!`
+/// message that previously followed `cache.update` is preserved at the call
+/// site so log telemetry is unchanged.
+pub(crate) async fn refresh_cache_from(
+    state: &ServerState,
+    issues: Vec<Issue>,
+    edges: &[BlockingEdge],
+) {
+    let (graph, ready_set) =
+        build_graph_and_ready_set(&issues, edges, state.github.owner(), state.github.repo());
+    state.cache.update(issues, ready_set, graph).await;
 }
 
 /// Executes a read-only MCP tool operation.
@@ -164,16 +239,13 @@ pub async fn rebuild_cache(state: &ServerState) {
 
     match state.github.fetch_graph_data().await {
         Ok((issues, edges)) => {
-            let graph = DependencyGraph::build(&issues, &edges);
-            // SPEC §3.3 Filter 3 / §14 Invariant 14(a): the cached ready set
-            // is guaranteed local-only by construction when the engine is
-            // passed the configured (owner, repo). This is the canonical
-            // chokepoint — downstream consumers (ready, prime,
+            // SPEC §3.3 Filter 3 / §14 Invariant 14(a): `refresh_cache_from`
+            // forwards the configured (owner, repo) to the engine — the
+            // canonical chokepoint that scopes the cached ready set to
+            // local-only sources. Downstream consumers (ready, prime,
             // update_status_fields) inherit the guarantee without
             // re-checking. (unblock-eos.4 / D6.a / GAP-14.b)
-            let ready_set =
-                graph.compute_ready_set(&issues, state.github.owner(), state.github.repo());
-            state.cache.update(issues, ready_set, graph).await;
+            refresh_cache_from(state, issues, &edges).await;
             tracing::debug!("Cache rebuilt after write tool execution");
         }
         Err(err) => {

--- a/crates/unblock-mcp/src/tools/prime.rs
+++ b/crates/unblock-mcp/src/tools/prime.rs
@@ -470,13 +470,17 @@ pub async fn handle_prime(
         .await
         .map_err(github_error_to_mcp)?;
 
-    // 3. Build graph and compute ready set.
-    // SPEC §3.3 Filter 3 / §14 Invariant 14(a): engine scopes source issues
-    // to the configured (owner, repo) before the blocker filter runs. The
-    // categorisation below and the cache store inherit that guarantee.
-    let graph = DependencyGraph::build(&issues_vec, &edges);
-    let ready_summaries =
-        graph.compute_ready_set(&issues_vec, state.github.owner(), state.github.repo());
+    // 3. Build graph and compute ready set via the shared helper. SPEC
+    //    §3.3 Filter 3 / §14 Invariant 14(a): the helper threads the
+    //    configured (owner, repo) through the engine so source issues are
+    //    scoped before the blocker filter runs. The categorisation below
+    //    and the cache store inherit that guarantee.
+    let (graph, ready_summaries) = crate::tools::build_graph_and_ready_set(
+        &issues_vec,
+        &edges,
+        state.github.owner(),
+        state.github.repo(),
+    );
 
     let now = Utc::now();
 

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -17,7 +17,6 @@ use chrono::Utc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
-use unblock_core::graph::DependencyGraph;
 use unblock_core::reconcile::{DriftKind, DriftReport, ReconcileEngine};
 use unblock_core::types::{Issue, QualifiedId};
 use unblock_github::projects::FieldValue;
@@ -174,14 +173,18 @@ pub async fn handle_reconcile(
         .map(|i| (i.qualified_id.clone(), i.clone()))
         .collect();
 
-    // 2. Build graph and compute ready set.
-    // SPEC §3.3 Filter 3 / §14 Invariant 14(a): scope sources to the
-    // configured (owner, repo) so the drift report's computed_ready set
-    // only considers configured-repo issues. The reconcile engine reads
-    // cross-repo nodes separately when chasing cycles and orphaned edges.
-    let graph = DependencyGraph::build(&issues_vec, &edges);
-    let ready_summaries =
-        graph.compute_ready_set(&issues_vec, state.github.owner(), state.github.repo());
+    // 2. Build graph and compute ready set via the shared helper. SPEC
+    //    §3.3 Filter 3 / §14 Invariant 14(a): the helper scopes sources to
+    //    the configured (owner, repo) so the drift report's
+    //    `computed_ready` set only considers configured-repo issues. The
+    //    reconcile engine reads cross-repo nodes separately when chasing
+    //    cycles and orphaned edges.
+    let (graph, ready_summaries) = crate::tools::build_graph_and_ready_set(
+        &issues_vec,
+        &edges,
+        state.github.owner(),
+        state.github.repo(),
+    );
     let computed_ready: HashSet<QualifiedId> = ready_summaries
         .iter()
         .map(|s| s.qualified_id.clone())

--- a/crates/unblock-mcp/src/tools/stats.rs
+++ b/crates/unblock-mcp/src/tools/stats.rs
@@ -389,12 +389,17 @@ pub async fn handle_stats(
         // The retry unexpectedly succeeded — populate the cache so a
         // follow-up call is warm, then aggregate against the freshly
         // fetched vectors without re-reading the cache.
-        let graph_built = DependencyGraph::build(&issues_vec, &edges_vec);
-        // SPEC §3.3 Filter 3 / §14 Invariant 14(a): pass configured coords
-        // so the cached ready set is local-only and `ready_count` in the
-        // stats envelope matches what `ready(milestone=…)` would return.
-        let ready_set =
-            graph_built.compute_ready_set(&issues_vec, state.github.owner(), state.github.repo());
+        //
+        // SPEC §3.3 Filter 3 / §14 Invariant 14(a): the helper threads
+        // configured coords through the engine so the cached ready set is
+        // local-only and `ready_count` in the stats envelope matches what
+        // `ready(milestone=…)` would return.
+        let (graph_built, ready_set) = crate::tools::build_graph_and_ready_set(
+            &issues_vec,
+            &edges_vec,
+            state.github.owner(),
+            state.github.repo(),
+        );
         let milestone = crate::tools::normalize_filter(params.milestone.as_deref());
         let filtered = filter_by_milestone(&issues_vec, milestone);
         let result = aggregate_stats(


### PR DESCRIPTION
…ready_set() helpers (unblock-29p.33)

Eliminate the build-graph -> compute-ready-set -> cache.update duplication across the four cross-tool write sites flagged on unblock-29p.8 (Linus suggestion #3): the rebuild_cache success branch and the fresh-fetch sequences in prime, reconcile, list, and the stats retry path.

Two helpers, both pub(crate), both in tools/mod.rs:

- `build_graph_and_ready_set(issues, edges, owner, repo) -> (DependencyGraph, Vec<IssueSummary>)`: pure synchronous helper. Centralises the build + compute_ready_set pair and the SPEC §3.3 Filter 3 / §14 Invariant 14(a) scoping chokepoint — `(owner, repo)` is now threaded through the engine in exactly one place per fresh-fetch flow.

- `refresh_cache_from(state, issues, edges)`: async wrapper that calls the pure helper and then `state.cache.update(...)`. Used by sites that fully delegate the build -> compute -> store sequence (rebuild_cache + the list handler).

prime, reconcile, and the stats retry path use the lower-level `build_graph_and_ready_set` directly because they need `&graph`, `&ready_summaries`, and `&issues` between compute_ready_set and cache.update (for categorise_issues, ReconcileEngine::analyse, and aggregate_stats respectively). Forcing them onto a single all-in-one helper would have required either a double-build, deep-cloning the inputs, or post-update cache re-reads with `.expect` (which introduces a new race window vs. concurrent invalidators) — each of which violates the dispatch's "observably equivalent" constraint. The two-helper split resolves this cleanly without any extra allocations or lock acquisitions.

Observably equivalent: no telemetry drift (every site-specific `tracing::debug!` after cache.update is preserved at the call site), no extra clones, no new race windows, no signature changes outside this crate. unblock-mcp is the binary crate, so no API:/BREAKING CHANGE: footer is required.

All 591 workspace tests pass (216 unblock-core + 153 unblock-github + 92 unblock-mcp + ...) along with cargo fmt --check, cargo clippy --all-targets -D warnings, and cargo doc --no-deps.