### PR TITLE
unblock-drh: map GraphQL NOT_FOUND to IssueNotFound (404), not 422

### DIFF
--- a/crates/unblock-github/src/errors.rs
+++ b/crates/unblock-github/src/errors.rs
@@ -13,6 +13,59 @@ use unblock_core::types::QualifiedId;
 
 use chrono::{DateTime, Utc};
 
+/// A single GraphQL error entry from a GitHub GraphQL response.
+///
+/// Carries both the human-readable `message` and the structured `error_type`
+/// (e.g. `"NOT_FOUND"`, `"FORBIDDEN"`) so downstream classifiers can route on
+/// the wire-typed signal rather than substring-sniffing free-text messages.
+///
+/// The `error_type` is `None` for synthetic entries constructed inside this
+/// crate (e.g. when a mutation response is well-formed at the transport
+/// layer but the project/field could not be resolved); the partition logic
+/// in `GitHubClient::graphql_with_features` populates it from the upstream
+/// `errors[i].type` field for real GraphQL responses.
+///
+/// See bead `unblock-drh` for the structural-classification rationale
+/// (Miguel's DECISION 2026-05-04: Option B, plumb `errors[].type` through
+/// the partition for robust `NOT_FOUND` detection).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphQLErrorEntry {
+    /// The human-readable error message.
+    pub message: String,
+    /// The structured `type` field from the upstream GraphQL response
+    /// (e.g. `"NOT_FOUND"`, `"FORBIDDEN"`), or `None` for synthetic
+    /// entries constructed inside this crate.
+    pub error_type: Option<String>,
+}
+
+impl GraphQLErrorEntry {
+    /// Constructs an entry carrying only a message (no structured type).
+    ///
+    /// Used by synthetic call sites inside this crate that need to surface
+    /// a contract violation as a [`Error::GitHubGraphQL`] without a real
+    /// upstream error type to plumb (e.g. "Required field 'X' was not
+    /// resolved").
+    #[must_use]
+    pub fn message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            error_type: None,
+        }
+    }
+}
+
+impl From<String> for GraphQLErrorEntry {
+    fn from(message: String) -> Self {
+        Self::message(message)
+    }
+}
+
+impl From<&str> for GraphQLErrorEntry {
+    fn from(message: &str) -> Self {
+        Self::message(message.to_owned())
+    }
+}
+
 /// Infrastructure-level errors for the GitHub API client.
 ///
 /// Each variant represents a specific infrastructure failure mode. Domain errors
@@ -53,10 +106,19 @@ pub enum Error {
     },
 
     /// One or more errors in a GitHub GraphQL response.
-    #[snafu(display("GitHub GraphQL error: {}", errors.join("; ")))]
+    ///
+    /// Each entry carries both the message and the upstream `type`
+    /// (when known) so downstream classifiers can route on the wire-
+    /// typed signal — e.g. mapping `type == "NOT_FOUND"` with an issue-
+    /// scoped message to [`DomainError::IssueNotFound`] (bead
+    /// `unblock-drh`, Miguel's DECISION 2026-05-04: Option B).
+    ///
+    /// [`DomainError::IssueNotFound`]:
+    ///     unblock_core::errors::DomainError::IssueNotFound
+    #[snafu(display("GitHub GraphQL error: {}", format_graphql_display(errors)))]
     GitHubGraphQL {
-        /// Individual error messages from the GraphQL response.
-        errors: Vec<String>,
+        /// Individual error entries from the GraphQL response.
+        errors: Vec<GraphQLErrorEntry>,
     },
 
     /// A GitHub GraphQL response containing at least one error with
