### PR TITLE
chore(resilience): bootstrap crate skeleton (unblock-1o4.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +405,18 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "failsafe"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b1dc7c28e66a8f5dc32b7043b735e93d9eea8ea6e7be5507dae5850ab7ac70"
+dependencies = [
+ "futures-core",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -904,6 +930,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1214,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,8 +1326,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1309,12 +1364,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1324,7 +1400,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1342,7 +1427,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2169,6 +2254,18 @@ dependencies = [
  "tracing-subscriber",
  "unblock-core",
  "unblock-github",
+]
+
+[[package]]
+name = "unblock-resilience"
+version = "0.1.0"
+dependencies = [
+ "backoff",
+ "failsafe",
+ "serde",
+ "snafu",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/unblock-core",
     "crates/unblock-github",
     "crates/unblock-mcp",
+    "crates/unblock-resilience",
 ]
 resolver = "2"
 
@@ -28,6 +29,8 @@ proptest = "1"
 criterion = { version = "0.5", features = ["async_tokio"] }
 wiremock = "0.6"
 async-trait = "0.1"
+failsafe = "1.3"
+backoff = { version = "0.4", features = ["tokio"] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/unblock-resilience/Cargo.toml
+++ b/crates/unblock-resilience/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "unblock-resilience"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "HTTP resilience policy: composed circuit breaker + retry-with-backoff for unblock"
+
+[lints]
+workspace = true
+
+[dependencies]
+failsafe = { workspace = true }
+backoff = { workspace = true }
+tokio = { version = "1", default-features = false, features = ["time"] }
+tracing = { workspace = true }
+snafu = { workspace = true }
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/crates/unblock-resilience/src/breaker.rs
+++ b/crates/unblock-resilience/src/breaker.rs
@@ -1,0 +1,3 @@
+//! Circuit-breaker primitive: `failsafe::Config` wrapper with an Instrument mirror.
+//!
+//! Bodies (`Breaker`, instrument callbacks) are added in bead 02.A.3 per spec §5.3.

--- a/crates/unblock-resilience/src/lib.rs
+++ b/crates/unblock-resilience/src/lib.rs
@@ -1,0 +1,15 @@
+//! Generic HTTP-resilience policy: composed circuit breaker + retry-with-backoff.
+//!
+//! Two consumer crates: `unblock-github` (this phase) and `unblock-indexer`
+//! (Phase 03). Both are architecturally orthogonal — `unblock-resilience` carries
+//! zero unblock-domain knowledge.
+//!
+//! See [`ResiliencePolicy::execute`] for the single entry point. State scope is
+//! per-process: each `ResiliencePolicy` instance owns its own breaker and retry
+//! configuration.
+
+pub mod breaker;
+pub mod policy;
+pub mod retry;
+pub mod snapshot;
+pub mod traits;

--- a/crates/unblock-resilience/src/policy.rs
+++ b/crates/unblock-resilience/src/policy.rs
@@ -1,0 +1,4 @@
+//! Composed `ResiliencePolicy`: breaker outside, retry inside (Decision L1.4).
+//!
+//! Bodies (`ResiliencePolicy`, `execute`) are added in bead 02.A.5 per spec
+//! §4.2 and §5.1/§5.2.

--- a/crates/unblock-resilience/src/retry.rs
+++ b/crates/unblock-resilience/src/retry.rs
@@ -1,0 +1,4 @@
+//! Retry-with-backoff primitive: `backoff::ExponentialBackoff` wrapper.
+//!
+//! Bodies (`RetryPolicy`, `default`/`from_env`) are added in bead 02.A.4 per
+//! spec §5.4 and §5.5.

--- a/crates/unblock-resilience/src/snapshot.rs
+++ b/crates/unblock-resilience/src/snapshot.rs
@@ -1,0 +1,5 @@
+//! Read-only observability snapshots for the breaker and retry policy.
+//!
+//! Bodies (`BreakerSnapshot`, `RetrySnapshot`, `BreakerState`) are added in
+//! beads 02.A.3 and 02.A.4 per spec §4.5. Serialisation is gated behind the
+//! `serde` feature.

--- a/crates/unblock-resilience/src/traits.rs
+++ b/crates/unblock-resilience/src/traits.rs
@@ -1,0 +1,4 @@
+//! Retryability classification trait and the policy-level error envelope.
+//!
+//! Bodies (`IsRetryable`, `ResilienceError<E>`) are added in bead 02.A.2 per
+//! spec §4.3 and §4.4.


### PR DESCRIPTION
## Summary

- Creates `crates/unblock-resilience/` with `Cargo.toml` and the 6 spec-mandated source files (`lib.rs`, `traits.rs`, `breaker.rs`, `retry.rs`, `policy.rs`, `snapshot.rs`) per spec §3.1.
- Registers the crate in workspace members and adds `failsafe = "1.3"` + `backoff = { version = "0.4", features = ["tokio"] }` to `[workspace.dependencies]`.
- Honours review constraints: H-3 (`license.workspace = true`, MIT OR Apache-2.0) and H-5 (`tokio` declared per-crate with `default-features = false, features = ["time"]` — NOT inherited from workspace `full`, preserving Phase 03 `unblock-indexer` consumability).
- Declares the `serde` optional feature now so `02.A.3` / `02.A.4` snapshot types can land their `#[cfg_attr(feature = "serde", derive(Serialize))]` without re-touching `Cargo.toml`.

Tracks bead [unblock-1o4.1](https://github.com/websublime/unblock/issues?q=unblock-1o4.1) (epic [unblock-1o4](https://github.com/websublime/unblock/issues?q=unblock-1o4) — 02.A Resilience Layer). Spec: `docs/specs/02-spec-mcp-complete.md` §3.1, §4.1.

## Test plan

- [x] `cargo build -p unblock-resilience` succeeds
- [x] `cargo tree -p unblock-resilience` shows zero `unblock-*` deps
- [x] `cargo fmt --check --all` clean
- [x] `cargo clippy -p unblock-resilience --all-targets -- -D warnings` clean
- [x] Full `cargo build --workspace` compiles
- [ ] Reviewer note: `cargo doc` emits 1 `rustdoc::broken_intra_doc_links` warning for `ResiliencePolicy::execute` (verbatim from spec §4.1) — resolves when `02.A.5` lands. Doc-clean acceptance lives at the **epic** level, not this skeleton bead.