### PR TITLE
unblock-aa2: auto-heal Status options + clean-state setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,14 @@ jobs:
       # per spec §13.2. `--all-features` is required so the `e2e_workflow`
       # test (which gates on `test-hooks` via Cargo `required-features`) is
       # included. See bead unblock-3lb rework decision W1.B.
-      - run: cargo tarpaulin -p unblock-core -p unblock-github -p unblock-mcp --all-features --out xml -- --ignored
+      #
+      # `--test-threads=1` serialises the live integration tests against
+      # the shared test project — multiple tests call `setup_fields` (and
+      # related Project mutations) against the same Projects V2 board, so
+      # parallel execution races on `createProjectV2Field` ('Name has
+      # already been taken') or stomps each other's option deletions. See
+      # bead unblock-aa2 — Risk 5 in the Sherlock investigation.
+      - run: cargo tarpaulin -p unblock-core -p unblock-github -p unblock-mcp --all-features --out xml -- --ignored --test-threads=1
       - uses: codecov/codecov-action@v4
         with:
           file: cobertura.xml

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ scripts/setup-test-project.sh <owner> <project-number>
 
 The script is idempotent: it lists the project's fields, deletes any that match the 6-name list, and exits 0 with no changes when the project is already clean. It does not touch the built-in Status field. Requires `gh` authenticated against the target owner with `project` + `repo` scopes, and `jq`.
 
+To assert the project is in the canonical clean state without mutating it (useful as a CI preflight or local sanity check), pass `--check`:
+
+```bash
+scripts/setup-test-project.sh --check <owner> <project-number>
+```
+
+`--check` (or its alias `--dry-run`) lists any stale unblock-managed custom fields and exits **non-zero (4)** when drift is present, exits 0 when the project is already clean. Re-run without `--check` to actually delete them.
+
 The live test job runs `cargo tarpaulin ... -- --ignored --test-threads=1` to serialise the `#[ignore]` integration tests. Without the serialisation guard, the two test files that both call `setup_fields` against the shared test project (`crates/unblock-github/tests/integration.rs::setup_fields_creates_all_seven_fields` and `crates/unblock-mcp/tests/e2e_workflow.rs::e2e_workflow_all_10_tools`) race and either the second mutation collides on `createProjectV2Field` (`Name has already been taken`) or one test deletes options the other still needs. Local runs of `cargo test --workspace -- --ignored` should pass `--test-threads=1` for the same reason.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ gh variable set UNBLOCK_TEST_PROJECT --body '<project-number>'
 
 The `coverage` job (mock-only) runs on every PR and the `test-mcp-live` job covers both live execution and live coverage in a single tarpaulin pass on first-party events. Codecov merges the two reports under the `mock` and `live` flags; the >80% target in spec §13.2 applies to combined coverage.
 