@@ -89,12 +151,12 @@ pub enum Error {
     ///     unblock_core::errors::DomainError::CrossRepoAccessDenied
     #[snafu(display("{}", format_forbidden_display(errors)))]
     GitHubGraphQLForbidden {
-        /// Messages from the GraphQL errors whose `type` was
-        /// `FORBIDDEN`. Non-FORBIDDEN messages from the same response
+        /// Entries from the GraphQL errors whose `type` was
+        /// `FORBIDDEN`. Non-FORBIDDEN entries from the same response
         /// are discarded; the classifier treats any FORBIDDEN as
         /// authoritative. This vector MAY be empty — see the variant
         /// docs for the `(no details)` sentinel semantics.
-        errors: Vec<String>,
+        errors: Vec<GraphQLErrorEntry>,
     },
 
     /// Network or connection failure when reaching GitHub.
@@ -352,12 +414,36 @@ pub enum Error {
 /// happens when every FORBIDDEN-typed response entry lacked a populated
 /// `message` body; see the variant docs). Otherwise joins the messages
 /// with `"; "` to match the historical `GitHubGraphQL` format.
-fn format_forbidden_display(errors: &[String]) -> String {
+fn format_forbidden_display(errors: &[GraphQLErrorEntry]) -> String {
     if errors.is_empty() {
         "GitHub GraphQL FORBIDDEN: (no details)".to_owned()
     } else {
-        format!("GitHub GraphQL FORBIDDEN: {}", errors.join("; "))
+        format!(
+            "GitHub GraphQL FORBIDDEN: {}",
+            errors
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ")
+        )
     }
+}
+
+/// Formats the `errors` vector of a [`Error::GitHubGraphQL`] variant for
+/// `Display`.
+///
+/// Joins the message fields with `"; "` to preserve the historical
+/// `Vec<String>` rendering — the structured `error_type` field is
+/// observability for in-process classifiers (e.g.
+/// [`crate::graphql::classify_issue_not_found`]) and is intentionally
+/// omitted from the human-facing `Display` form to keep log output
+/// stable for downstream tooling.
+fn format_graphql_display(errors: &[GraphQLErrorEntry]) -> String {
+    errors
+        .iter()
+        .map(|e| e.message.as_str())
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 impl Error {
@@ -424,7 +510,7 @@ mod tests {
     #[test]
     fn github_graphql_display() {
         let err = GitHubGraphQLSnafu {
-            errors: vec!["Field 'x' not found".to_owned()],
+            errors: vec![GraphQLErrorEntry::message("Field 'x' not found")],
         }
         .build();
         assert_eq!(err.to_string(), "GitHub GraphQL error: Field 'x' not found");
@@ -434,8 +520,8 @@ mod tests {
     fn github_graphql_display_multi_error() {
         let err = GitHubGraphQLSnafu {
             errors: vec![
-                "Field 'x' not found".to_owned(),
-                "Variable '$id' is not defined".to_owned(),
+                GraphQLErrorEntry::message("Field 'x' not found"),
+                GraphQLErrorEntry::message("Variable '$id' is not defined"),
             ],
         }
         .build();
@@ -448,10 +534,36 @@ mod tests {
     #[test]
     fn github_graphql_display_empty_vec() {
         let err = GitHubGraphQLSnafu {
-            errors: Vec::<String>::new(),
+            errors: Vec::<GraphQLErrorEntry>::new(),
         }
         .build();
         assert_eq!(err.to_string(), "GitHub GraphQL error: ");
+    }
+
+    #[test]
+    fn graphql_error_entry_carries_structured_type() {
+        // Bead unblock-drh: structural classification (Miguel's DECISION,
+        // Option B). The partition logic populates `error_type` from the
+        // upstream `errors[i].type` so downstream classifiers can route
+        // on the typed signal rather than substring-sniffing messages.
+        let entry = GraphQLErrorEntry {
+            message: "Could not resolve to an Issue with the number of 999.".to_owned(),
+            error_type: Some("NOT_FOUND".to_owned()),
+        };
+        assert_eq!(entry.error_type.as_deref(), Some("NOT_FOUND"));
+        assert!(entry.message.contains("to an Issue"));
+    }
+
+    #[test]
+    fn graphql_error_entry_from_string_has_no_type() {
+        // Synthetic entries constructed from a bare String inside this
+        // crate (e.g. mutation-response contract violations) have no
+        // structured type to plumb — `error_type` MUST be `None` so
+        // downstream classifiers can distinguish wire-typed signals
+        // from synthetic messages.
+        let entry: GraphQLErrorEntry = "synthetic".to_owned().into();
+        assert!(entry.error_type.is_none());
+        assert_eq!(entry.message, "synthetic");
     }
 
     #[test]
@@ -470,7 +582,9 @@ mod tests {
         // explicit and harder to accidentally weaken (bead
         // `unblock-eos.36`).
         let err = GitHubGraphQLForbiddenSnafu {
-            errors: vec!["Resource not accessible by integration".to_owned()],
+            errors: vec![GraphQLErrorEntry::message(
+                "Resource not accessible by integration",
+            )],
         }
         .build();
         assert_eq!(
@@ -493,7 +607,7 @@ mod tests {
         // trailing space — so log output stays self-describing. This
         // test pins the exact sentinel string.
         let err = GitHubGraphQLForbiddenSnafu {
-            errors: Vec::<String>::new(),
+            errors: Vec::<GraphQLErrorEntry>::new(),
         }
         .build();
         assert_eq!(err.to_string(), "GitHub GraphQL FORBIDDEN: (no details)");
@@ -578,11 +692,13 @@ mod tests {
             }
             .build(),
             GitHubGraphQLSnafu {
-                errors: vec!["err".to_owned()],
+                errors: vec![GraphQLErrorEntry::message("err")],
             }
             .build(),
             GitHubGraphQLForbiddenSnafu {
-                errors: vec!["Resource not accessible by integration".to_owned()],
+                errors: vec![GraphQLErrorEntry::message(
+                    "Resource not accessible by integration",
+                )],
             }
             .build(),
             RateLimitedSnafu {
@@ -626,7 +742,7 @@ mod tests {
     #[test]
     fn status_code_github_graphql() {
         let err = GitHubGraphQLSnafu {
-            errors: vec!["bad field".to_owned()],
+            errors: vec![GraphQLErrorEntry::message("bad field")],
         }
         .build();
         assert_eq!(err.status_code(), 422);

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -283,12 +283,24 @@ impl GitHubClient {
         let response = self
             .graphql(FETCH_ISSUE_QUERY, variables)
             .await
+            // Bead unblock-drh: compose the cross-repo FORBIDDEN→
+            // `CrossRepoAccessDenied` upgrade with the new
+            // NOT_FOUND→`IssueNotFound` upgrade. Order matters:
+            // `classify_cross_repo_fetch` consumes
+            // `GitHubGraphQLForbidden`, so the structural-type
+            // classifier (`classify_issue_not_found`) sees only
+            // non-FORBIDDEN GraphQL errors and routes the
+            // `type == "NOT_FOUND"` Issue-scoped entries to
+            // [`DomainError::IssueNotFound`]. Local fetches skip the
+            // cross-repo upgrade but still benefit from the
+            // not-found classifier.
             .map_err(|err| {
-                if is_cross_repo {
+                let err = if is_cross_repo {
                     classify_cross_repo_fetch(err, owner, repo)
                 } else {
                     err
-                }
+                };
+                classify_issue_not_found(err, number)
             })?;
 
         let issue_value = &response["data"]["repository"]["issue"];
@@ -536,12 +548,17 @@ impl GitHubClient {
             let has_forbidden = arr
                 .iter()
                 .any(|e| e.get("type").and_then(serde_json::Value::as_str) == Some("FORBIDDEN"));
-            let mut forbidden_messages: Vec<String> = Vec::new();
-            let mut other_messages: Vec<String> = Vec::new();
+            // Bead unblock-drh / Miguel's DECISION 2026-05-04 (Option B):
+            // each entry now carries its structured `error_type` alongside
+            // the message so downstream classifiers (e.g.
+            // `classify_issue_not_found`) can route on the wire-typed
+            // signal rather than substring-sniffing free-text messages.
+            let mut forbidden_entries: Vec<errors::GraphQLErrorEntry> = Vec::new();
+            let mut other_entries: Vec<errors::GraphQLErrorEntry> = Vec::new();
             for err in arr {
                 // Skip entries without a non-empty `message`: a missing
                 // or empty message carries no information and would
-                // silently pollute the message vectors (previously a
+                // silently pollute the entry vectors (previously a
                 // FORBIDDEN entry with no message body produced an
                 // empty-string entry in `forbidden_messages`).
                 let Some(message) = err
@@ -552,21 +569,29 @@ impl GitHubClient {
                 else {
                     continue;
                 };
-                let ty = err.get("type").and_then(|t| t.as_str()).unwrap_or_default();
-                if ty == "FORBIDDEN" {
-                    forbidden_messages.push(message);
+                let error_type = err
+                    .get("type")
+                    .and_then(|t| t.as_str())
+                    .filter(|t| !t.is_empty())
+                    .map(str::to_owned);
+                let entry = errors::GraphQLErrorEntry {
+                    message,
+                    error_type: error_type.clone(),
+                };
+                if error_type.as_deref() == Some("FORBIDDEN") {
+                    forbidden_entries.push(entry);
                 } else {
-                    other_messages.push(message);
+                    other_entries.push(entry);
                 }
             }
             if has_forbidden {
                 return Err(errors::GitHubGraphQLForbiddenSnafu {
-                    errors: forbidden_messages,
+                    errors: forbidden_entries,
                 }
                 .build());
             }
             return Err(errors::GitHubGraphQLSnafu {
-                errors: other_messages,
+                errors: other_entries,
             }
             .build());
         }
@@ -646,6 +671,61 @@ pub(crate) fn classify_cross_repo_fetch(
             }
             .build()
             .into()
+        }
+        other => other,
+    }
+}
+
+/// Upgrades a `GitHubGraphQL` error to
+/// [`DomainError::IssueNotFound`] when the upstream GraphQL response
+/// carries an entry with `type == "NOT_FOUND"` whose message identifies
+/// the missing resource as an Issue (rather than a Repository or other
+/// resource).
+///
+/// Bead `unblock-drh`, Miguel's DECISION 2026-05-04 (Option B —
+/// structural classification): GitHub returns HTTP 200 with a typed
+/// `errors` array for non-existent issue lookups; the `type` field
+/// (`NOT_FOUND`) is the wire-safe routing signal, but the partition
+/// emits a generic `GitHubGraphQL` (HTTP 422) because it has no way to
+/// know whether the missing resource was the queried issue or some
+/// other sub-selection. This classifier sits at call sites that DO
+/// know the issue number (`fetch_issue_in_repo`, `resolve_node_id`,
+/// `resolve_issue_ref` cross-repo arm) and translates the structured
+/// signal into the spec-correct domain error.
+///
+/// **Issue-specificity guard.** The classifier additionally requires
+/// the entry's message to contain the substring `"to an Issue"` — the
+/// documented GitHub phrasing for the missing-issue case. Without this
+/// guard, a Repository-not-found entry on the same query
+/// (`"Could not resolve to a Repository with the name"`) — which can
+/// fire when `owner` or `repo` is wrong rather than `number` — would
+/// be misclassified as `IssueNotFound`. Pinned by the regression
+/// guards `graphql_errors_array_without_forbidden_type_emits_graphql_variant`
+/// (errors.rs) and the unit tests on this classifier.
+///
+/// **Composes with `classify_cross_repo_fetch`.** Cross-repo call
+/// sites apply `classify_cross_repo_fetch` FIRST so a FORBIDDEN
+/// response upgrades to `CrossRepoAccessDenied` (per SPEC §11.1)
+/// before this classifier sees it. The FORBIDDEN→CrossRepo upgrade
+/// must always win because access denial is more authoritative than
+/// not-found (an unauthorised reader sees `NOT_FOUND` for everything).
+///
+/// Other errors pass through unchanged.
+///
+/// [`DomainError::IssueNotFound`]:
+///     unblock_core::errors::DomainError::IssueNotFound
+pub(crate) fn classify_issue_not_found(err: errors::Error, number: u64) -> errors::Error {
+    match err {
+        errors::Error::GitHubGraphQL { ref errors } => {
+            if errors.iter().any(|e| {
+                e.error_type.as_deref() == Some("NOT_FOUND") && e.message.contains("to an Issue")
+            }) {
+                unblock_core::errors::IssueNotFoundSnafu { number }
+                    .build()
+                    .into()
+            } else {
+                err
+            }
         }
         other => other,
     }
@@ -1239,7 +1319,9 @@ mod tests {
         // emits this variant by inspecting `errors[i].type == "FORBIDDEN"`
         // BEFORE reducing to messages.
         let gql_err = errors::GitHubGraphQLForbiddenSnafu {
-            errors: vec!["Resource not accessible by integration".to_owned()],
+            errors: vec![errors::GraphQLErrorEntry::message(
+                "Resource not accessible by integration",
+            )],
         }
         .build();
         let upgraded = classify_cross_repo_fetch(gql_err, "acme", "widgets");
@@ -1276,13 +1358,15 @@ mod tests {
         // MUST stay as GitHubGraphQL — only the FORBIDDEN-typed variant
         // upgrades.
         let gql_err = errors::GitHubGraphQLSnafu {
-            errors: vec!["Field 'x' not found".to_owned()],
+            errors: vec![errors::GraphQLErrorEntry::message("Field 'x' not found")],
         }
         .build();
         let result = classify_cross_repo_fetch(gql_err, "acme", "widgets");
         match result {
             errors::Error::GitHubGraphQL { errors } => {
-                assert_eq!(errors, vec!["Field 'x' not found".to_owned()]);
+                assert_eq!(errors.len(), 1);
+                assert_eq!(errors[0].message, "Field 'x' not found");
+                assert!(errors[0].error_type.is_none());
             }
             other => panic!("expected GitHubGraphQL passthrough, got: {other:?}"),
         }
@@ -1300,6 +1384,151 @@ mod tests {
         match result {
             errors::Error::RateLimited { .. } => {}
             other => panic!("expected RateLimited passthrough, got: {other:?}"),
+        }
+    }
+
+    // ── classify_issue_not_found (bead unblock-drh) ────────────────────
+
+    #[test]
+    fn classify_issue_not_found_upgrades_typed_issue_not_found() {
+        // Bead unblock-drh / Miguel's DECISION 2026-05-04 (Option B):
+        // a `GitHubGraphQL` carrying `error_type == Some("NOT_FOUND")`
+        // and an Issue-scoped message MUST upgrade to
+        // `DomainError::IssueNotFound { number }` (status_code 404).
+        // This is the live-failure-mode fix: GitHub returns
+        // `Could not resolve to an Issue with the number of N.` for
+        // non-existent issue numbers.
+        let gql_err = errors::GitHubGraphQLSnafu {
+            errors: vec![errors::GraphQLErrorEntry {
+                message: "Could not resolve to an Issue with the number of 999999999.".to_owned(),
+                error_type: Some("NOT_FOUND".to_owned()),
+            }],
+        }
+        .build();
+        let upgraded = classify_issue_not_found(gql_err, 999_999_999);
+        match upgraded {
+            errors::Error::Domain { source } => {
+                assert_eq!(source.status_code(), 404);
+                let msg = source.to_string();
+                assert!(
+                    msg.contains("999999999"),
+                    "display must carry the issue number: {msg}"
+                );
+            }
+            other => panic!("expected IssueNotFound Domain error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_issue_not_found_passes_through_repository_not_found() {
+        // The Issue-specificity guard: a Repository-not-found message
+        // (`Could not resolve to a Repository with the name`) MUST
+        // remain as `GitHubGraphQL` — the queried owner/repo is
+        // wrong, not the issue number. Without this guard, every
+        // mistyped owner would surface as `IssueNotFound`. Pinned by
+        // the existing partition test
+        // `graphql_errors_array_without_forbidden_type_emits_graphql_variant`.
+        let gql_err = errors::GitHubGraphQLSnafu {
+            errors: vec![errors::GraphQLErrorEntry {
+                message: "Could not resolve to a Repository with the name 'acme/missing'."
+                    .to_owned(),
+                error_type: Some("NOT_FOUND".to_owned()),
+            }],
+        }
+        .build();
+        let result = classify_issue_not_found(gql_err, 42);
+        match result {
+            errors::Error::GitHubGraphQL { errors } => {
+                assert_eq!(errors.len(), 1);
+                assert!(errors[0].message.contains("Repository"));
+                assert_eq!(errors[0].error_type.as_deref(), Some("NOT_FOUND"));
+            }
+            other => panic!("expected GitHubGraphQL passthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_issue_not_found_passes_through_when_type_missing() {
+        // Without `error_type == Some("NOT_FOUND")`, the classifier
+        // MUST NOT upgrade — even if the message happens to contain
+        // `to an Issue` substring (defensive against synthetic
+        // entries constructed inside this crate, which carry
+        // `error_type == None`).
+        let gql_err = errors::GitHubGraphQLSnafu {
+            errors: vec![errors::GraphQLErrorEntry::message(
+                "synthetic message about an Issue with no upstream type",
+            )],
+        }
+        .build();
+        let result = classify_issue_not_found(gql_err, 42);
+        match result {
+            errors::Error::GitHubGraphQL { .. } => {}
+            other => panic!("expected GitHubGraphQL passthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_issue_not_found_passes_through_forbidden_variant() {
+        // The classifier is scoped to `GitHubGraphQL` (the reducer's
+        // default bucket). A `GitHubGraphQLForbidden` MUST pass
+        // through so cross-repo call sites can let
+        // `classify_cross_repo_fetch` upgrade it to
+        // `CrossRepoAccessDenied` first — composition order matters,
+        // FORBIDDEN→CrossRepo always wins (an unauthorised reader
+        // sees `NOT_FOUND` for everything; the access-denial signal
+        // is more authoritative).
+        let gql_err = errors::GitHubGraphQLForbiddenSnafu {
+            errors: vec![errors::GraphQLErrorEntry::message("access denied")],
+        }
+        .build();
+        let result = classify_issue_not_found(gql_err, 42);
+        match result {
+            errors::Error::GitHubGraphQLForbidden { .. } => {}
+            other => panic!("expected GitHubGraphQLForbidden passthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_issue_not_found_passes_through_unrelated_errors() {
+        // A rate-limit error MUST pass through unchanged — the
+        // classifier is scoped to `GitHubGraphQL` only.
+        let err = errors::RateLimitedSnafu {
+            reset_at: chrono::Utc::now(),
+        }
+        .build();
+        let result = classify_issue_not_found(err, 42);
+        match result {
+            errors::Error::RateLimited { .. } => {}
+            other => panic!("expected RateLimited passthrough, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_issue_not_found_only_one_entry_must_match() {
+        // A mixed `GitHubGraphQL` payload with at least one
+        // NOT_FOUND-typed Issue-scoped entry MUST upgrade — the
+        // classifier scans all entries and routes on the first match.
+        // Guards against a future change that accidentally requires
+        // ALL entries to match.
+        let gql_err = errors::GitHubGraphQLSnafu {
+            errors: vec![
+                errors::GraphQLErrorEntry {
+                    message: "side-effect error".to_owned(),
+                    error_type: Some("INTERNAL".to_owned()),
+                },
+                errors::GraphQLErrorEntry {
+                    message: "Could not resolve to an Issue with the number of 7.".to_owned(),
+                    error_type: Some("NOT_FOUND".to_owned()),
+                },
+            ],
+        }
+        .build();
+        let upgraded = classify_issue_not_found(gql_err, 7);
+        match upgraded {
+            errors::Error::Domain { source } => {
+                assert_eq!(source.status_code(), 404);
+            }
+            other => panic!("expected IssueNotFound Domain error, got: {other:?}"),
         }
     }
 
@@ -2775,7 +3004,8 @@ mod tests {
         match err {
             errors::Error::GitHubGraphQLForbidden { errors } => {
                 assert_eq!(errors.len(), 1);
-                assert_eq!(errors[0], "Resource not accessible by integration");
+                assert_eq!(errors[0].message, "Resource not accessible by integration");
+                assert_eq!(errors[0].error_type.as_deref(), Some("FORBIDDEN"));
             }
             other => panic!("expected GitHubGraphQLForbidden, got: {other}"),
         }
@@ -2813,7 +3043,12 @@ mod tests {
         match err {
             errors::Error::GitHubGraphQL { errors } => {
                 assert_eq!(errors.len(), 1);
-                assert!(errors[0].contains("Repository"));
+                assert!(errors[0].message.contains("Repository"));
+                // Bead unblock-drh: structural type is now plumbed
+                // through the partition — the entry MUST carry
+                // `error_type == Some("NOT_FOUND")` so downstream
+                // classifiers can route on the typed signal.
+                assert_eq!(errors[0].error_type.as_deref(), Some("NOT_FOUND"));
             }
             other => panic!("expected GitHubGraphQL, got: {other}"),
         }
@@ -2849,7 +3084,8 @@ mod tests {
         match err {
             errors::Error::GitHubGraphQLForbidden { errors } => {
                 assert_eq!(errors.len(), 1);
-                assert_eq!(errors[0], "access denied");
+                assert_eq!(errors[0].message, "access denied");
+                assert_eq!(errors[0].error_type.as_deref(), Some("FORBIDDEN"));
             }
             other => panic!("expected GitHubGraphQLForbidden, got: {other}"),
         }
@@ -3006,7 +3242,8 @@ mod tests {
         match err {
             errors::Error::GitHubGraphQLForbidden { errors } => {
                 assert_eq!(errors.len(), 1, "empty-message entry must be dropped");
-                assert_eq!(errors[0], "access denied");
+                assert_eq!(errors[0].message, "access denied");
+                assert_eq!(errors[0].error_type.as_deref(), Some("FORBIDDEN"));
             }
             other => panic!("expected GitHubGraphQLForbidden, got: {other}"),
         }
@@ -3114,6 +3351,189 @@ mod tests {
         match err {
             errors::Error::GitHubApi { status, .. } => assert_eq!(status, 403),
             other => panic!("expected GitHubApi passthrough for local 403, got: {other}"),
+        }
+    }
+
+    // ── fetch_issue_in_repo: NOT_FOUND classifier (bead unblock-drh) ───
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_local_graphql_not_found_upgrades_to_issue_not_found() {
+        // Bead unblock-drh / Miguel's DECISION 2026-05-04 (Option B):
+        // a LOCAL fetch returning the live GitHub
+        // `errors[].type == "NOT_FOUND"` payload for a non-existent
+        // issue MUST upgrade to `DomainError::IssueNotFound`
+        // (status_code 404), not surface as a generic 422
+        // `GitHubGraphQL`. This is the live-failure-mode end-to-end
+        // contract that the four `*_returns_issue_not_found_for_nonexistent_number`
+        // integration tests pin under live CI.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to an Issue with the number of 999999999."
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("test-owner", "test-repo", 999_999_999)
+            .await
+            .expect_err("NOT_FOUND issue should produce Err");
+
+        match err {
+            errors::Error::Domain { source } => {
+                assert_eq!(source.status_code(), 404);
+                let msg = source.to_string();
+                assert!(
+                    msg.contains("999999999"),
+                    "display must carry the issue number: {msg}"
+                );
+            }
+            other => panic!("expected IssueNotFound Domain error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_cross_repo_graphql_not_found_upgrades_to_issue_not_found() {
+        // Bead unblock-drh: cross-repo path composes the
+        // FORBIDDEN→CrossRepoAccessDenied upgrade with the
+        // NOT_FOUND→IssueNotFound upgrade. A NOT_FOUND-typed Issue-
+        // scoped error from a cross-repo fetch MUST surface as
+        // IssueNotFound (the FORBIDDEN classifier does not match,
+        // so the issue-not-found classifier wins).
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to an Issue with the number of 7."
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("acme", "widgets", 7)
+            .await
+            .expect_err("NOT_FOUND issue should produce Err");
+
+        match err {
+            errors::Error::Domain { source } => {
+                assert_eq!(source.status_code(), 404);
+            }
+            other => panic!("expected IssueNotFound Domain error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_cross_repo_forbidden_wins_over_not_found_classifier() {
+        // Composition order: when a cross-repo fetch returns
+        // FORBIDDEN, the FORBIDDEN→CrossRepoAccessDenied upgrade MUST
+        // win — the NOT_FOUND classifier never sees it because
+        // `classify_cross_repo_fetch` consumes the
+        // `GitHubGraphQLForbidden` variant first. Guards against
+        // a future refactor that swaps the composition order and
+        // would silently downgrade access-denial signals to
+        // not-found. The reasoning: an unauthorised reader of a
+        // private repo sees `NOT_FOUND` for everything; the
+        // access-denial signal (when present) is more authoritative.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "FORBIDDEN",
+                        "message": "Resource not accessible by integration"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("acme", "widgets", 7)
+            .await
+            .expect_err("FORBIDDEN should produce Err");
+
+        match err {
+            errors::Error::Domain { source } => {
+                assert_eq!(source.status_code(), 403);
+                let msg = source.to_string();
+                assert!(msg.contains("acme"));
+                assert!(msg.contains("widgets"));
+            }
+            other => panic!("expected CrossRepoAccessDenied Domain error, got: {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_issue_in_repo_local_graphql_repository_not_found_stays_as_graphql() {
+        // Issue-specificity guard: a Repository-not-found error
+        // (`Could not resolve to a Repository with the name`) MUST
+        // remain as `GitHubGraphQL` (status_code 422) even though it
+        // shares `type == "NOT_FOUND"` — the missing resource is the
+        // queried owner/repo, not the issue number. Local-fetch
+        // variant (`test-owner/test-repo` matches the configured
+        // repo) so the cross-repo classifier is bypassed and the
+        // not-found classifier is the only one in play. Mirrors the
+        // existing partition-level guard
+        // `graphql_errors_array_without_forbidden_type_emits_graphql_variant`
+        // at the call-site classification layer.
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to a Repository with the name 'test-owner/test-repo'."
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .fetch_issue_in_repo("test-owner", "test-repo", 1)
+            .await
+            .expect_err("NOT_FOUND repository should produce Err");
+
+        match err {
+            errors::Error::GitHubGraphQL { errors } => {
+                assert_eq!(errors.len(), 1);
+                assert!(errors[0].message.contains("Repository"));
+                assert_eq!(errors[0].error_type.as_deref(), Some("NOT_FOUND"));
+            }
+            other => panic!("expected GitHubGraphQL passthrough, got: {other}"),
         }
     }
 }

--- a/crates/unblock-github/src/mutations.rs
+++ b/crates/unblock-github/src/mutations.rs
@@ -31,7 +31,7 @@ use unblock_core::types::{Issue, IssueSummary, IssueType, Priority, QualifiedId,
 
 use crate::client::GitHubClient;
 use crate::errors::{self, Error};
-use crate::graphql::{check_rest_response, classify_cross_repo_fetch};
+use crate::graphql::{check_rest_response, classify_cross_repo_fetch, classify_issue_not_found};
 
 /// Parameters for creating a new GitHub issue.
 ///
@@ -933,7 +933,17 @@ impl GitHubClient {
             "number": number,
         });
 
-        let response = self.graphql(query, variables).await?;
+        // Bead unblock-drh: live GitHub returns the unresolvable-issue
+        // case as a GraphQL `errors` array with `type == "NOT_FOUND"`,
+        // not as a null `data.repository.issue` payload. The structural
+        // classifier translates the typed signal into
+        // [`DomainError::IssueNotFound`] before the empty-node-id
+        // fallback below — but the fallback stays as defence in depth
+        // for a hypothetical future schema variant.
+        let response = self
+            .graphql(query, variables)
+            .await
+            .map_err(|err| classify_issue_not_found(err, number))?;
         let node_id = response["data"]["repository"]["issue"]["id"]
             .as_str()
             .unwrap_or_default()
@@ -1245,10 +1255,19 @@ impl GitHubClient {
                 // a 403 (HTTP) or GraphQL FORBIDDEN response on this
                 // cross-repo resolver MUST upgrade to
                 // `DomainError::CrossRepoAccessDenied { owner, repo }`.
+                //
+                // Bead unblock-drh: compose with the
+                // NOT_FOUND→`IssueNotFound` classifier — order matters
+                // (`classify_cross_repo_fetch` consumes
+                // `GitHubGraphQLForbidden` before the structural-type
+                // classifier sees it, so the FORBIDDEN→CrossRepo
+                // upgrade always wins, matching the SPEC §11.1
+                // precedence).
                 let response = self
                     .graphql(query, variables)
                     .await
-                    .map_err(|err| classify_cross_repo_fetch(err, owner, repo))?;
+                    .map_err(|err| classify_cross_repo_fetch(err, owner, repo))
+                    .map_err(|err| classify_issue_not_found(err, *number))?;
                 let node_id = response["data"]["repository"]["issue"]["id"]
                     .as_str()
                     .unwrap_or_default()
@@ -2333,5 +2352,107 @@ mod tests {
             url,
             "https://github.com/alpha/upstream/issues/42#issuecomment-cross"
         );
+    }
+
+    // ── resolve_node_id / resolve_issue_ref: NOT_FOUND classifier (bead unblock-drh) ─
+
+    /// Bead unblock-drh: when `add_blocked_by`'s `resolve_node_id` call
+    /// for the blocker number receives the live GitHub
+    /// `errors[].type == "NOT_FOUND"` payload (the wire shape returned
+    /// for a non-existent issue number), the chain MUST surface
+    /// `DomainError::IssueNotFound { number: <blocker_number> }` —
+    /// not the generic 422 `GitHubGraphQL`. This is the
+    /// `add_blocked_by_returns_issue_not_found_for_nonexistent_number`
+    /// integration-test contract pinned at the unit layer (no
+    /// `GITHUB_TOKEN` required).
+    #[tokio::test]
+    async fn add_blocked_by_resolve_node_id_not_found_surfaces_issue_not_found() {
+        let server = MockServer::start().await;
+        let client = GitHubClient::new_for_test(&server.uri());
+
+        // First GraphQL call: fetch_issue for the (existing) primary
+        // issue. Return a populated issue payload so we proceed past
+        // it to the resolve_node_id call.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_json_matches_query("FetchIssue"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "id": "I_primary",
+                            "number": 1,
+                            "title": "primary",
+                            "body": null,
+                            "state": "OPEN",
+                            "url": "https://example.invalid/1",
+                            "createdAt": "2026-04-30T00:00:00Z",
+                            "updatedAt": "2026-04-30T00:00:00Z",
+                            "issueType": null,
+                            "labels": {"nodes": []},
+                            "milestone": null,
+                            "assignees": {"nodes": []},
+                            "comments": {"nodes": []},
+                            "blocking": {"nodes": []},
+                            "blockedBy": {"nodes": []},
+                            "parent": null,
+                            "subIssues": {"nodes": []},
+                            "projectItems": {"nodes": []}
+                        }
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        // Second GraphQL call: resolve_node_id for the missing
+        // blocker. Returns the live NOT_FOUND payload.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_json_matches_query("ResolveNodeId"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to an Issue with the number of 999999999."
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let err = client
+            .add_blocked_by(1, 999_999_999)
+            .await
+            .expect_err("missing blocker should produce Err");
+
+        match err {
+            Error::Domain {
+                source: DomainError::IssueNotFound { number },
+            } => {
+                assert_eq!(number, 999_999_999);
+            }
+            other => panic!("expected IssueNotFound Domain error, got: {other}"),
+        }
+    }
+
+    /// Wiremock `body_json` is too strict for our needs — we want to
+    /// match on the GraphQL operation name embedded in the JSON `query`
+    /// field. This helper returns a [`wiremock::Match`] that succeeds
+    /// when the request body's `query` field contains the given
+    /// operation name substring.
+    fn body_json_matches_query(operation: &'static str) -> impl wiremock::Match {
+        struct M(&'static str);
+        impl wiremock::Match for M {
+            fn matches(&self, request: &wiremock::Request) -> bool {
+                let Ok(body) = serde_json::from_slice::<serde_json::Value>(&request.body) else {
+                    return false;
+                };
+                body.get("query")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|q| q.contains(self.0))
+            }
+        }
+        M(operation)
     }
 }

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -617,7 +617,7 @@ struct OptionNode {
 fn remove_field(map: &mut HashMap<String, FieldMeta>, name: &str) -> Result<FieldMeta, Error> {
     map.remove(name).ok_or_else(|| {
         errors::GitHubGraphQLSnafu {
-            errors: vec![format!("Required field '{name}' was not resolved")],
+            errors: vec![format!("Required field '{name}' was not resolved").into()],
         }
         .build()
     })
@@ -628,7 +628,7 @@ fn remove_field(map: &mut HashMap<String, FieldMeta>, name: &str) -> Result<Fiel
 fn remove_plain_field(map: &mut HashMap<String, String>, name: &str) -> Result<String, Error> {
     map.remove(name).ok_or_else(|| {
         errors::GitHubGraphQLSnafu {
-            errors: vec![format!("Required field '{name}' was not resolved")],
+            errors: vec![format!("Required field '{name}' was not resolved").into()],
         }
         .build()
     })
@@ -675,11 +675,14 @@ impl GitHubClient {
 
         if project_id.is_empty() {
             return Err(errors::GitHubGraphQLSnafu {
-                errors: vec![format!(
-                    "Project V2 #{project_number} not found on {}/{}",
-                    self.owner(),
-                    self.repo()
-                )],
+                errors: vec![
+                    format!(
+                        "Project V2 #{project_number} not found on {}/{}",
+                        self.owner(),
+                        self.repo()
+                    )
+                    .into(),
+                ],
             }
             .build());
         }
@@ -688,7 +691,7 @@ impl GitHubClient {
 
         let number = u32::try_from(project_number).map_err(|_| {
             errors::GitHubGraphQLSnafu {
-                errors: vec![format!("Project number {project_number} exceeds u32::MAX")],
+                errors: vec![format!("Project number {project_number} exceeds u32::MAX").into()],
             }
             .build()
         })?;
@@ -1115,7 +1118,7 @@ impl GitHubClient {
 
         if field_id.is_empty() {
             return Err(errors::GitHubGraphQLSnafu {
-                errors: vec![format!("Failed to create field '{}'", spec.name)],
+                errors: vec![format!("Failed to create field '{}'", spec.name).into()],
             }
             .build());
         }
@@ -1183,10 +1186,9 @@ impl GitHubClient {
 
         if field_id.is_empty() {
             return Err(errors::GitHubGraphQLSnafu {
-                errors: vec![format!(
-                    "Failed to create single-select field '{}'",
-                    spec.name
-                )],
+                errors: vec![
+                    format!("Failed to create single-select field '{}'", spec.name).into(),
+                ],
             }
             .build());
         }
@@ -2156,14 +2158,17 @@ impl GitHubClient {
 
         if node_id.is_empty() {
             return Err(errors::GitHubGraphQLSnafu {
-                errors: vec![format!(
-                    "Could not resolve node ID for {} '{}' — check the owner name",
-                    match owner_type {
-                        OwnerType::Org => "organization",
-                        OwnerType::User => "user",
-                    },
-                    self.owner()
-                )],
+                errors: vec![
+                    format!(
+                        "Could not resolve node ID for {} '{}' — check the owner name",
+                        match owner_type {
+                            OwnerType::Org => "organization",
+                            OwnerType::User => "user",
+                        },
+                        self.owner()
+                    )
+                    .into(),
+                ],
             }
             .build());
         }
@@ -2336,9 +2341,12 @@ impl GitHubClient {
 
         if number == 0 || url.is_empty() {
             return Err(errors::GitHubGraphQLSnafu {
-                errors: vec![format!(
-                    "createProjectV2 mutation returned empty project data for title '{title}'"
-                )],
+                errors: vec![
+                    format!(
+                        "createProjectV2 mutation returned empty project data for title '{title}'"
+                    )
+                    .into(),
+                ],
             }
             .build());
         }

--- a/crates/unblock-mcp/src/errors.rs
+++ b/crates/unblock-mcp/src/errors.rs
@@ -222,7 +222,9 @@ mod tests {
     fn github_graphql_maps_to_invalid_params() {
         // GraphQL errors have status_code 422.
         let err = GitHubGraphQLSnafu {
-            errors: vec!["Field 'x' not found".to_owned()],
+            errors: vec![unblock_github::errors::GraphQLErrorEntry::message(
+                "Field 'x' not found",
+            )],
         }
         .build();
         let (code, msg) = convert(err);


### PR DESCRIPTION
## unblock-drh: Map GraphQL 'Could not resolve to an Issue' to IssueNotFound (404), not 422

Plumbs `errors[].type` through the GraphQL partition (Miguel's DECISION 2026-05-04, Option B) so call sites that know the queried issue number can route a typed `NOT_FOUND` signal to `DomainError::IssueNotFound` (HTTP 404) instead of the generic `GitHubGraphQL` variant (HTTP 422).

### What was done

- `errors.rs`: introduced `GraphQLErrorEntry { message, error_type }` and switched `GitHubGraphQL` / `GitHubGraphQLForbidden` `errors` fields from `Vec<String>` to `Vec<GraphQLErrorEntry>`. Display impls extract `.message`; `From<String>`/`From<&str>` impls keep synthetic call sites ergonomic.
- `graphql.rs`: partition populates `error_type` from upstream `errors[i].type`; new private `classify_issue_not_found(err, number)` upgrades `GitHubGraphQL` with `type=="NOT_FOUND"` + Issue-scoped message to `IssueNotFound`. Wired into `fetch_issue_in_repo` composing with `classify_cross_repo_fetch` so FORBIDDEN→CrossRepo upgrade still wins per SPEC §11.1 precedence.
- `mutations.rs`: classifier wired into `resolve_node_id` and `resolve_issue_ref` CrossRepo arm.
- `projects.rs` / `unblock-mcp` test: synthetic `GitHubGraphQLSnafu` call sites updated to the new entry shape via `.into()`.

### Files changed

- `crates/unblock-github/src/errors.rs`
- `crates/unblock-github/src/graphql.rs`
- `crates/unblock-github/src/mutations.rs`
- `crates/unblock-github/src/projects.rs`
- `crates/unblock-mcp/src/errors.rs`

### Decisions

None — followed Miguel's DECISION (Option B) and Sherlock's INVESTIGATION roadmap exactly. Implementation note on the structural shape: changed `Vec<String>`→`Vec<GraphQLErrorEntry>` rather than adding a parallel field — cleaner forward-compat for any future per-error structured signals and avoids the parallel-vector-out-of-sync hazard.

### Deviations

None — implemented as spec.

### Test plan

- [x] `cargo fmt --check --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all 1041 tests pass
- [x] `cargo doc --no-deps -p unblock-github` — zero warnings
- [x] 6 new unit tests for `classify_issue_not_found` (upgrade, repo-not-found passthrough, missing-type passthrough, FORBIDDEN passthrough, unrelated-error passthrough, multi-entry match)
- [x] 4 new wiremock end-to-end tests on `fetch_issue_in_repo` (local NOT_FOUND→IssueNotFound, cross-repo NOT_FOUND→IssueNotFound, cross-repo FORBIDDEN wins, repo-not-found stays as GraphQL)
- [x] 1 new wiremock test on `add_blocked_by` exercising the `resolve_node_id` classifier path (no `GITHUB_TOKEN` required)
- [ ] Live CI `test-mcp-live` job: the 4 #[ignore]-gated integration tests pinned by the bead acceptance turn green

### API change

`API:` `GraphQLErrorEntry` struct added to public `errors` module.

`BREAKING CHANGE:` `Error::GitHubGraphQL.errors` and `Error::GitHubGraphQLForbidden.errors` changed from `Vec<String>` to `Vec<GraphQLErrorEntry>`. Display output unchanged; downstream callers constructing these variants from a string literal can use the provided `From<String>` / `From<&str>` impls or `GraphQLErrorEntry::message()`.