### PR TITLE
docs(mcp): annotate deleted helper symbols in historical inventory (u…

### DIFF
--- a/crates/unblock-mcp/src/tools/dep_remove.rs
+++ b/crates/unblock-mcp/src/tools/dep_remove.rs
@@ -96,9 +96,10 @@
 //! by bead `unblock-29p.33` — do NOT extract here.
 //!
 //! The Projects V2 Status field update ladder previously open-coded
-//! here as `update_status_to_ready` — the fifth copy across
-//! `close` / `close-cascade` / `depends` / `reopen` / `dep_remove` — was
-//! consolidated by bead `unblock-29p.24` into the shared
+//! here as `update_status_to_ready` (deleted; consolidated under
+//! `crate::tools::update_status_field_best_effort`) — the fifth copy
+//! across `close` / `close-cascade` / `depends` / `reopen` / `dep_remove`
+//! — was consolidated by bead `unblock-29p.24` into the shared
 //! `crate::tools::update_status_field_best_effort` helper. The
 //! `dep_remove` site now passes a private `DEP_REMOVE_LOG` config to
 //! preserve the pre-refactor log message strings bit-for-bit.
@@ -558,8 +559,10 @@ async fn reevaluate_source_after_remove(
 /// [`crate::tools::update_status_field_best_effort`] helper.
 ///
 /// Preserves bit-for-bit the message text emitted by the previous private
-/// `update_status_to_ready` helper, with the helper now adding `slug` as
-/// a uniform structured field on every record. The `option_missing_warn`
+/// `update_status_to_ready` helper (deleted; consolidated under
+/// `crate::tools::update_status_field_best_effort` by `unblock-29p.24`),
+/// with the helper now adding `slug` as a uniform structured field on
+/// every record. The `option_missing_warn`
 /// arm is `Some(...)` to preserve the pre-refactor warn that fires when
 /// the configured Status field has no `ready` option — `dep_remove`
 /// surfaces this as a misconfiguration rather than a silent no-op

--- a/crates/unblock-mcp/src/tools/mod.rs
+++ b/crates/unblock-mcp/src/tools/mod.rs
@@ -261,10 +261,12 @@ pub(crate) struct StatusUpdateLogConfig {
 ///    `matches!(source_ref, IssueRef::Local(_))` because the configured
 ///    project's `ProjectInfo` cannot host cross-repo source items per
 ///    spec §5.6.
-/// 4. **`tools::reopen::update_status_field`** — Status → caller-supplied
+/// 4. **`tools::reopen::update_status_field`** (deleted; consolidated under
+///    `update_status_field_best_effort`) — Status → caller-supplied
 ///    slug (`"ready"` or `"blocked"`) after
 ///    [`GitHubApi::reopen_issue`]. Caller-supplied slug.
-/// 5. **`tools::dep_remove::update_status_to_ready`** — Status → `ready`
+/// 5. **`tools::dep_remove::update_status_to_ready`** (deleted; consolidated
+///    under `update_status_field_best_effort`) — Status → `ready`
 ///    when [`GitHubApi::remove_blocked_by_refs`] left the source with
 ///    zero open blockers. Hardcoded slug per spec §8.5.
 ///

--- a/crates/unblock-mcp/src/tools/reopen.rs
+++ b/crates/unblock-mcp/src/tools/reopen.rs
@@ -217,8 +217,10 @@ fn validate_id(id: u64) -> Result<(), ErrorData> {
 /// [`crate::tools::update_status_field_best_effort`] helper.
 ///
 /// Preserves bit-for-bit the message text emitted by the previous private
-/// `update_status_field` helper, including the `slug` structured field
-/// that the helper now adds to every record. The `option_missing_warn`
+/// `update_status_field` helper (deleted; consolidated under
+/// `crate::tools::update_status_field_best_effort` by `unblock-29p.24`),
+/// including the `slug` structured field that the helper now adds to
+/// every record. The `option_missing_warn`
 /// arm is `Some(...)` to preserve the pre-refactor warn that fires when
 /// the configured Status field has no option matching the requested
 /// slug — reopen surfaces this as a misconfiguration rather than a silent


### PR DESCRIPTION
…nblock-29p.74)

The historical-inventory comment block in tools/mod.rs (lines 264, 267) and the LOG-config doc-comments in tools/reopen.rs (line 220) and tools/dep_remove.rs (lines 99, 561) reference five pre-refactor private helpers — `update_status_field` and `update_status_to_ready` — that were deleted in unblock-29p.24 when the five status-update sites were consolidated under `update_status_field_best_effort`.

The references were deliberately framed as historical narrative and use backticks (not [...] intra-doc links) so rustdoc warnings do not fire, but a future maintainer searching for those symbol names would hit dead references with no indication that the symbols are gone.

Approach A applied uniformly: annotate each deleted symbol inline with "(deleted; consolidated under `update_status_field_best_effort`)". Preserves the historical paper trail (valuable for git-blame archaeology) while making the deletion explicit so a grep hit immediately tells the reader the symbol is gone.

Workspace sweep covered all five sites — three additional stale references were found beyond the two named in the bead (reopen.rs:220, dep_remove.rs:99, dep_remove.rs:561) and folded into this commit per the explicit instruction not to silently leave (lesson from .33).

Doc-only — no production code, no public API change, no behaviour change. Quality gate: cargo fmt --check, clippy -D warnings, test --workspace, doc --no-deps --workspace all clean.