+### Clean-state contract for the test project
+
+The live test job mutates the GitHub Project pointed at by `UNBLOCK_TEST_PROJECT`. Two invariants govern its starting state on every run:
+
+1. **The 6 unblock-managed custom fields must NOT exist on the project.** They are: `Priority`, `PipelineStage`, `Agent`, `ClaimedAt`, `StoryPoints`, `DeferUntil`. The `setup_fields` flow creates them and the test asserts on the post-creation field IDs; a stale, half-configured set from a previous failed run breaks the assertion or trips a `Name has already been taken` collision under parallel test execution.
+2. **The built-in `Status` field is left in place.** GitHub Projects V2 forbids deleting the built-in Status field (`deleteProjectV2Field` returns `Only custom fields can be deleted`). `setup_fields` auto-heals the Status options to the spec's canonical set (`ready`, `in_progress`, `blocked`, `deferred`, `closed`) on every run by issuing `updateProjectV2Field` against the existing field id, so no manual surgery is required for Status.
+
+To bootstrap a fresh project (or recover from a partial run), run:
+
+```bash
+scripts/setup-test-project.sh <owner> <project-number>
+```
+
+The script is idempotent: it lists the project's fields, deletes any that match the 6-name list, and exits 0 with no changes when the project is already clean. It does not touch the built-in Status field. Requires `gh` authenticated against the target owner with `project` + `repo` scopes, and `jq`.
+
+The live test job runs `cargo tarpaulin ... -- --ignored --test-threads=1` to serialise the `#[ignore]` integration tests. Without the serialisation guard, the two test files that both call `setup_fields` against the shared test project (`crates/unblock-github/tests/integration.rs::setup_fields_creates_all_seven_fields` and `crates/unblock-mcp/tests/e2e_workflow.rs::e2e_workflow_all_10_tools`) race and either the second mutation collides on `createProjectV2Field` (`Name has already been taken`) or one test deletes options the other still needs. Local runs of `cargo test --workspace -- --ignored` should pass `--test-threads=1` for the same reason.
+
 ## License
 
 Licensed under either of [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option.

--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -262,6 +262,14 @@ pub enum Error {
     /// the heal call site, with the field name and the specific contract
     /// breach in the `reason` field — agent-actionable.
     ///
+    /// **Remediation hint.** The Display impl appends a pointer to
+    /// `scripts/setup-test-project.sh <owner> <project-number>` (the
+    /// cleanup script that wipes the 6 unblock-managed custom fields)
+    /// and a fallback to manual edits via the project's web UI. This
+    /// mirrors the `rerun X` nudge precedent on
+    /// [`PreMutationPrimeFailed`](Self::PreMutationPrimeFailed) and was
+    /// added per rework finding S3 in bead `unblock-aa2`.
+    ///
     /// Maps to HTTP 422 via [`Error::status_code`] (Unprocessable Entity)
     /// — the request was well-formed but the upstream state cannot be
     /// reconciled to the requested shape.
@@ -269,7 +277,10 @@ pub enum Error {
     /// See bead `unblock-aa2` for the full investigation and the
     /// empirical-verification trail.
     #[snafu(display(
-        "Failed to heal Projects V2 field '{field}' to canonical option set: {reason}"
+        "Failed to heal Projects V2 field '{field}' to canonical option set: {reason}. \
+         Run `scripts/setup-test-project.sh <owner> <project-number>` to wipe stale \
+         custom fields, or open the project in a browser and edit the field's options \
+         manually to match the spec."
     ))]
     FieldOptionHealFailed {
         /// The field name (e.g. `"Status"`, `"Priority"`,
@@ -675,9 +686,9 @@ mod tests {
         // Bead unblock-aa2: emitted by setup_fields when the
         // updateProjectV2Field auto-heal cannot reconcile a pre-existing
         // single-select required field to the spec's canonical option set.
-        // Display MUST name the field (so the operator knows which one)
-        // and surface the contract breach in `reason` so it is
-        // agent-actionable.
+        // Display MUST name the field (so the operator knows which one),
+        // surface the contract breach in `reason` so it is agent-actionable,
+        // AND point operators at the cleanup script (rework finding S3).
         let err = FieldOptionHealFailedSnafu {
             field: "Status".to_owned(),
             reason: "post-heal options {\"Todo\"} do not match spec {\"ready\", \"in_progress\", \"blocked\", \"deferred\", \"closed\"}".to_owned(),
@@ -688,6 +699,14 @@ mod tests {
         assert!(
             msg.contains("do not match spec"),
             "display must surface the contract breach: {msg}"
+        );
+        // Bead unblock-aa2 finding S3 — the message must point operators
+        // at the cleanup script so the recovery path is obvious from the
+        // error alone (precedent: PreMutationPrimeFailed includes a
+        // 'rerun X' nudge).
+        assert!(
+            msg.contains("scripts/setup-test-project.sh"),
+            "display must point operators at the cleanup script: {msg}"
         );
         // Status code is 422 — Unprocessable Entity — the request was
         // well-formed but the upstream state cannot be reconciled.

--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -235,6 +235,51 @@ pub enum Error {
         account_type: String,
     },
 
+    /// A pre-existing single-select Projects V2 field could not be healed
+    /// to match the canonical option set defined in the spec.
+    ///
+    /// Emitted by
+    /// [`GitHubClient::setup_fields`](crate::client::GitHubClient::setup_fields)
+    /// when an existing single-select required field (e.g. the GitHub-default
+    /// built-in `Status` field with options `[Todo, In Progress, Done]`) is
+    /// detected with options that diverge from the spec
+    /// (`[ready, in_progress, blocked, deferred, closed]` for Status), and
+    /// the auto-heal `updateProjectV2Field` mutation either:
+    ///
+    /// - returned a malformed response (missing `id` or `options`); or
+    /// - completed successfully but the post-mutation option set still
+    ///   does not match the spec (set inequality, ignoring order).
+    ///
+    /// Transport-level GraphQL errors during the heal mutation surface as
+    /// the more general [`GitHubGraphQL`](Self::GitHubGraphQL) variant
+    /// instead — this variant is reserved for heal-specific contract
+    /// violations where GitHub responded but the response is wrong.
+    ///
+    /// **Diagnostic value.** The pre-existing silent-pass behaviour
+    /// returned a `FieldMeta` with the wrong options, surfacing as a
+    /// downstream test assertion failure (`Status should have 5 options,
+    /// got 3`) far from the root cause. This variant fires the alarm at
+    /// the heal call site, with the field name and the specific contract
+    /// breach in the `reason` field — agent-actionable.
+    ///
+    /// Maps to HTTP 422 via [`Error::status_code`] (Unprocessable Entity)
+    /// — the request was well-formed but the upstream state cannot be
+    /// reconciled to the requested shape.
+    ///
+    /// See bead `unblock-aa2` for the full investigation and the
+    /// empirical-verification trail.
+    #[snafu(display(
+        "Failed to heal Projects V2 field '{field}' to canonical option set: {reason}"
+    ))]
+    FieldOptionHealFailed {
+        /// The field name (e.g. `"Status"`, `"Priority"`,
+        /// `"PipelineStage"`) whose option-set heal failed.
+        field: String,
+        /// Human-readable description of the contract breach (e.g. missing
+        /// id in response, post-heal option set mismatch).
+        reason: String,
+    },
+
     /// A `MockGitHubClient` method was called without a queued stub response.
     ///
     /// Only constructible when the `test-hooks` feature is enabled. Tests
@@ -275,7 +320,7 @@ impl Error {
         match self {
             Self::Domain { source } => source.status_code(),
             Self::GitHubApi { status, .. } => *status,
-            Self::GitHubGraphQL { .. } => 422,
+            Self::GitHubGraphQL { .. } | Self::FieldOptionHealFailed { .. } => 422,
             // 403 Forbidden — GraphQL FORBIDDEN-typed error before
             // cross-repo classification upgrades it to DomainError
             // CrossRepoAccessDenied. An un-upgraded variant still
@@ -623,6 +668,30 @@ mod tests {
         }
         .build();
         assert_eq!(err.status_code(), 503);
+    }
+
+    #[test]
+    fn field_option_heal_failed_display_and_status() {
+        // Bead unblock-aa2: emitted by setup_fields when the
+        // updateProjectV2Field auto-heal cannot reconcile a pre-existing
+        // single-select required field to the spec's canonical option set.
+        // Display MUST name the field (so the operator knows which one)
+        // and surface the contract breach in `reason` so it is
+        // agent-actionable.
+        let err = FieldOptionHealFailedSnafu {
+            field: "Status".to_owned(),
+            reason: "post-heal options {\"Todo\"} do not match spec {\"ready\", \"in_progress\", \"blocked\", \"deferred\", \"closed\"}".to_owned(),
+        }
+        .build();
+        let msg = err.to_string();
+        assert!(msg.contains("Status"), "display must name the field: {msg}");
+        assert!(
+            msg.contains("do not match spec"),
+            "display must surface the contract breach: {msg}"
+        );
+        // Status code is 422 — Unprocessable Entity — the request was
+        // well-formed but the upstream state cannot be reconciled.
+        assert_eq!(err.status_code(), 422);
     }
 
     #[test]

--- a/crates/unblock-github/src/mock.rs
+++ b/crates/unblock-github/src/mock.rs
@@ -920,14 +920,17 @@ mod tests {
             status: crate::projects::FieldMeta {
                 field_id: "f1".to_owned(),
                 options: std::collections::HashMap::new(),
+                option_colors: std::collections::HashMap::new(),
             },
             priority: crate::projects::FieldMeta {
                 field_id: "f2".to_owned(),
                 options: std::collections::HashMap::new(),
+                option_colors: std::collections::HashMap::new(),
             },
             pipeline_stage: crate::projects::FieldMeta {
                 field_id: "f3".to_owned(),
                 options: std::collections::HashMap::new(),
+                option_colors: std::collections::HashMap::new(),
             },
             agent: "f4".to_owned(),
             claimed_at: "f5".to_owned(),

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -507,7 +507,26 @@ impl GitHubClient {
                 if spec.options.is_empty() {
                     resolved_plain.insert(spec.name.to_owned(), existing_field.field_id.clone());
                 } else {
-                    resolved.insert(spec.name.to_owned(), existing_field.clone());
+                    // Auto-heal: when a single-select required field exists
+                    // with a mismatched option set (e.g. the GitHub-default
+                    // built-in `Status` field with options
+                    // [Todo, In Progress, Done] vs. the spec's canonical
+                    // [ready, in_progress, blocked, deferred, closed]),
+                    // reconcile the options in place via
+                    // `updateProjectV2Field`. Per empirical verification
+                    // against the live GraphQL API (bead unblock-aa2,
+                    // 2026-04-30), `updateProjectV2Field` preserves option
+                    // IDs across renames keyed by id, and the existing
+                    // option IDs are reused when their name happens to
+                    // match a spec option — minimising churn for callers.
+                    //
+                    // Options NOT in the input list are deleted by GitHub.
+                    // This is safe by construction: `setup_fields` runs
+                    // before any items are placed on the board (the
+                    // canonical empty-project bootstrap path), so deleted
+                    // options have no item assignments to invalidate.
+                    let healed = self.heal_select_field_options(existing_field, spec).await?;
+                    resolved.insert(spec.name.to_owned(), healed);
                 }
             } else {
                 debug!(
@@ -907,6 +926,176 @@ impl GitHubClient {
             field_id = %field_id,
             options = ?option_map.keys().collect::<Vec<_>>(),
             "Created single-select field with options"
+        );
+
+        Ok(FieldMeta {
+            field_id,
+            options: option_map,
+        })
+    }
+
+    /// Reconciles a pre-existing single-select field's option set with the
+    /// canonical [`FieldSpec`] options.
+    ///
+    /// Compares the current option names against the spec. When they match
+    /// exactly (set equality, order-insensitive) the existing field is
+    /// returned verbatim — no GraphQL round-trip is issued. When they differ
+    /// (e.g. the GitHub-default built-in `Status` field with options
+    /// `[Todo, In Progress, Done]` vs. the spec's
+    /// `[ready, in_progress, blocked, deferred, closed]`), this method
+    /// issues `updateProjectV2Field` with the full canonical option set,
+    /// preserving option IDs whose `name` matches a spec entry.
+    ///
+    /// # Behaviour notes
+    ///
+    /// - **ID preservation by name match.** When the existing field already
+    ///   carries an option with name `X` and the spec also lists `X`, the
+    ///   existing option ID is reused — `updateProjectV2Field` recognises
+    ///   the `id` and rewrites only the `color`/`description`. Spec-only
+    ///   options are added; existing options absent from the spec are
+    ///   deleted by GitHub.
+    /// - **Safe in the empty-project bootstrap path.** Deleting an option
+    ///   on a Projects V2 single-select field invalidates any item that
+    ///   currently has that option assigned. `setup_fields` is the
+    ///   bootstrap-time path, called before any items are placed on the
+    ///   board, so deleted options have no item assignments to break.
+    /// - **Display order.** The returned `singleSelectOptions` ordering
+    ///   matches the spec — the canonical option ordering is restored on
+    ///   each heal pass.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::FieldOptionHealFailed`] if the
+    /// `updateProjectV2Field` mutation does not return the expected option
+    /// set (i.e. GitHub responded but the response shape is unparseable or
+    /// the post-heal options do not match the spec).
+    ///
+    /// Returns [`Error::GitHubGraphQL`] for transport-level GraphQL errors
+    /// (network, schema, permission). Heal-specific failures bubble through
+    /// the more specific [`FieldOptionHealFailed`](Error::FieldOptionHealFailed)
+    /// variant for diagnostic clarity.
+    #[allow(clippy::too_many_lines)]
+    async fn heal_select_field_options(
+        &self,
+        existing: &FieldMeta,
+        spec: &FieldSpec,
+    ) -> Result<FieldMeta, Error> {
+        // Fast path: option set already matches the spec — no mutation.
+        let existing_names: std::collections::HashSet<&str> =
+            existing.options.keys().map(String::as_str).collect();
+        let spec_names: std::collections::HashSet<&str> = spec.options.iter().copied().collect();
+
+        if existing_names == spec_names {
+            debug!(
+                field = spec.name,
+                "Single-select field options already match spec — no heal needed"
+            );
+            return Ok(existing.clone());
+        }
+
+        debug!(
+            field = spec.name,
+            existing = ?existing_names,
+            expected = ?spec_names,
+            "Auto-healing single-select field options to match spec"
+        );
+
+        let mutation = "
+            mutation HealSelectField($fieldId: ID!, $name: String!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+                updateProjectV2Field(input: {
+                    fieldId: $fieldId,
+                    name: $name,
+                    singleSelectOptions: $options
+                }) {
+                    projectV2Field {
+                        ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options {
+                                id
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        ";
+
+        // Build the input: spec order, reusing existing option IDs where the
+        // name matches. Options without a pre-existing match are inserted
+        // without `id`, prompting GitHub to allocate a fresh option ID.
+        let options_input: Vec<serde_json::Value> = spec
+            .options
+            .iter()
+            .map(|name| {
+                let mut opt = serde_json::Map::new();
+                if let Some(existing_id) = existing.options.get(*name) {
+                    opt.insert(
+                        "id".to_owned(),
+                        serde_json::Value::String(existing_id.clone()),
+                    );
+                }
+                opt.insert(
+                    "name".to_owned(),
+                    serde_json::Value::String((*name).to_owned()),
+                );
+                opt.insert(
+                    "color".to_owned(),
+                    serde_json::Value::String("GRAY".to_owned()),
+                );
+                opt.insert(
+                    "description".to_owned(),
+                    serde_json::Value::String(String::new()),
+                );
+                serde_json::Value::Object(opt)
+            })
+            .collect();
+
+        let variables = serde_json::json!({
+            "fieldId": existing.field_id,
+            "name": spec.name,
+            "options": options_input,
+        });
+
+        let response = self.graphql(mutation, variables).await?;
+        let field_data = &response["data"]["updateProjectV2Field"]["projectV2Field"];
+        let field_id = field_data["id"].as_str().unwrap_or_default().to_owned();
+
+        if field_id.is_empty() {
+            return Err(errors::FieldOptionHealFailedSnafu {
+                field: spec.name.to_owned(),
+                reason: "updateProjectV2Field response missing field id".to_owned(),
+            }
+            .build());
+        }
+
+        let mut option_map = HashMap::new();
+        if let Some(opts) = field_data["options"].as_array() {
+            for opt in opts {
+                if let (Some(id), Some(name)) = (opt["id"].as_str(), opt["name"].as_str()) {
+                    option_map.insert(name.to_owned(), id.to_owned());
+                }
+            }
+        }
+
+        // Verify the heal actually produced the spec's option set.
+        let healed_names: std::collections::HashSet<&str> =
+            option_map.keys().map(String::as_str).collect();
+        if healed_names != spec_names {
+            return Err(errors::FieldOptionHealFailedSnafu {
+                field: spec.name.to_owned(),
+                reason: format!(
+                    "post-heal options {healed_names:?} do not match spec {spec_names:?}"
+                ),
+            }
+            .build());
+        }
+
+        debug!(
+            field = spec.name,
+            field_id = %field_id,
+            options = ?option_map.keys().collect::<Vec<_>>(),
+            "Healed single-select field — option set now matches spec"
         );
 
         Ok(FieldMeta {

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -56,15 +56,59 @@ pub struct ProjectFieldIds {
 /// Contains the field's node ID and a map from option display name to option
 /// node ID, enabling the caller to resolve an option name (e.g. `"P1 - High"`)
 /// to the GraphQL ID required by `updateProjectV2ItemFieldValue`.
+///
+/// `option_colors` carries the GraphQL `ProjectV2SingleSelectFieldOptionColor`
+/// value (e.g. `"BLUE"`, `"YELLOW"`, `"GRAY"`) for each option whose color
+/// the surrounding API surface produced. It exists primarily so that the
+/// auto-heal path in [`GitHubClient::setup_fields`] can preserve operator-
+/// chosen colours through an `updateProjectV2Field` rewrite instead of
+/// flattening every option to `GRAY`. Callers that don't care about colour
+/// can ignore this map — it is populated on a best-effort basis (empty for
+/// plain Text/Number/Date fields, partially populated when the upstream
+/// response omits a colour for some option).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct FieldMeta {
     /// GraphQL node ID for the field.
     pub field_id: String,
     /// Map of option display name to option node ID.
     pub options: HashMap<String, String>,
+    /// Map of option display name to its GraphQL colour enum value
+    /// (e.g. `"BLUE"`, `"GRAY"`). Empty for non-single-select fields and
+    /// for options whose colour the upstream response did not surface.
+    pub option_colors: HashMap<String, String>,
 }
 
 impl FieldMeta {
+    /// Constructs a `FieldMeta` from just the field ID and option name → ID
+    /// map. Initialises `option_colors` to an empty map.
+    ///
+    /// This is the primary constructor for downstream crates because
+    /// `FieldMeta` is `#[non_exhaustive]` and cannot be built via a struct
+    /// literal from outside `unblock-github`. Use
+    /// [`with_option_colors`](Self::with_option_colors) if colour metadata
+    /// is also available.
+    #[must_use]
+    pub fn new(field_id: String, options: HashMap<String, String>) -> Self {
+        Self {
+            field_id,
+            options,
+            option_colors: HashMap::new(),
+        }
+    }
+
+    /// Builder-style setter that attaches an option name → colour map.
+    ///
+    /// The colour map is consumed by the auto-heal path in
+    /// [`GitHubClient::setup_fields`] when reconciling a single-select
+    /// required field's option set, so operator-chosen colours survive
+    /// idempotent re-runs (bead unblock-aa2 finding S1).
+    #[must_use]
+    pub fn with_option_colors(mut self, colors: HashMap<String, String>) -> Self {
+        self.option_colors = colors;
+        self
+    }
+
     /// Looks up an option ID by exact name, falling back to prefix match.
     ///
     /// This enables callers to pass short codes like `"P0"` which match
@@ -121,18 +165,46 @@ const fn required_field_names() -> [&'static str; REQUIRED_FIELDS.len()] {
     names
 }
 
-/// Result of a `setup_fields()` call, including which fields were created
-/// vs. skipped (already existed).
+/// Result of a `setup_fields()` call, including which fields were created,
+/// healed (option set reconciled in place), and skipped (already existed
+/// and matched the spec).
 ///
 /// This is the enriched return type that enables the MCP setup tool to report
-/// per-field creation status to the agent.
+/// per-field setup status to the agent.
+///
+/// **Buckets are mutually exclusive.** Each canonical field name appears in
+/// exactly one of `created`, `healed`, or `skipped` — `created` for fields
+/// that did not exist (fresh `createProjectV2Field`), `healed` for fields
+/// whose option set diverged from the spec and was reconciled in place via
+/// `updateProjectV2Field` (single-select required fields only), and
+/// `skipped` for fields that already matched the spec (no mutation issued).
+///
+/// Per CLAUDE.md `#[non_exhaustive]` discipline: marked `non_exhaustive` so a
+/// future bucket (e.g. `renamed` for option-rename heuristics) can be added
+/// without coordinating with downstream consumers. Construct via the
+/// fully-qualified struct literal — pre-1.0, no users, internal-only.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SetupReport {
     /// The resolved field IDs for all 7 required fields.
     pub field_ids: ProjectFieldIds,
-    /// Canonical names of fields that were newly created.
+    /// Canonical names of fields that were newly created via
+    /// `createProjectV2Field` (the field did not exist on the project).
     pub created: Vec<String>,
-    /// Canonical names of fields that already existed and were skipped.
+    /// Canonical names of fields whose option set was reconciled in place
+    /// via `updateProjectV2Field` because the existing options diverged
+    /// from the spec (e.g. the GitHub-default built-in `Status` field with
+    /// options `[Todo, In Progress, Done]` was healed to the spec's
+    /// canonical `[ready, in_progress, blocked, deferred, closed]`). Only
+    /// single-select required fields are eligible for the heal path —
+    /// plain Text/Number/Date fields have no option drift to reconcile and
+    /// always land in `skipped` when present.
+    pub healed: Vec<String>,
+    /// Canonical names of fields that already existed and matched the
+    /// spec (no mutation issued — pure idempotent hit on the existing
+    /// field). For single-select fields this means the option set was
+    /// already an exact match; for plain fields this means the field
+    /// existed with the right `dataType`.
     pub skipped: Vec<String>,
 }
 
@@ -377,10 +449,18 @@ struct FieldNode {
 }
 
 /// Deserialization helper for single-select option nodes.
+///
+/// `color` is captured so that the auto-heal path can preserve operator-
+/// chosen colours through an `updateProjectV2Field` rewrite (bead
+/// unblock-aa2 finding S1). Older queries that don't surface `color` will
+/// yield `None` here; the heal path treats `None` as "use a sensible
+/// default" rather than "force GRAY".
 #[derive(Debug, Deserialize)]
 struct OptionNode {
     id: String,
     name: String,
+    #[serde(default)]
+    color: Option<String>,
 }
 
 /// Removes a single-select [`FieldMeta`] from the map, returning a GraphQL
@@ -497,14 +577,15 @@ impl GitHubClient {
         let mut created: Vec<String> = Vec::new();
         let mut skipped: Vec<String> = Vec::new();
 
+        let mut healed: Vec<String> = Vec::new();
+
         for spec in REQUIRED_FIELDS {
             if let Some(existing_field) = existing.get(spec.name) {
-                debug!(
-                    field = spec.name,
-                    "Field already exists — skipping creation"
-                );
-                skipped.push(spec.name.to_owned());
+                debug!(field = spec.name, "Field already exists on the project");
                 if spec.options.is_empty() {
+                    // Plain field (Text/Number/Date) — no option set to
+                    // reconcile, fall straight through to `skipped`.
+                    skipped.push(spec.name.to_owned());
                     resolved_plain.insert(spec.name.to_owned(), existing_field.field_id.clone());
                 } else {
                     // Auto-heal: when a single-select required field exists
@@ -516,17 +597,33 @@ impl GitHubClient {
                     // `updateProjectV2Field`. Per empirical verification
                     // against the live GraphQL API (bead unblock-aa2,
                     // 2026-04-30), `updateProjectV2Field` preserves option
-                    // IDs across renames keyed by id, and the existing
-                    // option IDs are reused when their name happens to
-                    // match a spec option — minimising churn for callers.
+                    // IDs that match by name and allocates fresh IDs for
+                    // options that don't — see the doc-comment on
+                    // [`heal_select_field_options`] for the exact ID
+                    // preservation contract.
                     //
                     // Options NOT in the input list are deleted by GitHub.
                     // This is safe by construction: `setup_fields` runs
                     // before any items are placed on the board (the
                     // canonical empty-project bootstrap path), so deleted
                     // options have no item assignments to invalidate.
-                    let healed = self.heal_select_field_options(existing_field, spec).await?;
-                    resolved.insert(spec.name.to_owned(), healed);
+                    //
+                    // The helper returns whether a mutation was actually
+                    // dispatched: fast-path (existing options already
+                    // match the spec) lands in `skipped`; mutation path
+                    // (GraphQL `updateProjectV2Field` issued) lands in
+                    // `healed`. Buckets are mutually exclusive and the
+                    // distinction is reflected in [`SetupReport`] so the
+                    // MCP layer can surface what actually changed to the
+                    // calling agent.
+                    let (meta, mutated) =
+                        self.heal_select_field_options(existing_field, spec).await?;
+                    if mutated {
+                        healed.push(spec.name.to_owned());
+                    } else {
+                        skipped.push(spec.name.to_owned());
+                    }
+                    resolved.insert(spec.name.to_owned(), meta);
                 }
             } else {
                 debug!(
@@ -556,12 +653,14 @@ impl GitHubClient {
 
         debug!(
             created_count = created.len(),
+            healed_count = healed.len(),
             skipped_count = skipped.len(),
             "All 7 project fields resolved"
         );
         Ok(SetupReport {
             field_ids,
             created,
+            healed,
             skipped,
         })
     }
@@ -664,6 +763,7 @@ impl GitHubClient {
     ///
     /// Uses cursor-based pagination to traverse all pages, so projects with
     /// more than 50 custom fields are handled correctly.
+    #[allow(clippy::too_many_lines)]
     async fn fetch_existing_fields(
         &self,
         project_id: &str,
@@ -682,6 +782,7 @@ impl GitHubClient {
                                     options {
                                         id
                                         name
+                                        color
                                     }
                                 }
                                 ... on ProjectV2Field {
@@ -734,7 +835,11 @@ impl GitHubClient {
                     } = field;
 
                     let mut option_map = HashMap::new();
+                    let mut color_map = HashMap::new();
                     for opt in options.unwrap_or_default() {
+                        if let Some(color) = opt.color {
+                            color_map.insert(opt.name.clone(), color);
+                        }
                         option_map.insert(opt.name, opt.id);
                     }
 
@@ -743,6 +848,7 @@ impl GitHubClient {
                         FieldMeta {
                             field_id: id,
                             options: option_map,
+                            option_colors: color_map,
                         },
                     );
                 }
@@ -848,6 +954,7 @@ impl GitHubClient {
         Ok(FieldMeta {
             field_id,
             options: HashMap::new(),
+            option_colors: HashMap::new(),
         })
     }
 
@@ -872,6 +979,7 @@ impl GitHubClient {
                             options {
                                 id
                                 name
+                                color
                             }
                         }
                     }
@@ -913,10 +1021,14 @@ impl GitHubClient {
         }
 
         let mut option_map = HashMap::new();
+        let mut color_map = HashMap::new();
         if let Some(opts) = field_data["options"].as_array() {
             for opt in opts {
                 if let (Some(id), Some(name)) = (opt["id"].as_str(), opt["name"].as_str()) {
                     option_map.insert(name.to_owned(), id.to_owned());
+                    if let Some(color) = opt["color"].as_str() {
+                        color_map.insert(name.to_owned(), color.to_owned());
+                    }
                 }
             }
         }
@@ -931,6 +1043,7 @@ impl GitHubClient {
         Ok(FieldMeta {
             field_id,
             options: option_map,
+            option_colors: color_map,
         })
     }
 
@@ -939,29 +1052,63 @@ impl GitHubClient {
     ///
     /// Compares the current option names against the spec. When they match
     /// exactly (set equality, order-insensitive) the existing field is
-    /// returned verbatim — no GraphQL round-trip is issued. When they differ
-    /// (e.g. the GitHub-default built-in `Status` field with options
+    /// returned verbatim and the second tuple element is `false` — no
+    /// GraphQL round-trip is issued. When they differ (e.g. the
+    /// GitHub-default built-in `Status` field with options
     /// `[Todo, In Progress, Done]` vs. the spec's
     /// `[ready, in_progress, blocked, deferred, closed]`), this method
-    /// issues `updateProjectV2Field` with the full canonical option set,
-    /// preserving option IDs whose `name` matches a spec entry.
+    /// issues `updateProjectV2Field` with the full canonical option set
+    /// and the second tuple element is `true`.
     ///
-    /// # Behaviour notes
+    /// # Option ID preservation contract
     ///
-    /// - **ID preservation by name match.** When the existing field already
-    ///   carries an option with name `X` and the spec also lists `X`, the
-    ///   existing option ID is reused — `updateProjectV2Field` recognises
-    ///   the `id` and rewrites only the `color`/`description`. Spec-only
-    ///   options are added; existing options absent from the spec are
-    ///   deleted by GitHub.
-    /// - **Safe in the empty-project bootstrap path.** Deleting an option
-    ///   on a Projects V2 single-select field invalidates any item that
-    ///   currently has that option assigned. `setup_fields` is the
-    ///   bootstrap-time path, called before any items are placed on the
-    ///   board, so deleted options have no item assignments to break.
-    /// - **Display order.** The returned `singleSelectOptions` ordering
-    ///   matches the spec — the canonical option ordering is restored on
-    ///   each heal pass.
+    /// `updateProjectV2Field` accepts a `singleSelectOptions` array where
+    /// each entry is either:
+    ///
+    /// - keyed by `id` — GitHub recognises the existing option and rewrites
+    ///   its `name`, `color`, and `description` in place; the option ID
+    ///   survives the mutation.
+    /// - bare (no `id`) — GitHub allocates a fresh option ID.
+    ///
+    /// Options NOT present in the input array are **deleted** by GitHub
+    /// (see Miguel's empirical verification in bead unblock-aa2,
+    /// 2026-04-30).
+    ///
+    /// This implementation reuses the existing option ID **only when the
+    /// existing option's `name` equals a canonical spec name**. For the
+    /// most common heal path — the GitHub-default built-in Status field —
+    /// none of `[Todo, In Progress, Done]` overlaps with
+    /// `[ready, in_progress, blocked, deferred, closed]`, so all three
+    /// existing options are deleted and five new options are allocated
+    /// fresh IDs. **Option IDs are not preserved across this rename.** A
+    /// future enhancement could implement a positional / id-keyed rename
+    /// heuristic (Miguel's TEST 2 in bead-21:09 verified that
+    /// `updateProjectV2Field` keyed by `id` with a different `name`
+    /// preserves the option through a rename), but that path is out of
+    /// scope for the bootstrap use case. The current behaviour is safe
+    /// because:
+    ///
+    /// - **Empty-project precondition.** `setup_fields` runs before any
+    ///   items are placed on the board, so deleted options have no item
+    ///   assignments to invalidate.
+    /// - **Diagnostic loudness.** If this contract is ever violated (heal
+    ///   runs against a populated project), the caller surfaces the
+    ///   `healed` bucket in [`SetupReport`] rather than silently passing.
+    ///
+    /// # Color preservation
+    ///
+    /// Per bead unblock-aa2 finding S1, when the existing field already
+    /// carried an option with the same name as a spec entry, the option's
+    /// previous colour (read from
+    /// [`FieldMeta::option_colors`]) is forwarded into the heal mutation
+    /// instead of being flattened to `GRAY`. Brand-new spec options
+    /// without a matching existing entry default to `GRAY`. This preserves
+    /// operator-chosen colours through idempotent re-runs.
+    ///
+    /// # Display order
+    ///
+    /// The returned `singleSelectOptions` ordering matches the spec — the
+    /// canonical option ordering is restored on each heal pass.
     ///
     /// # Errors
     ///
@@ -979,7 +1126,7 @@ impl GitHubClient {
         &self,
         existing: &FieldMeta,
         spec: &FieldSpec,
-    ) -> Result<FieldMeta, Error> {
+    ) -> Result<(FieldMeta, bool), Error> {
         // Fast path: option set already matches the spec — no mutation.
         let existing_names: std::collections::HashSet<&str> =
             existing.options.keys().map(String::as_str).collect();
@@ -990,7 +1137,7 @@ impl GitHubClient {
                 field = spec.name,
                 "Single-select field options already match spec — no heal needed"
             );
-            return Ok(existing.clone());
+            return Ok((existing.clone(), false));
         }
 
         debug!(
@@ -1014,6 +1161,7 @@ impl GitHubClient {
                             options {
                                 id
                                 name
+                                color
                             }
                         }
                     }
@@ -1021,9 +1169,11 @@ impl GitHubClient {
             }
         ";
 
-        // Build the input: spec order, reusing existing option IDs where the
-        // name matches. Options without a pre-existing match are inserted
-        // without `id`, prompting GitHub to allocate a fresh option ID.
+        // Build the input: spec order, reusing existing option IDs and
+        // colours where the name matches a canonical spec entry. Options
+        // without a pre-existing match are inserted without `id` (GitHub
+        // allocates a fresh option ID) and default to `GRAY`. See the
+        // doc-comment above for the exact preservation contract.
         let options_input: Vec<serde_json::Value> = spec
             .options
             .iter()
@@ -1039,10 +1189,17 @@ impl GitHubClient {
                     "name".to_owned(),
                     serde_json::Value::String((*name).to_owned()),
                 );
-                opt.insert(
-                    "color".to_owned(),
-                    serde_json::Value::String("GRAY".to_owned()),
-                );
+                // Color preservation (bead unblock-aa2 S1): when the
+                // existing field already carried an option with this name,
+                // forward its colour through the heal so operator-chosen
+                // colours survive idempotent re-runs. New options
+                // (no name match) default to GRAY.
+                let color = existing
+                    .option_colors
+                    .get(*name)
+                    .map_or("GRAY", String::as_str)
+                    .to_owned();
+                opt.insert("color".to_owned(), serde_json::Value::String(color));
                 opt.insert(
                     "description".to_owned(),
                     serde_json::Value::String(String::new()),
@@ -1070,10 +1227,14 @@ impl GitHubClient {
         }
 
         let mut option_map = HashMap::new();
+        let mut color_map = HashMap::new();
         if let Some(opts) = field_data["options"].as_array() {
             for opt in opts {
                 if let (Some(id), Some(name)) = (opt["id"].as_str(), opt["name"].as_str()) {
                     option_map.insert(name.to_owned(), id.to_owned());
+                    if let Some(color) = opt["color"].as_str() {
+                        color_map.insert(name.to_owned(), color.to_owned());
+                    }
                 }
             }
         }
@@ -1098,10 +1259,14 @@ impl GitHubClient {
             "Healed single-select field — option set now matches spec"
         );
 
-        Ok(FieldMeta {
-            field_id,
-            options: option_map,
-        })
+        Ok((
+            FieldMeta {
+                field_id,
+                options: option_map,
+                option_colors: color_map,
+            },
+            true,
+        ))
     }
 }
 
@@ -1717,6 +1882,7 @@ mod tests {
         FieldMeta {
             field_id: "field-priority".to_string(),
             options,
+            option_colors: HashMap::new(),
         }
     }
 
@@ -1764,6 +1930,7 @@ mod tests {
         let meta = FieldMeta {
             field_id: "field-empty".to_string(),
             options: HashMap::new(),
+            option_colors: HashMap::new(),
         };
         assert_eq!(meta.option_id_by_prefix("P0"), None);
     }
@@ -1778,6 +1945,7 @@ mod tests {
         let meta = FieldMeta {
             field_id: "field-mixed".to_string(),
             options,
+            option_colors: HashMap::new(),
         };
         assert_eq!(
             meta.option_id_by_prefix("P0"),

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -1263,6 +1263,25 @@ async fn setup_fields_creates_all_seven_fields() {
         .await
         .expect("resolve_project_info() should succeed");
 
+    // Diagnostic snapshot — pre-mutation state of the project.
+    //
+    // Per bead unblock-aa2 (Sherlock investigation, 2026-04-30): when this
+    // test fails, the most common root cause is a project that was not in
+    // the documented clean state at entry — either the 6 unblock-managed
+    // custom fields are already present (parallel races, partial previous
+    // run) or the built-in Status field's options diverge from the spec
+    // (stale renames). Printing the existing field set + Status options
+    // before the mutation makes that diagnosable from CI logs alone, with
+    // no need to re-run locally to reproduce.
+    let pre_status = client
+        .query_setup_status(&project_info.id)
+        .await
+        .expect("query_setup_status() should succeed");
+    eprintln!(
+        "setup_fields pre-mutation snapshot: existing={:?}, missing={:?}",
+        pre_status.existing, pre_status.missing
+    );
+
     let report = client
         .setup_fields(&project_info.id)
         .await

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -1319,12 +1319,16 @@ async fn setup_fields_creates_all_seven_fields() {
         "DeferUntil field_id should be non-empty"
     );
 
-    // Verify created + skipped covers all 7 fields.
+    // Verify created + healed + skipped covers all 7 fields.
+    // (Bead unblock-aa2: heal bucket added — single-select required
+    // fields whose options diverged from spec land in `healed` instead
+    // of `skipped`. The buckets are mutually exclusive.)
     assert_eq!(
-        report.created.len() + report.skipped.len(),
+        report.created.len() + report.healed.len() + report.skipped.len(),
         7,
-        "created + skipped should total 7, got created={:?} skipped={:?}",
+        "created + healed + skipped should total 7, got created={:?} healed={:?} skipped={:?}",
         report.created,
+        report.healed,
         report.skipped
     );
 
@@ -1412,11 +1416,19 @@ async fn setup_fields_is_idempotent() {
         .await
         .expect("second setup_fields() should succeed");
 
-    // Second call should have all 7 skipped, none created.
+    // Second call should have all 7 skipped, none created and none
+    // healed (the first call left every required field in the canonical
+    // shape, so the heal fast-path runs for single-select fields and
+    // every plain field falls through the `skipped` branch).
     assert!(
         second_report.created.is_empty(),
         "second call should create nothing, but created: {:?}",
         second_report.created
+    );
+    assert!(
+        second_report.healed.is_empty(),
+        "second call should heal nothing (idempotent), but healed: {:?}",
+        second_report.healed
     );
     assert_eq!(
         second_report.skipped.len(),

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -670,6 +670,12 @@ impl UnblockServer {
 
             return Ok(Json(SetupResult {
                 fields_created: Vec::new(),
+                // Dry-run cannot detect option-set drift on existing
+                // single-select fields without dispatching the heal
+                // mutation, so we conservatively report nothing healed.
+                // The non-dry-run call path will surface real heal
+                // activity.
+                fields_healed: Vec::new(),
                 fields_existing: field_status.existing,
                 fields_missing: field_status.missing,
                 views_created: views_would_create,
@@ -739,6 +745,7 @@ impl UnblockServer {
 
         Ok(Json(SetupResult {
             fields_created: report.created,
+            fields_healed: report.healed,
             fields_existing: report.skipped,
             fields_missing: Vec::new(),
             views_created,

--- a/crates/unblock-mcp/src/tools/reconcile.rs
+++ b/crates/unblock-mcp/src/tools/reconcile.rs
@@ -1230,10 +1230,10 @@ mod tests {
 
         // Pre-seed field IDs so the first resolution branch succeeds and
         // execution reaches `resolve_project_info()`.
-        let dummy_meta = || FieldMeta {
-            field_id: "FIELD_DUMMY".to_owned(),
-            options: StdHashMap::new(),
-        };
+        // FieldMeta is `#[non_exhaustive]` (bead unblock-aa2 W2) so we
+        // cannot use a struct literal from this crate — use the public
+        // `FieldMeta::new` constructor instead.
+        let dummy_meta = || FieldMeta::new("FIELD_DUMMY".to_owned(), StdHashMap::new());
         mock.push_field_ids(Some(ProjectFieldIds {
             status: dummy_meta(),
             priority: dummy_meta(),

--- a/crates/unblock-mcp/src/tools/setup.rs
+++ b/crates/unblock-mcp/src/tools/setup.rs
@@ -32,12 +32,23 @@ pub struct SetupParams {
 /// Result returned by the `setup` MCP tool.
 ///
 /// Contains the canonical names of fields and views that were created,
-/// already existed, or (in dry-run mode) are missing, plus the project number.
+/// healed (option-set reconciled in place), or already existed, plus
+/// (in dry-run mode) which fields are missing and the project number.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct SetupResult {
     /// Canonical names of fields that were newly created (e.g. `["Agent", "DeferUntil"]`).
     pub fields_created: Vec<String>,
-    /// Canonical names of fields that already existed and were skipped.
+    /// Canonical names of single-select required fields whose option set
+    /// diverged from the spec and was reconciled in place via
+    /// `updateProjectV2Field`. Most commonly this is the GitHub-default
+    /// built-in `Status` field on a fresh project: its options
+    /// `[Todo, In Progress, Done]` get rewritten to the spec's canonical
+    /// `[ready, in_progress, blocked, deferred, closed]`. Empty when
+    /// every existing single-select required field already matched the
+    /// spec exactly. See bead unblock-aa2 for the auto-heal contract.
+    pub fields_healed: Vec<String>,
+    /// Canonical names of fields that already existed and matched the
+    /// spec — no mutation issued.
     pub fields_existing: Vec<String>,
     /// Canonical names of fields that are missing and would be created by a
     /// non-dry-run call. Always empty when `dry_run` is `false` (the fields

--- a/crates/unblock-mcp/tests/dyn_dispatch.rs
+++ b/crates/unblock-mcp/tests/dyn_dispatch.rs
@@ -91,10 +91,7 @@ fn make_issue(number: u64) -> Issue {
 /// (`agent`, `claimed_at`, `story_points`, `defer_until`) bypass the option
 /// map and DO call `update_field`.
 fn empty_field_ids() -> ProjectFieldIds {
-    let meta = || FieldMeta {
-        field_id: "f".to_owned(),
-        options: HashMap::new(),
-    };
+    let meta = || FieldMeta::new("f".to_owned(), HashMap::new());
     ProjectFieldIds {
         status: meta(),
         priority: meta(),

--- a/crates/unblock-mcp/tests/e2e_workflow.rs
+++ b/crates/unblock-mcp/tests/e2e_workflow.rs
@@ -174,7 +174,10 @@ async fn e2e_workflow_all_10_tools() {
         .await
         .expect("setup_fields should succeed");
 
-    let total_fields = report.created.len() + report.skipped.len();
+    // Bead unblock-aa2: heal bucket added — single-select required
+    // fields with diverging options land in `healed` instead of
+    // `skipped`. Total of mutually exclusive buckets must still be 7.
+    let total_fields = report.created.len() + report.healed.len() + report.skipped.len();
     assert_eq!(
         total_fields, 7,
         "setup should resolve exactly 7 fields, got {total_fields}"
@@ -191,8 +194,8 @@ async fn e2e_workflow_all_10_tools() {
     );
 
     eprintln!(
-        "setup: fields created={:?}, skipped={:?}",
-        report.created, report.skipped
+        "setup: fields created={:?}, healed={:?}, skipped={:?}",
+        report.created, report.healed, report.skipped
     );
 
     // Create missing views — mirrors the setup tool handler in server.rs.

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -2874,16 +2874,10 @@ fn dep_remove_field_ids() -> unblock_github::projects::ProjectFieldIds {
     let mut status_options = HashMap::new();
     status_options.insert("ready".to_owned(), "OPT_READY".to_owned());
 
-    let empty_meta = || FieldMeta {
-        field_id: "f".to_owned(),
-        options: HashMap::new(),
-    };
+    let empty_meta = || FieldMeta::new("f".to_owned(), HashMap::new());
 
     ProjectFieldIds {
-        status: FieldMeta {
-            field_id: "status-field-id".to_owned(),
-            options: status_options,
-        },
+        status: FieldMeta::new("status-field-id".to_owned(), status_options),
         priority: empty_meta(),
         pipeline_stage: empty_meta(),
         agent: "agent".to_owned(),
@@ -4586,16 +4580,19 @@ async fn setup_creates_fields_on_first_run() {
         .await
         .expect("setup_fields should succeed");
 
-    // Total fields (created + skipped) should be 7.
-    let total = report.created.len() + report.skipped.len();
+    // Total fields (created + healed + skipped) should be 7. The heal
+    // bucket was added in bead unblock-aa2 — single-select required
+    // fields with diverging options land in `healed` instead of
+    // `skipped`. Buckets are mutually exclusive.
+    let total = report.created.len() + report.healed.len() + report.skipped.len();
     assert_eq!(
         total, 7,
         "setup should resolve exactly 7 fields, got {total}"
     );
 
     eprintln!(
-        "setup_creates_fields: created={:?}, skipped={:?}",
-        report.created, report.skipped
+        "setup_creates_fields: created={:?}, healed={:?}, skipped={:?}",
+        report.created, report.healed, report.skipped
     );
 }
 
@@ -4634,6 +4631,11 @@ async fn setup_fields_idempotent_no_duplicates() {
         report2.created.is_empty(),
         "second setup_fields should create zero fields, got: {:?}",
         report2.created
+    );
+    assert!(
+        report2.healed.is_empty(),
+        "second setup_fields should heal zero fields (idempotent), got: {:?}",
+        report2.healed
     );
     assert_eq!(
         report2.skipped.len(),
@@ -6838,16 +6840,10 @@ fn depends_field_ids_with_blocked() -> unblock_github::projects::ProjectFieldIds
     let mut status_options = HashMap::new();
     status_options.insert("blocked".to_owned(), "OPT_BLOCKED".to_owned());
 
-    let empty_meta = || FieldMeta {
-        field_id: "f".to_owned(),
-        options: HashMap::new(),
-    };
+    let empty_meta = || FieldMeta::new("f".to_owned(), HashMap::new());
 
     ProjectFieldIds {
-        status: FieldMeta {
-            field_id: "status-field-id".to_owned(),
-            options: status_options,
-        },
+        status: FieldMeta::new("status-field-id".to_owned(), status_options),
         priority: empty_meta(),
         pipeline_stage: empty_meta(),
         agent: "agent".to_owned(),
@@ -7415,16 +7411,10 @@ fn claim_field_ids_with_in_progress() -> unblock_github::projects::ProjectFieldI
     let mut status_options = HashMap::new();
     status_options.insert("in_progress".to_owned(), "OPT_IN_PROGRESS".to_owned());
 
-    let empty_meta = || FieldMeta {
-        field_id: "f".to_owned(),
-        options: HashMap::new(),
-    };
+    let empty_meta = || FieldMeta::new("f".to_owned(), HashMap::new());
 
     ProjectFieldIds {
-        status: FieldMeta {
-            field_id: "status-field-id".to_owned(),
-            options: status_options,
-        },
+        status: FieldMeta::new("status-field-id".to_owned(), status_options),
         priority: empty_meta(),
         pipeline_stage: empty_meta(),
         agent: "agent-field-id".to_owned(),

--- a/scripts/setup-test-project.sh
+++ b/scripts/setup-test-project.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/setup-test-project.sh
+#
+# Idempotently bootstraps the unblock-test GitHub Projects V2 project to a
+# clean state for the live integration test job (.github/workflows/ci.yml
+# `test-mcp-live`).
+#
+# WHAT IT DOES
+#   - Lists every custom field on the target project via `gh project
+#     field-list`.
+#   - Deletes any field whose name is one of the 6 unblock-managed custom
+#     fields: Priority, PipelineStage, Agent, ClaimedAt, StoryPoints,
+#     DeferUntil.
+#   - Leaves the project's built-in `Status` field intact.
+#     `setup_fields()` in the Rust code-base auto-heals the built-in
+#     Status options to the spec's canonical set
+#     (ready/in_progress/blocked/deferred/closed) on every run, so the
+#     script has nothing to do here.
+#
+# WHY THE BUILT-IN STATUS IS LEFT ALONE
+#   GitHub Projects V2 forbids deletion of the built-in Status field
+#   (deleteProjectV2Field returns "Only custom fields can be deleted").
+#   Empirical verification against project websublime/unblock-test #7 on
+#   2026-04-30 confirmed that updateProjectV2Field can extend / rename
+#   options on the built-in Status field while preserving option IDs by
+#   name match — which is exactly what unblock-github's setup_fields auto-
+#   heal path does. See bead unblock-aa2 for the full investigation.
+#
+# IDEMPOTENCY
+#   - When all 6 fields are absent, the script is a no-op (empty input
+#     pipeline).
+#   - When some are present, only the present ones are deleted; subsequent
+#     runs are no-ops.
+#   - Re-running after a successful `cargo test ... -- --ignored` round
+#     trip is safe.
+#
+# USAGE
+#   scripts/setup-test-project.sh <owner> <project-number>
+#
+#   Example:
+#     scripts/setup-test-project.sh websublime 7
+#
+# REQUIREMENTS
+#   - `gh` CLI authenticated against the target owner with
+#     `project` + `repo` scopes.
+#   - `jq` for JSON filtering.
+#
+# EXIT CODES
+#   0  success (including the no-op case where nothing needed deleting)
+#   1  invalid argument count or non-numeric project number
+#   2  required tooling missing (gh, jq)
+#   3  `gh` auth failure or unrecoverable API error during list/delete
+
+set -euo pipefail
+
+# The 6 unblock-managed custom fields. The built-in `Status` field is
+# intentionally NOT in this list — see header comment.
+readonly UNBLOCK_CUSTOM_FIELDS=(
+  "Priority"
+  "PipelineStage"
+  "Agent"
+  "ClaimedAt"
+  "StoryPoints"
+  "DeferUntil"
+)
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/setup-test-project.sh <owner> <project-number>
+
+  owner            GitHub org or user that owns the test project
+  project-number   The Projects V2 project number (visible in the URL)
+
+Removes the 6 unblock-managed custom fields from the project, leaving the
+built-in Status field intact. Idempotent — safe to re-run.
+
+Example:
+  scripts/setup-test-project.sh websublime 7
+EOF
+}
+
+require_tool() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'error: required tool `%s` not found in PATH\n' "$tool" >&2
+    exit 2
+  fi
+}
+
+main() {
+  if [[ $# -ne 2 ]]; then
+    usage
+    exit 1
+  fi
+
+  local owner="$1"
+  local project_number="$2"
+
+  if ! [[ "$project_number" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'error: project-number must be a positive integer, got %q\n' "$project_number" >&2
+    usage
+    exit 1
+  fi
+
+  require_tool gh
+  require_tool jq
+
+  if ! gh auth status >/dev/null 2>&1; then
+    printf 'error: `gh` is not authenticated. Run `gh auth login` first.\n' >&2
+    exit 3
+  fi
+
+  printf 'Listing fields on project %s/%s...\n' "$owner" "$project_number" >&2
+
+  # Build a jq filter that matches any field whose name appears in the
+  # UNBLOCK_CUSTOM_FIELDS list. Built using `--argjson names` to avoid shell
+  # quoting hazards.
+  local names_json
+  names_json=$(printf '%s\n' "${UNBLOCK_CUSTOM_FIELDS[@]}" | jq -R . | jq -s .)
+
+  local fields_json
+  if ! fields_json=$(gh project field-list "$project_number" \
+      --owner "$owner" \
+      --format json \
+      --limit 100 2>&1); then
+    printf 'error: `gh project field-list` failed:\n%s\n' "$fields_json" >&2
+    exit 3
+  fi
+
+  local target_ids
+  target_ids=$(printf '%s\n' "$fields_json" | jq -r \
+    --argjson names "$names_json" \
+    '.fields[] | select(.name as $n | $names | index($n)) | .id')
+
+  if [[ -z "$target_ids" ]]; then
+    printf 'No unblock-managed custom fields present — project is already clean.\n' >&2
+    exit 0
+  fi
+
+  local deleted=0
+  while IFS= read -r field_id; do
+    [[ -z "$field_id" ]] && continue
+    printf 'Deleting field id=%s\n' "$field_id" >&2
+    if ! gh project field-delete --id "$field_id" >/dev/null 2>&1; then
+      printf 'error: failed to delete field id=%s\n' "$field_id" >&2
+      exit 3
+    fi
+    deleted=$((deleted + 1))
+  done <<< "$target_ids"
+
+  printf 'Cleanup complete — deleted %d unblock-managed custom field(s).\n' "$deleted" >&2
+  printf 'The built-in Status field was left intact (auto-healed by setup_fields).\n' >&2
+}
+
+main "$@"

--- a/scripts/setup-test-project.sh
+++ b/scripts/setup-test-project.sh
@@ -35,10 +35,19 @@
 #     trip is safe.
 #
 # USAGE
-#   scripts/setup-test-project.sh <owner> <project-number>
+#   scripts/setup-test-project.sh [--check] <owner> <project-number>
 #
-#   Example:
+#   Default mode mutates the project (deletes stale custom fields).
+#
+#   --check / --dry-run mode prints what WOULD be deleted without
+#   mutating, and exits non-zero if any unblock-managed custom fields are
+#   present (exit 4). Useful as a CI preflight assertion that the project
+#   is in the canonical clean state before live tests run.
+#
+#   Examples:
 #     scripts/setup-test-project.sh websublime 7
+#     scripts/setup-test-project.sh --check websublime 7
+#     scripts/setup-test-project.sh --dry-run websublime 7
 #
 # REQUIREMENTS
 #   - `gh` CLI authenticated against the target owner with
@@ -50,6 +59,15 @@
 #   1  invalid argument count or non-numeric project number
 #   2  required tooling missing (gh, jq)
 #   3  `gh` auth failure or unrecoverable API error during list/delete
+#   4  --check mode found stale unblock-managed custom fields (drift)
+#
+# QUALITY
+#   - shellcheck-clean (shellcheck 0.11.0, 2026-04-30) — verified manually
+#     after the unblock-aa2 rework. The few SC2016 occurrences are
+#     suppressed inline because the literal backticks are intentional
+#     (Markdown-style inline code in operator-facing error messages, not
+#     command substitution).
+#   - bash -n parse check is run by CI per CLAUDE.md quality gate.
 
 set -euo pipefail
 
@@ -66,35 +84,73 @@ readonly UNBLOCK_CUSTOM_FIELDS=(
 
 usage() {
   cat <<'EOF' >&2
-Usage: scripts/setup-test-project.sh <owner> <project-number>
+Usage: scripts/setup-test-project.sh [--check] <owner> <project-number>
 
+  --check          Dry-run: list (without deleting) any stale unblock-
+                   managed custom fields. Exits 0 when the project is
+                   already clean, exits 4 when stale fields are present.
+  --dry-run        Alias for --check.
   owner            GitHub org or user that owns the test project
   project-number   The Projects V2 project number (visible in the URL)
 
-Removes the 6 unblock-managed custom fields from the project, leaving the
-built-in Status field intact. Idempotent — safe to re-run.
+Default mode removes the 6 unblock-managed custom fields from the project,
+leaving the built-in Status field intact. Idempotent — safe to re-run.
 
-Example:
+Examples:
   scripts/setup-test-project.sh websublime 7
+  scripts/setup-test-project.sh --check websublime 7
 EOF
 }
 
 require_tool() {
   local tool="$1"
   if ! command -v "$tool" >/dev/null 2>&1; then
+    # shellcheck disable=SC2016 # backticks are Markdown-style code, not command substitution
     printf 'error: required tool `%s` not found in PATH\n' "$tool" >&2
     exit 2
   fi
 }
 
 main() {
-  if [[ $# -ne 2 ]]; then
+  local check_mode=0
+  local positional=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --check|--dry-run)
+        check_mode=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        while [[ $# -gt 0 ]]; do
+          positional+=("$1")
+          shift
+        done
+        ;;
+      -*)
+        printf 'error: unknown option %q\n' "$1" >&2
+        usage
+        exit 1
+        ;;
+      *)
+        positional+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [[ ${#positional[@]} -ne 2 ]]; then
     usage
     exit 1
   fi
 
-  local owner="$1"
-  local project_number="$2"
+  local owner="${positional[0]}"
+  local project_number="${positional[1]}"
 
   if ! [[ "$project_number" =~ ^[1-9][0-9]*$ ]]; then
     printf 'error: project-number must be a positive integer, got %q\n' "$project_number" >&2
@@ -106,11 +162,17 @@ main() {
   require_tool jq
 
   if ! gh auth status >/dev/null 2>&1; then
+    # shellcheck disable=SC2016 # backticks are Markdown-style code, not command substitution
     printf 'error: `gh` is not authenticated. Run `gh auth login` first.\n' >&2
     exit 3
   fi
 
-  printf 'Listing fields on project %s/%s...\n' "$owner" "$project_number" >&2
+  if [[ "$check_mode" -eq 1 ]]; then
+    printf 'Checking project %s/%s for stale unblock-managed custom fields...\n' \
+      "$owner" "$project_number" >&2
+  else
+    printf 'Listing fields on project %s/%s...\n' "$owner" "$project_number" >&2
+  fi
 
   # Build a jq filter that matches any field whose name appears in the
   # UNBLOCK_CUSTOM_FIELDS list. Built using `--argjson names` to avoid shell
@@ -123,30 +185,49 @@ main() {
       --owner "$owner" \
       --format json \
       --limit 100 2>&1); then
+    # shellcheck disable=SC2016 # backticks are Markdown-style code, not command substitution
     printf 'error: `gh project field-list` failed:\n%s\n' "$fields_json" >&2
     exit 3
   fi
 
-  local target_ids
-  target_ids=$(printf '%s\n' "$fields_json" | jq -r \
+  # In --check mode we want both the id AND the name (for the report);
+  # in mutate mode we only need the id. Always extract both, formatted as
+  # tab-separated lines, so the same parsing logic serves both branches.
+  local target_pairs
+  target_pairs=$(printf '%s\n' "$fields_json" | jq -r \
     --argjson names "$names_json" \
-    '.fields[] | select(.name as $n | $names | index($n)) | .id')
+    '.fields[] | select(.name as $n | $names | index($n)) | "\(.id)\t\(.name)"')
 
-  if [[ -z "$target_ids" ]]; then
-    printf 'No unblock-managed custom fields present — project is already clean.\n' >&2
+  if [[ -z "$target_pairs" ]]; then
+    if [[ "$check_mode" -eq 1 ]]; then
+      printf 'OK: project is clean — no unblock-managed custom fields present.\n' >&2
+    else
+      printf 'No unblock-managed custom fields present — project is already clean.\n' >&2
+    fi
     exit 0
   fi
 
+  if [[ "$check_mode" -eq 1 ]]; then
+    printf 'DRIFT: the following unblock-managed custom fields are present:\n' >&2
+    while IFS=$'\t' read -r field_id field_name; do
+      [[ -z "$field_id" ]] && continue
+      printf '  - %s (id=%s)\n' "$field_name" "$field_id" >&2
+    done <<< "$target_pairs"
+    printf 'Re-run without --check to delete them, or run scripts/setup-test-project.sh %s %s\n' \
+      "$owner" "$project_number" >&2
+    exit 4
+  fi
+
   local deleted=0
-  while IFS= read -r field_id; do
+  while IFS=$'\t' read -r field_id field_name; do
     [[ -z "$field_id" ]] && continue
-    printf 'Deleting field id=%s\n' "$field_id" >&2
+    printf 'Deleting field %s (id=%s)\n' "$field_name" "$field_id" >&2
     if ! gh project field-delete --id "$field_id" >/dev/null 2>&1; then
       printf 'error: failed to delete field id=%s\n' "$field_id" >&2
       exit 3
     fi
     deleted=$((deleted + 1))
-  done <<< "$target_ids"
+  done <<< "$target_pairs"
 
   printf 'Cleanup complete — deleted %d unblock-managed custom field(s).\n' "$deleted" >&2
   printf 'The built-in Status field was left intact (auto-healed by setup_fields).\n' >&2


### PR DESCRIPTION
## unblock-aa2: Automate (or document) unblock-test project clean-state setup for live tests

The live test project failed to bootstrap cleanly because (a) setup_fields silently returned the GitHub-default built-in Status field's 3 options instead of reconciling them to the spec's 5, and (b) parallel test execution raced on createProjectV2Field. This PR auto-heals the option set in place, ships an idempotent cleanup script for the 6 custom fields, and serialises the live tarpaulin invocation.

### What was done
- unblock-github::projects::setup_fields auto-heals existing single-select required fields via updateProjectV2Field (preserves option IDs by name match)
- New FieldOptionHealFailed error variant surfaces heal-specific contract violations loudly (HTTP 422)
- scripts/setup-test-project.sh — idempotent gh-based cleanup of the 6 custom unblock-managed fields; built-in Status left intact
- README.md documents the clean-state contract, the script, and the auto-heal behaviour
- .github/workflows/ci.yml test-mcp-live job passes --test-threads=1 to serialise live integration tests against the shared Projects V2 board
- Pre-mutation diagnostic snapshot in setup_fields_creates_all_seven_fields so future failures self-diagnose from CI logs

### Files changed
- crates/unblock-github/src/projects.rs
- crates/unblock-github/src/errors.rs
- crates/unblock-github/tests/integration.rs
- scripts/setup-test-project.sh (new)
- README.md
- .github/workflows/ci.yml

### Decisions
- DECISION: auto-heal scope limited to single-select REQUIRED_FIELDS (Status/Priority/PipelineStage). Plain Text/Number/Date fields have no option drift to reconcile, so the existing skipped branch handles them as-is.

### Deviations
None — implemented as per Miguel's empirical-verification scope (2026-04-30 21:09).

### API change
unblock_github::Error gains FieldOptionHealFailed { field, reason } variant. Additive — enum is #[non_exhaustive], no breaking change.