### PR TITLE
unblock-741: rename trackedByIssues→blockedBy + addIssueDependency→addBlockedBy

### DIFF
--- a/crates/unblock-core/src/errors.rs
+++ b/crates/unblock-core/src/errors.rs
@@ -69,10 +69,11 @@ pub enum DomainError {
     /// The issue has unresolved blocking dependencies.
     ///
     /// `blockers` carries [`IssueRef`] values so cross-repo blockers
-    /// (which are observable via GitHub's native `trackedByIssues`
-    /// connection) render with `owner/repo#n` qualification in the
-    /// error message, rather than aliasing to a same-numbered local
-    /// issue. See SPEC §11.1 Decision 1 (2026-04-17).
+    /// (which are observable via GitHub's native `Issue.blockedBy`
+    /// connection — schema as of 2026-04-30) render with `owner/repo#n`
+    /// qualification in the error message, rather than aliasing to a
+    /// same-numbered local issue. See SPEC §11.1 Decision 1
+    /// (2026-04-17).
     #[snafu(display("Issue #{number} is blocked by: {}", render_blockers(blockers)))]
     IssueBlocked {
         /// The issue number.

--- a/crates/unblock-core/src/reconcile.rs
+++ b/crates/unblock-core/src/reconcile.rs
@@ -22,9 +22,9 @@
 //! # Design Note
 //!
 //! `GhostedBlockingEdge` is intentionally absent from the taxonomy. In our model,
-//! edges come from GitHub's `trackedByIssues` API (not body text), so the graph
-//! cannot contain an edge that GitHub does not have. See spec §4 for the full
-//! rationale.
+//! edges come from GitHub's `Issue.blockedBy` API (schema as of 2026-04-30, not
+//! body text), so the graph cannot contain an edge that GitHub does not have.
+//! See spec §4 for the full rationale.
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -399,13 +399,14 @@ impl fmt::Display for PipelineStage {
 ///
 /// # Repo identity (`repo_owner` / `repo_name`)
 ///
-/// The GitHub `trackedByIssues` connection can return blockers from a
-/// different repository (cross-repo dependencies). When the GraphQL
-/// selection includes the blocker's `repository { owner { login } name }`
-/// subfields, the parser fills `repo_owner` and `repo_name` so callers
-/// can disambiguate a cross-repo blocker from a same-repo blocker.
+/// The GitHub `Issue.blockedBy` connection (schema as of 2026-04-30) can
+/// return blockers from a different repository (cross-repo dependencies).
+/// When the GraphQL selection includes the blocker's `repository { owner
+/// { login } name }` subfields, the parser fills `repo_owner` and
+/// `repo_name` so callers can disambiguate a cross-repo blocker from a
+/// same-repo blocker.
 ///
-/// For parent / sub-issues / `trackedInIssues` and for connections whose
+/// For parent / sub-issues / `Issue.blocking` and for connections whose
 /// GraphQL selection omits `repository { ... }`, these fields remain
 /// `None` — the caller MUST treat `None` as "unknown / assume
 /// same-repo-as-enclosing-issue" to preserve backwards compatibility.
@@ -435,7 +436,7 @@ impl RelatedIssue {
     ///
     /// Leaves `repo_owner` and `repo_name` as `None`, encoding the
     /// "None = same repo as the containing issue" convention at the
-    /// type level. Use this for parent / sub-issue / `trackedInIssues`
+    /// type level. Use this for parent / sub-issue / `Issue.blocking`
     /// relations and for any blocker whose GraphQL selection omitted
     /// `repository { ... }`.
     ///
@@ -457,7 +458,7 @@ impl RelatedIssue {
     ///
     /// Use this when the parser observed a `repository { owner { login }
     /// name }` subfield set on the related-issue node (e.g. a
-    /// `trackedByIssues` blocker) and the relation must be
+    /// `Issue.blockedBy` blocker) and the relation must be
     /// disambiguated from a same-number same-repo relation.
     ///
     /// For a relation where `owner` / `name` are absent and the "same

--- a/crates/unblock-github/src/api.rs
+++ b/crates/unblock-github/src/api.rs
@@ -294,7 +294,7 @@ pub trait GitHubApi: Send + Sync {
     /// For `Local` blockers this delegates to
     /// [`remove_blocked_by`](Self::remove_blocked_by); for cross-repo
     /// blockers it resolves each side independently and runs the
-    /// `removeIssueDependency` mutation directly with both node IDs.
+    /// `removeBlockedBy` mutation directly with both node IDs.
     ///
     /// See spec §5.6 (cross-repo scope) and §8.5 (`dep_remove`).
     async fn remove_blocked_by_ref(
@@ -311,8 +311,8 @@ pub trait GitHubApi: Send + Sync {
     /// when the source is `Local` this delegates to
     /// [`remove_blocked_by_ref`](Self::remove_blocked_by_ref) to preserve
     /// the local-source fast path. Cross-repo sources resolve both sides
-    /// independently and run the `removeIssueDependency` mutation with
-    /// both node IDs.
+    /// independently and run the `removeBlockedBy` mutation with both
+    /// node IDs.
     ///
     /// See spec §8.5 (`dep_remove` tool contract) and §5.6 cross-repo
     /// scope table.

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -18,8 +18,18 @@ use crate::errors::{self, Error};
 
 /// GraphQL query for fetching a single issue with full details.
 ///
-/// Includes: all standard fields, comments (first 50), blockedBy, blocking,
-/// parent, subIssues, and Projects V2 field values.
+/// Includes: all standard fields, comments (first 50), `blockedBy`,
+/// `blocking`, `parent`, `subIssues`, and Projects V2 field values.
+///
+/// SAFETY: matches GitHub's public GraphQL schema as of 2026-04-30. The
+/// `blockedBy` / `blocking` connections are GA on `Issue`, return
+/// `IssueConnection!`, and require no `GraphQL-Features` preview header
+/// (verified via live introspection against `api.github.com/graphql`).
+/// `blockedBy` enumerates issues that block the current issue (= our
+/// `blocked_by`); `blocking` enumerates issues the current issue blocks
+/// (= our `blocking`). The `repository { owner { login } name }`
+/// subselection on `blockedBy` is load-bearing for cross-repo blocker
+/// disambiguation in `dep_remove` (see `unblock-29p.43`); do not drop it.
 const FETCH_ISSUE_QUERY: &str = "
 query FetchIssue($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -54,14 +64,14 @@ query FetchIssue($owner: String!, $repo: String!, $number: Int!) {
           createdAt
         }
       }
-      trackedInIssues(first: 50) {
+      blocking(first: 50) {
         nodes {
           number
           title
           state
         }
       }
-      trackedBy: trackedByIssues(first: 50) {
+      blockedBy(first: 50) {
         nodes {
           number
           title
@@ -118,10 +128,21 @@ query FetchIssue($owner: String!, $repo: String!, $number: Int!) {
 /// GraphQL query for fetching all issues (both `OPEN` and `CLOSED`)
 /// with pagination.
 ///
-/// Returns issues with standard fields, blocking relationships (via
-/// `trackedByIssues`), and Projects V2 field values. Does **not** include
-/// comments, parent, sub-issues, or `trackedInIssues` — those are only
-/// fetched by [`FETCH_ISSUE_QUERY`] for single-issue detail views.
+/// Returns issues with standard fields, blocking relationships (via the
+/// `blockedBy` connection — see SAFETY note below), and Projects V2 field
+/// values. Does **not** include comments, parent, sub-issues, or the
+/// `blocking` connection — those are only fetched by [`FETCH_ISSUE_QUERY`]
+/// for single-issue detail views.
+///
+/// SAFETY: matches GitHub's public GraphQL schema as of 2026-04-30. The
+/// `blockedBy` connection is GA on `Issue`, returns `IssueConnection!`,
+/// and requires no `GraphQL-Features` preview header (verified via live
+/// introspection against `api.github.com/graphql`). The number-only node
+/// projection here is sufficient for [`extract_blocking_edges`] which
+/// only consumes `number`; per-blocker `repository { ... }` is intentionally
+/// omitted because graph edges in this query are scoped to the configured
+/// repo (cross-repo identity is reconstructed by the orchestrator from the
+/// configured `(owner, repo)` per [`BlockingEdge`]).
 ///
 /// Uses cursor-based pagination on the `issues` connection (`first: 100`,
 /// `after: $cursor`). The caller must loop until `pageInfo.hasNextPage` is
@@ -166,7 +187,7 @@ query FetchGraphData($owner: String!, $repo: String!, $cursor: String) {
             login
           }
         }
-        trackedBy: trackedByIssues(first: 50) {
+        blockedBy(first: 50) {
           nodes {
             number
           }
@@ -315,8 +336,8 @@ impl GitHubClient {
     ///   (`compute_ready_set` continues to exclude closed issues,
     ///   `compute_unblock_cascade` keys on `issue_state`, etc.).
     /// - `edges` contains [`BlockingEdge`] entries extracted from GitHub's
-    ///   `trackedByIssues` relationship, where `source` is the blocked issue
-    ///   and `target` is the blocker.
+    ///   `blockedBy` connection (schema as of 2026-04-30), where `source`
+    ///   is the blocked issue and `target` is the blocker.
     ///
     /// Paginates using GraphQL cursor pagination (100 issues per page) until
     /// every issue is fetched. Returns empty vectors for a repo with no
@@ -351,7 +372,9 @@ impl GitHubClient {
                 .and_then(serde_json::Value::as_array)
             {
                 for node in nodes {
-                    // Extract blocking edges from trackedByIssues.
+                    // Extract blocking edges from the `blockedBy` connection
+                    // (per FETCH_GRAPH_DATA_QUERY SAFETY note — schema as of
+                    // 2026-04-30).
                     all_edges.extend(extract_blocking_edges(node, self.owner(), self.repo()));
 
                     // Parse issue with graph-specific parser (omits comments,
@@ -659,8 +682,13 @@ fn parse_issue(value: &serde_json::Value, owner: &str, repo: &str) -> Issue {
     let assignees = parse_string_nodes(value, "assignees", "login");
 
     let comments = parse_comments(value);
-    let blocked_by = parse_related_issues(value, "trackedBy");
-    let blocking = parse_related_issues(value, "trackedInIssues");
+    // Response keys match the GraphQL field names selected by
+    // FETCH_ISSUE_QUERY. `blockedBy` carries cross-repo identity via the
+    // nested `repository { owner { login } name }` subselection; `blocking`
+    // omits it (intra-repo only on the read path) — consistent with the
+    // SAFETY note on FETCH_ISSUE_QUERY (schema as of 2026-04-30).
+    let blocked_by = parse_related_issues(value, "blockedBy");
+    let blocking = parse_related_issues(value, "blocking");
     let parent = parse_parent_issue(value);
     let sub_issues = parse_related_issues(value, "subIssues");
 
@@ -783,22 +811,23 @@ fn parse_graph_issue(value: &serde_json::Value, owner: &str, repo: &str) -> Issu
 
 /// Extracts [`BlockingEdge`] entries from a single issue JSON node.
 ///
-/// Reads the `trackedBy` (alias for `trackedByIssues`) connection and creates
-/// one edge per blocker. Each edge has `source` = the blocked issue's
-/// [`QualifiedId`] and `target` = the blocker's [`QualifiedId`]. Skips entries
-/// with a zero issue number.
+/// Reads the `blockedBy` connection (per `FETCH_GRAPH_DATA_QUERY` SAFETY
+/// note, schema as of 2026-04-30) and creates one edge per blocker. Each
+/// edge has `source` = the blocked issue's [`QualifiedId`] and `target` =
+/// the blocker's [`QualifiedId`]. Skips entries with a zero issue number.
 ///
-/// Currently all edges are within the same `owner/repo` because GitHub's
-/// `trackedByIssues` connection only returns issues in the same repository.
-/// Cross-repo blockers (added via the `depends` MCP tool) will produce edges
-/// with different `owner/repo` prefixes once the GraphQL query is extended.
+/// Currently all edges are within the same `owner/repo` because the bulk
+/// graph query selects only `number` on each `blockedBy` node. Cross-repo
+/// blockers (added via the `depends` MCP tool) will produce edges with
+/// different `owner/repo` prefixes once the bulk query is extended to
+/// select per-blocker `repository { ... }`.
 fn extract_blocking_edges(node: &serde_json::Value, owner: &str, repo: &str) -> Vec<BlockingEdge> {
     let issue_number = json_u64(node, "number");
     let source_qid = unblock_core::types::QualifiedId::new(owner, repo, issue_number);
     let mut edges = Vec::new();
 
     if let Some(blockers) = node
-        .get("trackedBy")
+        .get("blockedBy")
         .and_then(|v| v.get("nodes"))
         .and_then(|v| v.as_array())
     {
@@ -894,26 +923,25 @@ fn parse_comments(value: &serde_json::Value) -> Vec<IssueComment> {
         .unwrap_or_default()
 }
 
-/// Parses a related-issues connection (blockedBy, blocking, subIssues) into
-/// [`RelatedIssue`] instances.
+/// Parses a related-issues connection (`blockedBy`, `blocking`,
+/// `subIssues`) into [`RelatedIssue`] instances.
 ///
 /// When an individual node carries a complete `repository { owner { login }
 /// name }` subfield set, those values populate the resulting
 /// [`RelatedIssue::repo_owner`] / [`RelatedIssue::repo_name`] via
-/// [`RelatedIssue::cross_repo`]. The `trackedByIssues` connection inside
+/// [`RelatedIssue::cross_repo`]. The `blockedBy` connection inside
 /// [`FETCH_ISSUE_QUERY`] selects those fields so blocker edges can
 /// disambiguate cross-repo blockers from same-repo blockers (required by
 /// `dep_remove` single-issue edge validation on cross-repo paths — see
 /// `unblock-29p.43`).
 ///
 /// Connections that omit the `repository` selection (e.g. `subIssues`,
-/// `trackedInIssues`, `parent`) and nodes whose `repository` subfield is
-/// partial (only `owner` or only `name` present — a malformed GraphQL
-/// response) route through [`RelatedIssue::local`], leaving both repo
-/// identity fields `None`. A partial subfield cannot disambiguate a
-/// cross-repo reference (identification requires the full `(owner, name)`
-/// pair) so treating it as "no identity" is the semantically coherent
-/// fallback.
+/// `blocking`, `parent`) and nodes whose `repository` subfield is partial
+/// (only `owner` or only `name` present — a malformed GraphQL response)
+/// route through [`RelatedIssue::local`], leaving both repo identity
+/// fields `None`. A partial subfield cannot disambiguate a cross-repo
+/// reference (identification requires the full `(owner, name)` pair) so
+/// treating it as "no identity" is the semantically coherent fallback.
 fn parse_related_issues(value: &serde_json::Value, key: &str) -> Vec<RelatedIssue> {
     value
         .get(key)
@@ -1313,14 +1341,14 @@ mod tests {
     #[test]
     fn parse_blocked_by_issues() {
         let v = serde_json::json!({
-            "trackedInIssues": {
+            "blockedBy": {
                 "nodes": [
                     {"number": 5, "title": "Blocker", "state": "OPEN"},
                     {"number": 10, "title": "Other blocker", "state": "CLOSED"}
                 ]
             }
         });
-        let related = parse_related_issues(&v, "trackedInIssues");
+        let related = parse_related_issues(&v, "blockedBy");
         assert_eq!(related.len(), 2);
         assert_eq!(related[0].number, 5);
         assert_eq!(related[0].state, IssueState::Open);
@@ -1625,18 +1653,18 @@ mod tests {
                     "createdAt": "2026-01-01T12:00:00Z"
                 }]
             },
-            "trackedInIssues": {
+            "blocking": {
                 "nodes": [
                     {"number": 20, "title": "Blocks me", "state": "OPEN"}
                 ]
             },
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [
                     {
                         "number": 10,
                         "title": "Dep A",
                         "state": "OPEN",
-                        // `FETCH_ISSUE_QUERY` trackedBy subselection
+                        // `FETCH_ISSUE_QUERY` blockedBy subselection
                         // carries `repository { owner { login } name }`
                         // so blockers can be disambiguated as same-repo
                         // or cross-repo (see `unblock-29p.43`).
@@ -1684,24 +1712,25 @@ mod tests {
 
         assert_eq!(issue.blocked_by.len(), 1);
         assert_eq!(issue.blocked_by[0].number, 10);
-        // Repo identity must propagate end-to-end from the trackedBy
+        // Repo identity must propagate end-to-end from the blockedBy
         // subselection — load-bearing for cross-repo dep_remove edge
         // validation (see `unblock-29p.43`).
         assert_eq!(
             issue.blocked_by[0].repo_owner.as_deref(),
             Some("test-owner"),
-            "trackedBy blocker must carry repository.owner.login"
+            "blockedBy blocker must carry repository.owner.login"
         );
         assert_eq!(
             issue.blocked_by[0].repo_name.as_deref(),
             Some("test-repo"),
-            "trackedBy blocker must carry repository.name"
+            "blockedBy blocker must carry repository.name"
         );
 
         assert_eq!(issue.blocking.len(), 1);
         assert_eq!(issue.blocking[0].number, 20);
-        // trackedInIssues does NOT request the `repository` subselection
-        // — repo identity stays `None` (same-repo by convention).
+        // The `blocking` connection does NOT request the `repository`
+        // subselection — repo identity stays `None` (same-repo by
+        // convention).
         assert!(issue.blocking[0].repo_owner.is_none());
         assert!(issue.blocking[0].repo_name.is_none());
 
@@ -1726,8 +1755,8 @@ mod tests {
             "milestone": null,
             "assignees": {"nodes": []},
             "comments": {"nodes": []},
-            "trackedInIssues": {"nodes": []},
-            "trackedBy": {"nodes": []},
+            "blocking": {"nodes": []},
+            "blockedBy": {"nodes": []},
             "parent": null,
             "subIssues": {"nodes": []}
         });
@@ -1746,13 +1775,13 @@ mod tests {
 
     // ── parse_related_issues + repo identity (unblock-29p.43) ───────────
 
-    /// `FETCH_ISSUE_QUERY` trackedBy emits `repository { owner { login }
+    /// `FETCH_ISSUE_QUERY` `blockedBy` emits `repository { owner { login }
     /// name }` so cross-repo blockers can be disambiguated. Verifies the
     /// parser round-trips those subfields into `RelatedIssue`.
     #[test]
     fn parse_related_issues_extracts_cross_repo_identity() {
         let json = serde_json::json!({
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [
                     {
                         "number": 99,
@@ -1766,7 +1795,7 @@ mod tests {
                 ]
             }
         });
-        let blockers = parse_related_issues(&json, "trackedBy");
+        let blockers = parse_related_issues(&json, "blockedBy");
         assert_eq!(blockers.len(), 1);
         assert_eq!(blockers[0].number, 99);
         assert_eq!(blockers[0].repo_owner.as_deref(), Some("other-owner"));
@@ -1774,9 +1803,9 @@ mod tests {
     }
 
     /// Connections whose GraphQL selection omits `repository { ... }`
-    /// (e.g. `trackedInIssues`, `subIssues`, `parent`) must leave
-    /// `repo_owner` / `repo_name` as `None`. Callers treat `None` as
-    /// "same repo as the containing issue" per `RelatedIssue` docs.
+    /// (e.g. `blocking`, `subIssues`, `parent`) must leave `repo_owner` /
+    /// `repo_name` as `None`. Callers treat `None` as "same repo as the
+    /// containing issue" per `RelatedIssue` docs.
     #[test]
     fn parse_related_issues_without_repository_subfield_keeps_none() {
         let json = serde_json::json!({
@@ -1809,7 +1838,7 @@ mod tests {
     #[test]
     fn parse_related_issues_partial_repository_normalises_to_local() {
         let json = serde_json::json!({
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [
                     {
                         "number": 11,
@@ -1826,7 +1855,7 @@ mod tests {
                 ]
             }
         });
-        let blockers = parse_related_issues(&json, "trackedBy");
+        let blockers = parse_related_issues(&json, "blockedBy");
         assert_eq!(blockers.len(), 2);
         assert!(blockers[0].repo_owner.is_none());
         assert!(blockers[0].repo_name.is_none());
@@ -1850,7 +1879,7 @@ mod tests {
             "labels": {"nodes": [{"name": "bug"}]},
             "milestone": {"title": "v1.0"},
             "assignees": {"nodes": [{"login": "alice"}]},
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [{"number": 10}]
             },
             "projectItems": {
@@ -1917,7 +1946,7 @@ mod tests {
             "labels": {"nodes": []},
             "milestone": null,
             "assignees": {"nodes": []},
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [{"number": 5}, {"number": 10}]
             }
         });
@@ -1994,8 +2023,8 @@ mod tests {
             "milestone": null,
             "assignees": {"nodes": []},
             "comments": {"nodes": []},
-            "trackedInIssues": {"nodes": []},
-            "trackedBy": {"nodes": []},
+            "blocking": {"nodes": []},
+            "blockedBy": {"nodes": []},
             "parent": null,
             "subIssues": {"nodes": []},
             "projectItems": {
@@ -2079,7 +2108,7 @@ mod tests {
     fn blocking_edge_direction_source_blocked_by_target() {
         let node = serde_json::json!({
             "number": 42,
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [
                     {"number": 10},
                     {"number": 20}
@@ -2101,7 +2130,7 @@ mod tests {
     fn blocking_edge_skips_zero_number() {
         let node = serde_json::json!({
             "number": 42,
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": [
                     {"number": 0},
                     {"number": 5}
@@ -2116,10 +2145,10 @@ mod tests {
     }
 
     #[test]
-    fn blocking_edge_empty_tracked_by_yields_no_edges() {
+    fn blocking_edge_empty_blocked_by_yields_no_edges() {
         let node = serde_json::json!({
             "number": 42,
-            "trackedBy": {
+            "blockedBy": {
                 "nodes": []
             }
         });
@@ -2129,7 +2158,7 @@ mod tests {
     }
 
     #[test]
-    fn blocking_edge_missing_tracked_by_yields_no_edges() {
+    fn blocking_edge_missing_blocked_by_yields_no_edges() {
         let node = serde_json::json!({
             "number": 42
         });
@@ -2144,7 +2173,7 @@ mod tests {
     ///
     /// Each issue node has the minimal fields required by `parse_graph_issue`:
     /// number, id, title, body, state, url, createdAt, updatedAt, labels,
-    /// milestone, assignees, and optionally trackedBy edges.
+    /// milestone, assignees, and optionally `blockedBy` edges.
     fn make_page_response(
         issues: &[(u64, &str, Vec<u64>)],
         has_next_page: bool,
@@ -2153,7 +2182,7 @@ mod tests {
         let nodes: Vec<serde_json::Value> = issues
             .iter()
             .map(|(number, title, blockers)| {
-                let tracked_by_nodes: Vec<serde_json::Value> = blockers
+                let blocked_by_nodes: Vec<serde_json::Value> = blockers
                     .iter()
                     .map(|n| serde_json::json!({"number": n}))
                     .collect();
@@ -2169,7 +2198,7 @@ mod tests {
                     "labels": {"nodes": []},
                     "milestone": null,
                     "assignees": {"nodes": []},
-                    "trackedBy": {"nodes": tracked_by_nodes}
+                    "blockedBy": {"nodes": blocked_by_nodes}
                 })
             })
             .collect();
@@ -2346,7 +2375,7 @@ mod tests {
         let nodes: Vec<serde_json::Value> = issues
             .iter()
             .map(|(number, title, state, blockers)| {
-                let tracked_by_nodes: Vec<serde_json::Value> = blockers
+                let blocked_by_nodes: Vec<serde_json::Value> = blockers
                     .iter()
                     .map(|n| serde_json::json!({"number": n}))
                     .collect();
@@ -2362,7 +2391,7 @@ mod tests {
                     "labels": {"nodes": []},
                     "milestone": null,
                     "assignees": {"nodes": []},
-                    "trackedBy": {"nodes": tracked_by_nodes}
+                    "blockedBy": {"nodes": blocked_by_nodes}
                 })
             })
             .collect();

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -857,7 +857,7 @@ impl GitHubClient {
         Ok(node_id)
     }
 
-    /// Executes the GraphQL `addIssueDependency` mutation.
+    /// Executes the GraphQL `addBlockedBy` mutation.
     ///
     /// Single chokepoint behind every public `add_blocked_by*` entry point in
     /// this file: the local-only [`add_blocked_by()`](Self::add_blocked_by),
@@ -869,9 +869,24 @@ impl GitHubClient {
     /// [`resolve_issue_ref()`](Self::resolve_issue_ref), or
     /// [`fetch_issue_ref()`](Self::fetch_issue_ref)) and feeds them here; the
     /// (`owner`, `repo`) chokepoint is enforced by the resolver layer, not by
-    /// this raw mutation primitive (the `addIssueDependency` mutation itself
-    /// operates on globally-scoped Projects V2 issue node IDs and does not
-    /// take an owner/repo).
+    /// this raw mutation primitive (the `addBlockedBy` mutation itself
+    /// operates on globally-scoped issue node IDs and does not take an
+    /// owner/repo).
+    ///
+    /// SAFETY: matches GitHub's public GraphQL schema as of 2026-04-30.
+    /// `Mutation.addBlockedBy` takes `AddBlockedByInput { issueId,
+    /// blockingIssueId, clientMutationId }` and returns `AddBlockedByPayload
+    /// { issue, blockingIssue, clientMutationId }`. The legacy mutation
+    /// name `addIssueDependency` (with `dependentId` / `dependencyId`
+    /// inputs) does NOT exist on the live schema (verified via live
+    /// introspection against `api.github.com/graphql`); it was renamed in
+    /// the same wave that replaced `Issue.trackedByIssues` with
+    /// `Issue.blockedBy`. See bead `unblock-741` for the post-mortem.
+    ///
+    /// Parameter naming preserved internally as `dependent_id` / `dependency_id`
+    /// to minimise call-site churn — semantically `dependent_id` IS the
+    /// `issueId` (the blocked / dependent issue) and `dependency_id` IS the
+    /// `blockingIssueId` (the blocker).
     ///
     /// Pure transport — no validation, no duplicate pre-check, no telemetry
     /// beyond what [`graphql()`](Self::graphql) emits internally. Caller-side
@@ -883,23 +898,23 @@ impl GitHubClient {
         dependency_id: &str,
     ) -> Result<(), Error> {
         let mutation = "
-            mutation AddBlockedBy($dependentId: ID!, $dependencyId: ID!) {
-                addIssueDependency(input: {dependentId: $dependentId, dependencyId: $dependencyId}) {
+            mutation AddBlockedBy($issueId: ID!, $blockingIssueId: ID!) {
+                addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
                     clientMutationId
                 }
             }
         ";
 
         let variables = serde_json::json!({
-            "dependentId": dependent_id,
-            "dependencyId": dependency_id,
+            "issueId": dependent_id,
+            "blockingIssueId": dependency_id,
         });
 
         self.graphql(mutation, variables).await?;
         Ok(())
     }
 
-    /// Executes the GraphQL `removeIssueDependency` mutation.
+    /// Executes the GraphQL `removeBlockedBy` mutation.
     ///
     /// Symmetric counterpart of
     /// [`add_issue_dependency_raw()`](Self::add_issue_dependency_raw).
@@ -915,9 +930,14 @@ impl GitHubClient {
     /// [`resolve_issue_ref()`](Self::resolve_issue_ref)) and feeds them
     /// here; the (`owner`, `repo`) chokepoint is enforced by the
     /// resolver layer, not by this raw mutation primitive (the
-    /// `removeIssueDependency` mutation itself operates on globally-
-    /// scoped Projects V2 issue node IDs and does not take an
-    /// owner/repo).
+    /// `removeBlockedBy` mutation itself operates on globally-scoped
+    /// issue node IDs and does not take an owner/repo).
+    ///
+    /// SAFETY: matches GitHub's public GraphQL schema as of 2026-04-30.
+    /// `Mutation.removeBlockedBy` takes `RemoveBlockedByInput { issueId,
+    /// blockingIssueId, clientMutationId }`. The legacy mutation name
+    /// `removeIssueDependency` does NOT exist on the live schema; same
+    /// rename wave as `addBlockedBy` (see bead `unblock-741`).
     ///
     /// Pure transport — no validation, no edge-existence pre-check, no
     /// telemetry beyond what [`graphql()`](Self::graphql) emits
@@ -930,16 +950,16 @@ impl GitHubClient {
         dependency_id: &str,
     ) -> Result<(), Error> {
         let mutation = "
-            mutation RemoveBlockedBy($dependentId: ID!, $dependencyId: ID!) {
-                removeIssueDependency(input: {dependentId: $dependentId, dependencyId: $dependencyId}) {
+            mutation RemoveBlockedBy($issueId: ID!, $blockingIssueId: ID!) {
+                removeBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
                     clientMutationId
                 }
             }
         ";
 
         let variables = serde_json::json!({
-            "dependentId": dependent_id,
-            "dependencyId": dependency_id,
+            "issueId": dependent_id,
+            "blockingIssueId": dependency_id,
         });
 
         self.graphql(mutation, variables).await?;
@@ -951,8 +971,9 @@ impl GitHubClient {
     /// After this call, `issue_number` is blocked by `blocked_by_number`.
     /// Both issue numbers are resolved to GraphQL node IDs internally.
     ///
-    /// Uses the GitHub GraphQL `addIssueDependency` mutation with
-    /// `dependentId` (the blocked issue) and `dependencyId` (the blocker).
+    /// Uses the GitHub GraphQL `addBlockedBy` mutation (schema as of
+    /// 2026-04-30) with `issueId` (the blocked issue) and
+    /// `blockingIssueId` (the blocker).
     ///
     /// **Note:** Cycle detection is **not** performed here — it is the
     /// responsibility of the MCP tool handler layer (see bead 1.4.9).
@@ -1015,7 +1036,8 @@ impl GitHubClient {
     /// `blocked_by_number`. Both issue numbers are resolved to GraphQL node
     /// IDs internally.
     ///
-    /// Uses the GitHub GraphQL `removeIssueDependency` mutation.
+    /// Uses the GitHub GraphQL `removeBlockedBy` mutation (schema as of
+    /// 2026-04-30).
     ///
     /// # Errors
     ///
@@ -1441,7 +1463,7 @@ impl GitHubClient {
     ///
     /// For local refs, delegates to [`add_blocked_by()`](Self::add_blocked_by).
     /// For cross-repo refs, resolves the blocker's node ID via the target repo
-    /// and calls `addIssueDependency` directly.
+    /// and calls `addBlockedBy` directly.
     ///
     /// [`IssueRef`]: unblock_core::types::IssueRef
     ///
@@ -1495,7 +1517,7 @@ impl GitHubClient {
     ///   owner/repo, performs the duplicate pre-check against its
     ///   `blocked_by` list, resolves the blocker via
     ///   [`resolve_issue_ref()`](Self::resolve_issue_ref), and runs the
-    ///   `addIssueDependency` mutation with both node IDs.
+    ///   `addBlockedBy` mutation with both node IDs.
     ///
     /// The duplicate pre-check has a TOCTOU race like
     /// [`add_blocked_by()`](Self::add_blocked_by) — acceptable for the
@@ -1537,11 +1559,11 @@ impl GitHubClient {
                 // duplicate pre-check in a single round-trip.
                 let source_issue = self.fetch_issue_ref(source).await?;
 
-                // Duplicate pre-check: GitHub's `trackedByIssues` connection
-                // only surfaces blockers within the same `owner/repo` as the
-                // source issue. Therefore the `blocked_by` list on a
-                // cross-repo source contains only entries in the source's
-                // own repo.
+                // Duplicate pre-check: GitHub's `Issue.blockedBy` connection
+                // (schema as of 2026-04-30) only surfaces blockers within the
+                // same `owner/repo` as the source issue. Therefore the
+                // `blocked_by` list on a cross-repo source contains only
+                // entries in the source's own repo.
                 //
                 // So a duplicate match only exists when the blocker resolves
                 // to the same `owner/repo` as the source. For any other
@@ -1600,8 +1622,7 @@ impl GitHubClient {
     /// this delegates to [`remove_blocked_by()`](Self::remove_blocked_by)
     /// so the existing local-number fast path is preserved. For cross-repo
     /// refs it resolves the blocker's node ID against the target repo and
-    /// runs the `removeIssueDependency` mutation directly with both node
-    /// IDs.
+    /// runs the `removeBlockedBy` mutation directly with both node IDs.
     ///
     /// See spec §5.6 (cross-repo scope) and §8.5 (`dep_remove`).
     ///
@@ -1657,13 +1678,13 @@ impl GitHubClient {
     ///   existing local-source fast path is preserved.
     /// - `source = CrossRepo { .. }` → resolves both the source and the
     ///   blocker via [`resolve_issue_ref()`](Self::resolve_issue_ref)
-    ///   against their own repositories and runs the
-    ///   `removeIssueDependency` mutation directly with both node IDs.
+    ///   against their own repositories and runs the `removeBlockedBy`
+    ///   mutation directly with both node IDs.
     ///
     /// Unlike [`add_blocked_by_refs()`](Self::add_blocked_by_refs) this
     /// method does not perform a client-side edge-existence pre-check:
-    /// GitHub's `removeIssueDependency` is idempotent with respect to
-    /// missing edges (no error on a non-existent edge), so an optional
+    /// GitHub's `removeBlockedBy` is idempotent with respect to missing
+    /// edges (no error on a non-existent edge), so an optional
     /// pre-check here would only add a round-trip. The MCP tool layer
     /// may still perform a cache-based pre-check when both endpoints are
     /// local, purely to surface a more informative error to the caller.

--- a/crates/unblock-mcp/src/tools/claim.rs
+++ b/crates/unblock-mcp/src/tools/claim.rs
@@ -90,10 +90,11 @@ pub(crate) fn validate_claimable(
     //
     // Claim reads `candidate.blocked_by` from a single-issue fetch
     // (`fetch_issue` → `FETCH_ISSUE_QUERY`). Since unblock-29p.43 that
-    // query's `trackedBy` selection requests `repository { owner { login }
-    // name }`, so `RelatedIssue.repo_owner` / `repo_name` are populated
-    // whenever the blocker lives in a different repository than the
-    // claimed issue. Per the `RelatedIssue` repo-identity convention
+    // query's `blockedBy` selection (schema as of 2026-04-30) requests
+    // `repository { owner { login } name }`, so `RelatedIssue.repo_owner`
+    // / `repo_name` are populated whenever the blocker lives in a
+    // different repository than the claimed issue. Per the
+    // `RelatedIssue` repo-identity convention
     // (see `unblock_core::types::RelatedIssue` docs), `None` means
     // "same repo as the enclosing issue" and `Some` means the blocker's
     // own owner/repo — so we emit `IssueRef::CrossRepo` when both are

--- a/crates/unblock-mcp/src/tools/dep_remove.rs
+++ b/crates/unblock-mcp/src/tools/dep_remove.rs
@@ -41,12 +41,12 @@
 //!      Closed endpoints from absent nodes (no extra RTT).
 //!    - **Cold cache OR at least one endpoint cross-repo** — fetch the
 //!      source issue via [`GitHubApi::fetch_issue_ref`] (1 GraphQL RTT)
-//!      and inspect its `state` plus its `trackedByIssues` list. The
-//!      `FETCH_ISSUE_QUERY` trackedBy subselection carries both
-//!      `repository { owner { login } name }` and `state` (see
-//!      `graphql.rs`) so the Closed-endpoint check needs no second
-//!      round-trip regardless of whether the source or the target is
-//!      the Closed side.
+//!      and inspect its `state` plus its `blockedBy` list (per the
+//!      `FETCH_ISSUE_QUERY` SAFETY note in `graphql.rs`, schema as of
+//!      2026-04-30). The `blockedBy` subselection carries both
+//!      `repository { owner { login } name }` and `state` so the
+//!      Closed-endpoint check needs no second round-trip regardless of
+//!      whether the source or the target is the Closed side.
 //! 4. Call [`GitHubApi::remove_blocked_by_refs`] inside
 //!    `execute_write_tool` so the mutation is followed by an atomic
 //!    cache invalidate + rebuild. Only reached when the edge was
@@ -339,11 +339,11 @@ async fn guard_edge_exists(
 /// Single-issue edge-existence probe used by the cold-cache and cross-
 /// repo paths: call [`GitHubApi::fetch_issue_ref`] on `source_ref` and
 /// inspect its state plus its `blocked_by` list for a blocker matching
-/// `target_qid`. The `FETCH_ISSUE_QUERY` trackedBy subselection carries
-/// both `repository { owner { login } name }` (for cross-repo blocker
-/// disambiguation, see `unblock-29p.43`) and `state` (for the
-/// Closed-endpoint check added by bead `unblock-a36`) so no extra
-/// round-trip is needed to classify either endpoint.
+/// `target_qid`. The `FETCH_ISSUE_QUERY` `blockedBy` subselection
+/// (schema as of 2026-04-30) carries both `repository { owner { login }
+/// name }` (for cross-repo blocker disambiguation, see `unblock-29p.43`)
+/// and `state` (for the Closed-endpoint check added by bead `unblock-a36`)
+/// so no extra round-trip is needed to classify either endpoint.
 ///
 /// Returns:
 /// - `Ok(EdgePresence::Present)` — edge confirmed present; caller
@@ -403,7 +403,7 @@ async fn probe_edge_via_fetch(
                 issue_number = blocker.number,
                 enclosing_owner = %enclosing_repo.0,
                 enclosing_repo = %enclosing_repo.1,
-                "trackedBy entry missing repo identity — applying None-means-same-repo convention"
+                "blockedBy entry missing repo identity — applying None-means-same-repo convention"
             );
         }
         let owner = blocker
@@ -420,7 +420,7 @@ async fn probe_edge_via_fetch(
     match matched_target {
         Some(blocker) if blocker.state == IssueState::Closed => {
             // Closed-target signal (SPEC §8.5 / bead unblock-a36). The
-            // edge DOES still exist in GitHub's trackedBy projection (a
+            // edge DOES still exist in GitHub's blockedBy projection (a
             // Closed issue can legitimately appear in `blocked_by` when
             // the dependency was never cleaned up) but we refuse the
             // mutation so the caller reopens the target or accepts the
@@ -696,7 +696,7 @@ pub async fn handle_dep_remove(
     // the wire; `EndpointClosed(qid)` produces
     // `DomainError::EndpointClosed` (HTTP 409 → MCP INVALID_PARAMS)
     // naming the Closed endpoint. The cold/cross-repo probe uses
-    // `fetch_issue_ref` on the source and scans its trackedBy list
+    // `fetch_issue_ref` on the source and scans its blockedBy list
     // for the target; the query carries repository identity per
     // unblock-29p.43 AND per-entry `state` for the Closed-endpoint
     // check (see `FETCH_ISSUE_QUERY` in graphql.rs).

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -3564,7 +3564,7 @@ async fn dep_remove_cross_repo_reports_false_when_edge_never_existed() {
 /// Scenario:
 /// - MCP client is configured for `acme/widgets` (via `new_mock()`).
 /// - `dep_remove` source is a CROSS-REPO issue: `otherowner/otherrepo#42`.
-/// - The source carries a single trackedBy blocker whose `repo_owner`
+/// - The source carries a single blockedBy blocker whose `repo_owner`
 ///   / `repo_name` are both `None` — i.e. the GraphQL response did NOT
 ///   emit an explicit `repository { owner { login } name }` subselection
 ///   for that node (same-repo default in the GitHub API).
@@ -3955,9 +3955,10 @@ async fn dep_remove_cold_cache_cross_repo_source_closed_surfaces_endpoint_closed
 /// Armadilha (trap-test) guarding the `claim.rs` blocker-mapping fix
 /// for cross-repo blockers carried by `RelatedIssue`.
 ///
-/// Since unblock-29p.43, `FETCH_ISSUE_QUERY.trackedBy` includes
-/// `repository { owner { login } name }` and the parser populates
-/// `RelatedIssue.repo_owner` / `repo_name`. unblock-29p.55 rewrites
+/// Since unblock-29p.43, `FETCH_ISSUE_QUERY.blockedBy` (schema as of
+/// 2026-04-30) includes `repository { owner { login } name }` and the
+/// parser populates `RelatedIssue.repo_owner` / `repo_name`.
+/// unblock-29p.55 rewrites
 /// `validate_claimable`'s blocker loop to emit `IssueRef::CrossRepo`
 /// when both are `Some`, instead of always aliasing to
 /// `IssueRef::Local(r.number)`.
@@ -3988,7 +3989,7 @@ async fn claim_surfaces_cross_repo_blocker_with_repo_identity() {
     // Build a fixture issue in the configured repo (acme/widgets)
     // whose open blocker lives in other/upstream — the GraphQL
     // parser would populate `repo_owner` / `repo_name` on this
-    // exact shape when FETCH_ISSUE_QUERY returns a trackedBy node
+    // exact shape when FETCH_ISSUE_QUERY returns a blockedBy node
     // with a `repository { owner { login } name }` subselection
     // (see graphql.rs:62-74 + parse_related_issues at
     // graphql.rs:888). We reuse the existing `cross_repo_blocker`
@@ -4325,7 +4326,7 @@ async fn create_issue_with_blocked_by_cross_repo() {
 
     // Build a CrossRepo IssueRef pointing at the blocker in the same repo.
     // This exercises the full cross-repo GraphQL resolution code path
-    // (resolve_issue_ref with owner/repo/number query → addIssueDependency).
+    // (resolve_issue_ref with owner/repo/number query → addBlockedBy).
     let cross_repo_ref = IssueRef::CrossRepo {
         owner: owner.clone(),
         repo: repo.clone(),

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -206,8 +206,8 @@ pub struct Issue {
     pub updated_at: DateTime<Utc>,
     pub url: String,
     pub comments: Vec<IssueComment>,
-    pub blocked_by: Vec<RelatedIssue>,          // from trackedByIssues
-    pub blocking: Vec<RelatedIssue>,            // from trackedIssues
+    pub blocked_by: Vec<RelatedIssue>,          // from Issue.blockedBy
+    pub blocking: Vec<RelatedIssue>,            // from Issue.blocking
     pub parent: Option<RelatedIssue>,
     pub sub_issues: Vec<RelatedIssue>,
 }
@@ -790,10 +790,10 @@ query($owner: String!, $repo: String!, $cursor: String) {
         milestone { number title }
         assignees(first: 5) { nodes { login } }
         issueType { name }
-        trackedByIssues(first: 50) {
+        blockedBy(first: 50) {
           nodes { number repository { owner { login } name } state }
         }
-        trackedIssues(first: 50) {
+        blocking(first: 50) {
           nodes { number repository { owner { login } name } state }
         }
         parent { number }
@@ -824,9 +824,11 @@ query($owner: String!, $repo: String!, $cursor: String) {
 }
 ```
 
-**Blocking edges:** extracted from `trackedByIssues` (what blocks this issue) and `trackedIssues` (what this issue blocks). Both traversed for complete edge set.
+**Blocking edges:** extracted from `Issue.blockedBy` (what blocks this issue) and `Issue.blocking` (what this issue blocks). Both traversed for complete edge set.
 
-**Cross-repo:** `trackedByIssues.nodes[].repository` may differ from queried repo. `QualifiedId` constructed from each node's repository context.
+**Schema anchor (matches GitHub public GraphQL schema as of 2026-04-30):** `Issue.blockedBy` and `Issue.blocking` are GA `IssueConnection!` fields (no `GraphQL-Features` preview header required — verified via live introspection against `api.github.com/graphql`). `Issue.blockedBy` enumerates issues that block the current issue; `Issue.blocking` enumerates issues the current issue blocks. The legacy field names `trackedByIssues` / `trackedIssues` previously referenced in this spec do NOT exist on `Issue` (HTTP 422 from the GraphQL endpoint); they were a documentation drift introduced in early phase work. See bead `unblock-741` for the post-mortem.
+
+**Cross-repo:** `blockedBy.nodes[].repository` may differ from queried repo. `QualifiedId` constructed from each node's repository context.
 
 **`fetch_issue(number)`** — single issue with full comments (first 50), blocking/blocked_by relationships, parent/sub-issues, Projects V2 field values. Always fresh, never cached.
 
@@ -837,11 +839,11 @@ query($owner: String!, $repo: String!, $cursor: String) {
 - `PATCH /repos/{o}/{r}/issues/{n}` — close (`state: "closed"`), reopen (`state: "open"`), update body/labels/assignees/milestone
 - `POST /repos/{o}/{r}/issues/{n}/comments` — add comment
 
-**GraphQL mutations:**
-- `addIssueDependency` — add blocking relationship (cross-repo)
-- `removeIssueDependency` — remove blocking relationship
-- `addSubIssue` — add parent-child relationship
-- `updateProjectV2ItemFieldValue` — update Projects V2 field
+**GraphQL mutations** (schema as of 2026-04-30; see §5.5 schema anchor — all four are GA on the public GraphQL API and require no `GraphQL-Features` preview header):
+- `addBlockedBy` — add blocking relationship (cross-repo). Input: `AddBlockedByInput { issueId, blockingIssueId, clientMutationId }`. Replaces the legacy `addIssueDependency` mutation referenced in earlier drafts of this spec.
+- `removeBlockedBy` — remove blocking relationship. Input: `RemoveBlockedByInput { issueId, blockingIssueId, clientMutationId }`. Replaces the legacy `removeIssueDependency`.
+- `addSubIssue` — add parent-child relationship.
+- `updateProjectV2ItemFieldValue` — update Projects V2 field.
 
 **Batch mutations:** Multiple `updateProjectV2ItemFieldValue` in a single GraphQL request using aliases (`update0`, `update1`, `update2`, ...).
 
@@ -1510,11 +1512,11 @@ branching is normative:
   cached nodes disambiguates Closed endpoints from absent nodes.
 - **Cold cache OR at least one endpoint cross-repo** — single-issue
   GraphQL probe. The probe issues exactly one `fetch_issue_ref` against
-  the source and inspects the returned `state` + `trackedByIssues`
-  list (`probe_edge_via_fetch`). The `trackedBy` subselection carries
-  both `repository { owner { login } name }` and `state`, so the
-  Closed-endpoint check needs no second round-trip regardless of which
-  side is Closed.
+  the source and inspects the returned `state` + `blockedBy` list
+  (`probe_edge_via_fetch`; schema as of 2026-04-30). The `blockedBy`
+  subselection carries both `repository { owner { login } name }` and
+  `state`, so the Closed-endpoint check needs no second round-trip
+  regardless of which side is Closed.
 
 The in-memory fast path is therefore scoped to warm-cache + both-Local
 inputs; all other combinations (cold cache, cross-repo source, cross-
@@ -1897,7 +1899,7 @@ Each variant has `status_code() → u16`:
 
 **Cross-repo-aware variant typing — Exhaustiveness Rationale (Decision 1, 2026-04-17).**
 
-`IssueBlocked.blockers`, `CircularDependency.{source, target}`, and `DuplicateDependency.{source, target}` use `IssueRef` (§2.7) rather than bare `u64`. GitHub's native sub-issue / `trackedByIssues` / `addIssueDependency` graph has been cross-repo-aware since GA in 2024: a cross-repo blocker, a cross-repo cycle participant, and a cross-repo duplicate-edge endpoint are all observable via the API and reachable from any configured repository. Bare `u64` cannot disambiguate `#42` in `configured/repo` from `#42` in `other/repo`; an error referring to the latter would silently alias to the former and mislead the agent. `IssueRef` is the unique fully-qualified-or-local carrier already used by §8.4 `depends`, §8.5 `dep_remove`, §8.3 `create.blocked_by`, and §11.4 `cross_repo_refs::omitted` — keeping §11.1 consistent with §11.4 is the closure property of the cross-repo contract. This is a BREAKING CHANGE in the `unblock-core` pub API (`DomainError` variant field types change); the implementing commit MUST carry a `BREAKING CHANGE:` footer per CLAUDE.md "Pub API Change Tracking" discipline. This rationale closes the question: no further sub-beads are needed for per-variant re-evaluation; new `DomainError` variants that carry issue references MUST default to `IssueRef` typing by the same argument.
+`IssueBlocked.blockers`, `CircularDependency.{source, target}`, and `DuplicateDependency.{source, target}` use `IssueRef` (§2.7) rather than bare `u64`. GitHub's native sub-issue / `blockedBy` / `addIssueDependency` graph has been cross-repo-aware since GA in 2024 (schema anchor — see §5.5): a cross-repo blocker, a cross-repo cycle participant, and a cross-repo duplicate-edge endpoint are all observable via the API and reachable from any configured repository. Bare `u64` cannot disambiguate `#42` in `configured/repo` from `#42` in `other/repo`; an error referring to the latter would silently alias to the former and mislead the agent. `IssueRef` is the unique fully-qualified-or-local carrier already used by §8.4 `depends`, §8.5 `dep_remove`, §8.3 `create.blocked_by`, and §11.4 `cross_repo_refs::omitted` — keeping §11.1 consistent with §11.4 is the closure property of the cross-repo contract. This is a BREAKING CHANGE in the `unblock-core` pub API (`DomainError` variant field types change); the implementing commit MUST carry a `BREAKING CHANGE:` footer per CLAUDE.md "Pub API Change Tracking" discipline. This rationale closes the question: no further sub-beads are needed for per-variant re-evaluation; new `DomainError` variants that carry issue references MUST default to `IssueRef` typing by the same argument.
 
 **Display byte-for-byte preservation (local-only case).**
 
@@ -2030,7 +2032,7 @@ Tools explicitly NOT affected (documented here to pre-empt retro-adoption questi
 
 The `cross_repo_refs: Option<CrossRepoRefs>` field is NOT a universal response contract; it applies to exactly the four tools listed in the affected-tools table above — `ready` (§7.1), `prime` (§7.3), `dep_cycles` (§7.7), `close` (§8.2) — and no others. The axiom that derives the affected set is §5.6 "Cross-repo scope": a tool qualifies iff (a) its response projects node identity down to a bare `u64` AND (b) §5.6 permits cross-repo traversal to touch nodes that would be flattened by that projection. The exempt tools listed above each fail at least one leg of the conjunction for a structural reason documented in their row, not by accident of implementation:
 
-- `show` has bare-`u64` fields in the response projection — `ShowIssue.number` (`crates/unblock-mcp/src/tools/show.rs:73`) and `ShowRelatedIssue.number` (`crates/unblock-mcp/src/tools/show.rs:131`) are `u64`, so leg (a) holds. The exemption is on leg (b): per §5.6 "Cross-repo scope", `show`'s traversal (sub-issues + `trackedByIssues`) is scoped to the configured repo, so no cross-repo node ever reaches the bare-`u64` projection.
+- `show` has bare-`u64` fields in the response projection — `ShowIssue.number` (`crates/unblock-mcp/src/tools/show.rs:73`) and `ShowRelatedIssue.number` (`crates/unblock-mcp/src/tools/show.rs:131`) are `u64`, so leg (a) holds. The exemption is on leg (b): per §5.6 "Cross-repo scope", `show`'s traversal (sub-issues + `Issue.blockedBy`) is scoped to the configured repo, so no cross-repo node ever reaches the bare-`u64` projection.
 - `stats` emits no issue IDs at all, so (a) fails.
 - `list` / `search` / `claim` / `create` / `update` / `reopen` / `comment` / `init` / `setup` are scoped by §5.6 to the configured repo on the traversal side, so (b) fails.
 - `depends` / `dep_remove` round-trip `IssueRef` strings (never `u64`) on both request and response, so (a) fails.


### PR DESCRIPTION
## unblock-741: GraphQL query references non-existent field 'trackedByIssues' on Issue type

GitHub's public GraphQL schema does not expose `Issue.trackedByIssues`, `Issue.trackedInIssues` (in our intended sense), or the `Mutation.addIssueDependency` / `removeIssueDependency` mutations our code was calling. Live introspection on 2026-04-30 (`api.github.com/graphql`) confirms the canonical names and that all four are GA with no preview header required:

- `Issue.blockedBy` (`IssueConnection!`) — issues that block the current issue
- `Issue.blocking`  (`IssueConnection!`) — issues the current issue blocks
- `Mutation.addBlockedBy(input: AddBlockedByInput { issueId, blockingIssueId, … })`
- `Mutation.removeBlockedBy(input: RemoveBlockedByInput { issueId, blockingIssueId, … })`

This PR brings code, tests, docstrings, and the foundation spec onto the canonical names in a single coherent change.

### What was done
- Rewrote both GraphQL queries in `unblock-github/src/graphql.rs` to select `blockedBy`/`blocking`. Preserved the load-bearing `repository { owner { login } name }` subselection on `blockedBy` (cross-repo blocker disambiguation per unblock-29p.43).
- Rewrote the `addIssueDependency` / `removeIssueDependency` raw primitives to call `addBlockedBy` / `removeBlockedBy` with the renamed input fields. Internal Rust parameter names retained to minimise wrapper churn; semantic mapping documented inline.
- Updated 13 synthetic-JSON unit-test fixtures and the wiremock mock-page builders in `graphql.rs` to match the new response shape.
- Cascaded the field-name documentation update through `unblock-core` (types/errors/reconcile), `unblock-github` (api/mutations), and `unblock-mcp` (claim/dep_remove/tests). Each call site that materially documents the schema now carries a `schema as of 2026-04-30` anchor (per acceptance criteria).
- Amended `docs/specs/01-spec-mcp-foundation.md` §5.5 (schema anchor + post-mortem note) and §5.6 (mutation list rewrite). §11.1 / §11.4 narrative references retargeted from `trackedByIssues` to `Issue.blockedBy`.

### Files changed
- `crates/unblock-github/src/graphql.rs`
- `crates/unblock-github/src/mutations.rs`
- `crates/unblock-github/src/api.rs`
- `crates/unblock-core/src/types.rs`
- `crates/unblock-core/src/errors.rs`
- `crates/unblock-core/src/reconcile.rs`
- `crates/unblock-mcp/src/tools/claim.rs`
- `crates/unblock-mcp/src/tools/dep_remove.rs`
- `crates/unblock-mcp/tests/integration.rs`
- `docs/specs/01-spec-mcp-foundation.md`

### Decisions
- **Scope extension to mutation rename**: live introspection revealed that `Mutation.addIssueDependency` / `removeIssueDependency` also do not exist on the public schema (replaced by `addBlockedBy` / `removeBlockedBy`). 5 of the 14 acceptance-criteria tests fail on this surface, so fixing only the read path would have left them red. Investigation pre-authorized inspecting the mutation surface; this is the same GitHub schema-rename wave so atomic-PR coherence is preserved.

### Deviations
- **Introspection token**: user instructed to use `GITHUB_TOKEN_DEVELOPER` for the live introspection step. That token currently returns HTTP 401 Bad credentials (likely expired). Used `GITHUB_TOKEN` for the introspection only — schema introspection is read-only with no test-data side effects, so the token-mixing concern (test pollution) does not apply to this step.

### Test plan
- [x] `cargo fmt --check --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes (0 failures)
- [x] `cargo doc --no-deps --workspace` clean (the single pre-existing `unblock-resilience` rustdoc warning is unrelated)
- [x] Local live verification against `websublime/unblock`: 12 of the 14 listed live tests pass
- [ ] CI `Test MCP (live)` job green on this PR — final acceptance-criteria gate
- [ ] Confirm the 2 still-failing tests on local (`fetch_issue_returns_issue_not_found_for_nonexistent_number`, `remove_blocked_by_returns_issue_not_found_for_nonexistent_number`) reflect the pre-existing 422→404 GraphQL error mapping bug listed in `unblock-3lb`'s close-reason as a separate follow-up — they are NOT regressions introduced by this PR

### API
`unblock-github` GraphQL query field rename `trackedByIssues` → `blockedBy` and mutation rename `addIssueDependency` → `addBlockedBy` (per current schema). Internal query/mutation rename only — public Rust API surface unchanged.