### PR TITLE
unblock-q1c: live test fixtures populate Status/Priority/Agent on board

### DIFF
--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -636,6 +636,150 @@ fn remove_plain_field(map: &mut HashMap<String, String>, name: &str) -> Result<S
     })
 }
 
+/// Sets Projects V2 custom fields on a project item.
+///
+/// Updates Priority, Status, `PipelineStage`, Agent, `StoryPoints`, and
+/// `DeferUntil`. Each field update is best-effort: failures are logged as
+/// warnings via [`tracing::warn!`] but do not abort the remaining updates.
+/// This keeps the create flow resilient to partial project configuration
+/// (e.g. missing option values).
+///
+/// The `status` parameter controls the Status field value. Callers MUST
+/// source the string from
+/// [`unblock_core::types::Status::option_name`] — never a raw literal. Per
+/// `unblock-1zj` (spec §8.3) `create` always lands new issues in
+/// `Status::Backlog.option_name()` (= `"Backlog"`) regardless of blocker
+/// state, because Backlog is sticky.
+///
+/// `priority` and `pipeline_stage` use prefix matching (via
+/// [`FieldMeta::option_id_by_prefix`]) so callers can pass short codes like
+/// `"P0"` which resolve to the full option name `"P0 - Critical"`.
+///
+/// **Agent (introduced by `unblock-wgj`).** When `agent` is `Some(name)`,
+/// the Agent text field is written to `name`. When `None`, the Agent field
+/// write is SKIPPED (no field update mutation issued — distinct from
+/// writing an empty string). The caller is responsible for resolving the
+/// §8.1 precedence chain (explicit > `state.agent_kind_str()` > omit)
+/// BEFORE invoking this helper. Spec §8.3 step 4 "omit-empty rule".
+///
+/// `pipeline_stage` follows the same omit-on-`None` rule as Agent — when
+/// `None`, no mutation is issued.
+///
+/// # Errors
+///
+/// This helper does NOT return errors. Per-field failures are logged via
+/// [`tracing::warn!`] and the function continues with subsequent fields.
+/// Callers that need to fail-fast on a specific field write must call
+/// [`crate::api::GitHubApi::update_field`] directly.
+#[allow(clippy::too_many_arguments)]
+pub async fn set_project_fields(
+    client: &dyn crate::api::GitHubApi,
+    project_id: &str,
+    item_id: &str,
+    field_ids: &ProjectFieldIds,
+    priority: &str,
+    status: &str,
+    agent: Option<&str>,
+    pipeline_stage: Option<&str>,
+    story_points: Option<f64>,
+    defer_until: Option<NaiveDate>,
+) {
+    // Set Priority (prefix match: "P0" -> "P0 - Critical", etc.).
+    if let Some(option_id) = field_ids.priority.option_id_by_prefix(priority)
+        && let Err(e) = client
+            .update_field(
+                project_id,
+                item_id,
+                &field_ids.priority.field_id,
+                &FieldValue::SingleSelectOption(option_id.clone()),
+            )
+            .await
+    {
+        warn!(error = %e, "Failed to set Priority field");
+    }
+
+    // Set Status. Per `unblock-1zj` (spec §8.3 / Decision 2 — Backlog
+    // sticky), `create` lands every new issue in
+    // `Status::Backlog.option_name()` regardless of blocker state; the
+    // pre-`unblock-1zj` `ready` / `blocked` branch on
+    // `blocked_by_refs.is_empty()` is REMOVED. Other write tools (e.g.
+    // `claim`, `update`) drive Status away from `Backlog` via explicit
+    // user/agent transitions — they pass their own canonical option name
+    // through `status` here.
+    if let Some(option_id) = field_ids.status.options.get(status)
+        && let Err(e) = client
+            .update_field(
+                project_id,
+                item_id,
+                &field_ids.status.field_id,
+                &FieldValue::SingleSelectOption(option_id.clone()),
+            )
+            .await
+    {
+        warn!(error = %e, "Failed to set Status field");
+    }
+
+    // Set PipelineStage when Some — same prefix-match contract as Priority.
+    // None means SKIP the PipelineStage write (no mutation issued).
+    if let Some(stage) = pipeline_stage
+        && let Some(option_id) = field_ids.pipeline_stage.option_id_by_prefix(stage)
+        && let Err(e) = client
+            .update_field(
+                project_id,
+                item_id,
+                &field_ids.pipeline_stage.field_id,
+                &FieldValue::SingleSelectOption(option_id.clone()),
+            )
+            .await
+    {
+        warn!(error = %e, "Failed to set PipelineStage field");
+    }
+
+    // Set Agent — gated on §8.1 precedence chain. `None` means SKIP the
+    // Agent field write (Invariant 18, §14). The caller resolved the chain
+    // before calling this helper.
+    if let Some(agent_name) = agent
+        && let Err(e) = client
+            .update_field(
+                project_id,
+                item_id,
+                &field_ids.agent,
+                &FieldValue::Text(agent_name.to_owned()),
+            )
+            .await
+    {
+        warn!(error = %e, "Failed to set Agent field");
+    }
+
+    // Set StoryPoints if provided.
+    if let Some(sp) = story_points
+        && let Err(e) = client
+            .update_field(
+                project_id,
+                item_id,
+                &field_ids.story_points,
+                &FieldValue::Number(sp),
+            )
+            .await
+    {
+        warn!(error = %e, "Failed to set StoryPoints field");
+    }
+
+    // Set DeferUntil if provided.
+    if let Some(du) = defer_until
+        && let Err(e) = client
+            .update_field(
+                project_id,
+                item_id,
+                &field_ids.defer_until,
+                &FieldValue::Date(du),
+            )
+            .await
+    {
+        warn!(error = %e, "Failed to set DeferUntil field");
+    }
+}
+
 impl GitHubClient {
     /// Resolves the linked GitHub Projects V2 project for the configured repository.
     ///

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -200,6 +200,81 @@ pub(crate) fn fixture_labels(extra: &[&str]) -> Vec<String> {
     labels
 }
 
+/// Bead `unblock-q1c`: live test fixture project-field populator.
+///
+/// Idempotently runs `setup_fields` (caches `field_ids` on the client),
+/// resolves the project's item ID for the just-created issue, and writes
+/// Priority + Status (+ optional Agent / `PipelineStage`) via
+/// [`unblock_github::projects::set_project_fields`]. Mirrors the canonical
+/// exemplar in `crates/unblock-mcp/tests/e2e_workflow.rs` so live integration
+/// fixtures populate the canonical Projects V2 fields after `create_issue`,
+/// instead of leaving the live board's Status / Priority / Agent / Pipeline
+/// columns empty (defeats the "live documentation" goal of `unblock-wgj.22`).
+///
+/// Best-effort by design: per-field failures inside `set_project_fields`
+/// are logged via `tracing::warn!` and do not return errors. If the issue
+/// has no `ProjectV2Item` yet (cross-repo, project not configured), the
+/// function returns `None` so the caller can either skip the populate step
+/// or treat the missing item as a soft failure.
+///
+/// **Gating contract.** Callers MUST gate on
+/// [`require_github_token_and_project`] before invoking this helper —
+/// `setup_fields` requires `UNBLOCK_PROJECT` to be exported and panics in
+/// the `resolve_project_info` step otherwise.
+async fn populate_project_fields(
+    client: &Arc<GitHubClient>,
+    issue_node_id: &str,
+    priority: &str,
+    status_option_name: &str,
+    agent: Option<&str>,
+    pipeline_stage: Option<&str>,
+) -> Option<String> {
+    use unblock_github::GitHubApi;
+
+    let project_info = client
+        .resolve_project_info()
+        .await
+        .expect("resolve_project_info should succeed (UNBLOCK_PROJECT exported)");
+
+    // Idempotent — safe to call once per test even if a sibling test in the
+    // same process already ran setup_fields. Cache hit short-circuits the
+    // per-field round-trips; cache miss does the canonical 7-field setup.
+    if client.field_ids().await.is_none() {
+        let report = client
+            .setup_fields(&project_info.id)
+            .await
+            .expect("setup_fields should succeed");
+        client.set_field_ids(report.field_ids).await;
+    }
+
+    let field_ids = client
+        .field_ids()
+        .await
+        .expect("field_ids should be cached after setup_fields + set_field_ids");
+
+    let item_id = client
+        .get_project_item_id(issue_node_id, &project_info.id)
+        .await
+        .ok()?;
+
+    let api: &dyn GitHubApi = client.as_ref();
+    unblock_github::projects::set_project_fields(
+        api,
+        &project_info.id,
+        &item_id,
+        &field_ids,
+        priority,
+        status_option_name,
+        agent,
+        pipeline_stage,
+        None,
+        None,
+    )
+    .await;
+
+    Some(item_id)
+}
+
 // ── Canonical view names for the create_view live tests ────────────
 //
 // Per bead `unblock-1hz` decision D3 (option y — reuse stable-name refactor),
@@ -366,7 +441,11 @@ async fn fetch_issue_returns_full_details_for_existing_issue() {
     // `fetch_issue(1)` and broke against repos whose lowest issue number is
     // greater than 1, or whose issues have been deleted between live runs
     // (see beads `unblock-mwg`, `unblock-741`).
-    if !require_github_token() {
+    //
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -405,6 +484,18 @@ async fn fetch_issue_returns_full_details_for_existing_issue() {
     // not panic the guard) but *before* the asserts (so an assertion panic
     // still triggers cleanup).
     let mut guard = CloseIssueGuard::new(&client, created.number);
+
+    // Bead `unblock-q1c`: populate Projects V2 fields so the live board
+    // shows clean rows. Bug fixture (Appendix B.3) — P0 default.
+    populate_project_fields(
+        &client,
+        &created.node_id,
+        "P0",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     let issue = client
         .fetch_issue(created.number)
@@ -609,7 +700,12 @@ async fn fetch_graph_data_issues_have_valid_status_and_priority() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn create_issue_returns_issue_with_correct_fields() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board AND so the representative pin
+    // assertion below (`fetch_field_value` re-fetch) has a project to
+    // query.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -662,6 +758,56 @@ async fn create_issue_returns_issue_with_correct_fields() {
         "newly created issue should be Open"
     );
 
+    // Bead `unblock-q1c`: populate Projects V2 fields so the live board
+    // shows clean rows AND so this test acts as the representative
+    // fields-populated invariant pin point for the `unblock-github` live
+    // suite. Bug fixture (Appendix B.3) → P0 + Backlog (canonical
+    // create-time Status per spec §8.3) + integration-fixture agent.
+    let item_id = populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P0",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await
+    .expect("populate_project_fields should resolve a ProjectV2Item ID");
+
+    // Re-fetch the field values via the read path used by the
+    // `update_field_changes_value_on_project_item` test. Asserts the
+    // populate path actually wrote each field — `set_project_fields` is
+    // best-effort and only logs warnings on per-field failures, so the
+    // round-trip read is the only way to fail-fast on a regression that
+    // breaks the populate flow (bead `unblock-q1c` Risks).
+    let resolved_field_ids = client
+        .field_ids()
+        .await
+        .expect("field_ids should be cached after populate_project_fields");
+
+    let priority_value =
+        fetch_field_value(&client, &item_id, &resolved_field_ids.priority.field_id).await;
+    assert_eq!(
+        priority_value.as_deref(),
+        Some("P0 - Critical"),
+        "Priority should be populated to canonical 'P0 - Critical' after populate_project_fields"
+    );
+
+    let status_value =
+        fetch_field_value(&client, &item_id, &resolved_field_ids.status.field_id).await;
+    assert_eq!(
+        status_value.as_deref(),
+        Some(Status::Backlog.option_name()),
+        "Status should be populated to canonical Backlog after populate_project_fields"
+    );
+
+    let agent_value = fetch_field_value(&client, &item_id, &resolved_field_ids.agent).await;
+    assert_eq!(
+        agent_value.as_deref(),
+        Some("integration-fixture"),
+        "Agent should be populated to 'integration-fixture' after populate_project_fields"
+    );
+
     // Explicit cleanup on the happy path; disarm the guard so it does not
     // double-close.
     client
@@ -671,7 +817,7 @@ async fn create_issue_returns_issue_with_correct_fields() {
     guard.disarm();
 
     eprintln!(
-        "create_issue test: created and closed issue #{}",
+        "create_issue test: created, populated fields, asserted re-fetch, and closed issue #{}",
         issue.number
     );
 }
@@ -681,7 +827,10 @@ async fn create_issue_returns_issue_with_correct_fields() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn close_issue_closes_issue_and_refetch_confirms() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -715,6 +864,18 @@ async fn close_issue_closes_issue_and_refetch_confirms() {
     // Arm the drop guard so the issue is closed even if an assertion panics.
     let mut guard = CloseIssueGuard::new(&client, issue.number);
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Refactor fixture
+    // (Appendix B.3) → P1 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P1",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     // Close it without a reason.
     client
         .close_issue(issue.number, None)
@@ -742,7 +903,10 @@ async fn close_issue_closes_issue_and_refetch_confirms() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn close_issue_with_reason_adds_comment_before_closing() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -756,6 +920,10 @@ async fn close_issue_with_reason_adds_comment_before_closing() {
     // Create a Spike fixture to close with a reason (spec Appendix
     // B.3 — unblock-wgj.22). Exercises the `Spike` IssueType +
     // canonical Priority default (P2 — Medium).
+    //
+    // Bead `unblock-q1c` DRIFT-D closure: `issue_type` populated with
+    // canonical Spike (was `None`, contradicting Appendix B.3 "all 8
+    // IssueType variants exercised").
     let params = CreateIssueParams {
         title: "Investigate flaky checkout test".to_owned(),
         body: Some(
@@ -767,7 +935,7 @@ async fn close_issue_with_reason_adds_comment_before_closing() {
         labels: fixture_labels(&["test"]),
         milestone: None,
         assignees: vec![],
-        issue_type: None,
+        issue_type: Some(IssueType::Spike.canonical_name().to_owned()),
     };
 
     let issue = client
@@ -777,6 +945,18 @@ async fn close_issue_with_reason_adds_comment_before_closing() {
 
     // Arm the drop guard so the issue is closed even if an assertion panics.
     let mut guard = CloseIssueGuard::new(&client, issue.number);
+
+    // Bead `unblock-q1c`: populate Projects V2 fields. Spike fixture
+    // (Appendix B.3) → P2 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     let reason_text = "Closing because the test is complete.";
 
@@ -855,7 +1035,10 @@ async fn close_issue_returns_issue_not_found_for_nonexistent_number() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn add_comment_posts_comment_and_returns_url() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -888,6 +1071,20 @@ async fn add_comment_posts_comment_and_returns_url() {
 
     // Arm the drop guard so the issue is closed even if an assertion panics.
     let mut guard = CloseIssueGuard::new(&client, issue.number);
+
+    // Bead `unblock-q1c`: populate Projects V2 fields. Docs fixture
+    // (Appendix B.3) → P3 + Backlog. Agent intentionally `None` to
+    // exercise the §8.3 / §8.6 absence-leaves-unmodified edge case
+    // (matches the canonical e2e_workflow.rs pattern for issue C).
+    populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P3",
+        Status::Backlog.option_name(),
+        None,
+        None,
+    )
+    .await;
 
     let comment_body = "Integration test comment — hello from add_comment!";
 
@@ -967,7 +1164,10 @@ async fn add_comment_returns_issue_not_found_for_nonexistent_number() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn add_blocked_by_creates_blocking_relationship() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -994,6 +1194,18 @@ async fn add_blocked_by_creates_blocking_relationship() {
 
     let mut guard_a = CloseIssueGuard::new(&client, issue_a.number);
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Task fixture
+    // (Appendix B.3) → P2 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &issue_a.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     let issue_b = client
         .create_issue(CreateIssueParams {
             title: "Add OAuth token validation".to_owned(),
@@ -1007,6 +1219,16 @@ async fn add_blocked_by_creates_blocking_relationship() {
         .expect("create_issue B should succeed");
 
     let mut guard_b = CloseIssueGuard::new(&client, issue_b.number);
+
+    populate_project_fields(
+        &client,
+        &issue_b.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Add blocking relationship: A is blocked by B.
     client
@@ -1058,7 +1280,10 @@ async fn add_blocked_by_creates_blocking_relationship() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn remove_blocked_by_removes_blocking_relationship() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -1086,6 +1311,18 @@ async fn remove_blocked_by_removes_blocking_relationship() {
 
     let mut guard_a = CloseIssueGuard::new(&client, issue_a.number);
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Chore fixture
+    // (Appendix B.3) → P4 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &issue_a.node_id,
+        "P4",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     let issue_b = client
         .create_issue(CreateIssueParams {
             title: "Migrate auth middleware to async".to_owned(),
@@ -1099,6 +1336,17 @@ async fn remove_blocked_by_removes_blocking_relationship() {
         .expect("create_issue B should succeed");
 
     let mut guard_b = CloseIssueGuard::new(&client, issue_b.number);
+
+    // Refactor fixture (Appendix B.3) → P1 + Backlog.
+    populate_project_fields(
+        &client,
+        &issue_b.node_id,
+        "P1",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Add, then remove the blocking relationship.
     client
@@ -1152,7 +1400,10 @@ async fn remove_blocked_by_removes_blocking_relationship() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn add_blocked_by_duplicate_returns_duplicate_dependency() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -1178,6 +1429,18 @@ async fn add_blocked_by_duplicate_returns_duplicate_dependency() {
 
     let mut guard_a = CloseIssueGuard::new(&client, issue_a.number);
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Spike fixture
+    // (Appendix B.3) → P2 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &issue_a.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     let issue_b = client
         .create_issue(CreateIssueParams {
             title: "Fix authentication bypass in /login endpoint".to_owned(),
@@ -1191,6 +1454,17 @@ async fn add_blocked_by_duplicate_returns_duplicate_dependency() {
         .expect("create_issue B should succeed");
 
     let mut guard_b = CloseIssueGuard::new(&client, issue_b.number);
+
+    // Bug fixture (Appendix B.3) → P0 + Backlog.
+    populate_project_fields(
+        &client,
+        &issue_b.node_id,
+        "P0",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // First add should succeed.
     client
@@ -1291,7 +1565,10 @@ async fn remove_blocked_by_returns_issue_not_found_for_nonexistent_number() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn add_sub_issue_creates_parent_child_relationship() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -1320,6 +1597,19 @@ async fn add_sub_issue_creates_parent_child_relationship() {
 
     let mut guard_parent = CloseIssueGuard::new(&client, parent.number);
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Epic parent
+    // (Appendix B.3 — Implement OAuth login flow) → P1 + Backlog +
+    // integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &parent.node_id,
+        "P1",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     let child = client
         .create_issue(CreateIssueParams {
             title: "Add OAuth callback handler".to_owned(),
@@ -1333,6 +1623,17 @@ async fn add_sub_issue_creates_parent_child_relationship() {
         .expect("create child should succeed");
 
     let mut guard_child = CloseIssueGuard::new(&client, child.number);
+
+    // Task child (Appendix B.3) → P2 + Backlog.
+    populate_project_fields(
+        &client,
+        &child.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Add sub-issue relationship.
     client

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -2043,6 +2043,19 @@ async fn query_setup_status_reports_fields_without_creating() {
 
 // ── Projects V2: update_field ───────────────────────────────────────
 
+// This test intentionally exercises `GitHubClient::update_field` directly
+// rather than going through the `populate_project_fields` helper introduced
+// in unblock-q1c. `update_field` is the unit-under-test here: this is the
+// only live coverage that pins its single-field write contract (Priority
+// SingleSelect + Agent Text re-fetch round-trip, including the
+// `option_id_by_prefix` resolution path documented in unblock-ekf). The
+// q1c migration (set_project_fields → populate_project_fields wrapper)
+// targeted FIXTURE sites that create an issue and then leave its custom
+// fields blank — this test is not such a site; it is the dedicated
+// `update_field` regression test and must keep calling `update_field`
+// directly so a regression there fails this assertion rather than being
+// masked by the higher-level helper. Do NOT migrate this call to
+// `populate_project_fields`.
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via `cargo test --workspace -- --ignored` with GITHUB_TOKEN set"]
 async fn update_field_changes_value_on_project_item() {

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -284,143 +284,14 @@ impl UnblockServer {
     }
 }
 
-/// Set project fields on a newly created issue's project item.
-///
-/// Generates [`set_project_fields`] with the correct visibility:
-/// `pub` when the `test-hooks` feature is enabled (integration tests),
-/// `pub(crate)` otherwise (production builds).
-macro_rules! define_set_project_fields {
-    ($vis:vis) => {
-        /// Updates Priority, Status, Agent, `StoryPoints`, and
-        /// `DeferUntil`. Each field update is best-effort: failures are
-        /// logged as warnings but do not abort the remaining updates.
-        /// This keeps the create flow resilient to partial project
-        /// configuration (e.g. missing option values).
-        ///
-        /// The `status` parameter controls the initial Status field
-        /// value. Callers MUST source the string from
-        /// [`unblock_core::types::Status::option_name`] — never a raw
-        /// literal. Per `unblock-1zj` (spec §8.3) `create` always lands
-        /// new issues in `Status::Backlog.option_name()` (= `"Backlog"`)
-        /// regardless of blocker state, because Backlog is sticky.
-        ///
-        /// Priority uses prefix matching so callers can pass short
-        /// codes like `"P0"` which resolve to the full option name
-        /// `"P0 - Critical"`.
-        ///
-        /// **Agent (introduced by `unblock-wgj`).** When `agent` is
-        /// `Some(name)`, the Agent text field is written to `name`.
-        /// When `None`, the Agent field write is SKIPPED (no field
-        /// update mutation issued — distinct from writing an empty
-        /// string). The caller is responsible for resolving the §8.1
-        /// precedence chain (explicit > `state.agent_kind_str()` >
-        /// omit) BEFORE invoking this helper. Spec §8.3 step 4
-        /// "omit-empty rule".
-        ///
-        /// Exposed to integration tests when the `test-hooks` feature
-        /// is enabled. Production builds keep this `pub(crate)` so it
-        /// never appears on the library surface.
-        #[allow(clippy::too_many_arguments)]
-        $vis async fn set_project_fields(
-            client: &dyn GitHubApi,
-            project_id: &str,
-            item_id: &str,
-            field_ids: &unblock_github::projects::ProjectFieldIds,
-            priority: &str,
-            status: &str,
-            agent: Option<&str>,
-            story_points: Option<f64>,
-            defer_until: Option<chrono::NaiveDate>,
-        ) {
-            use unblock_github::projects::FieldValue;
-
-            // Set Priority (prefix match: "P0" -> "P0 - Critical", etc.).
-            if let Some(option_id) = field_ids.priority.option_id_by_prefix(priority)
-                && let Err(e) = client
-                    .update_field(
-                        project_id,
-                        item_id,
-                        &field_ids.priority.field_id,
-                        &FieldValue::SingleSelectOption(option_id.clone()),
-                    )
-                    .await
-            {
-                tracing::warn!(error = %e, "Failed to set Priority field");
-            }
-
-            // Set Status. Per `unblock-1zj` (spec §8.3 / Decision 2 — Backlog
-            // sticky), `create` lands every new issue in
-            // `Status::Backlog.option_name()` regardless of blocker state;
-            // the pre-`unblock-1zj` `ready` / `blocked` branch on
-            // `blocked_by_refs.is_empty()` is REMOVED. Other write tools
-            // (e.g. `claim`, `update`) drive Status away from `Backlog` via
-            // explicit user/agent transitions — they pass their own
-            // canonical option name through `status` here.
-            if let Some(option_id) = field_ids.status.options.get(status)
-                && let Err(e) = client
-                    .update_field(
-                        project_id,
-                        item_id,
-                        &field_ids.status.field_id,
-                        &FieldValue::SingleSelectOption(option_id.clone()),
-                    )
-                    .await
-            {
-                tracing::warn!(error = %e, "Failed to set Status field");
-            }
-
-            // Set Agent — gated on §8.1 precedence chain. `None` means
-            // SKIP the Agent field write (Invariant 18, §14). The
-            // caller resolved the chain before calling this helper.
-            if let Some(agent_name) = agent
-                && let Err(e) = client
-                    .update_field(
-                        project_id,
-                        item_id,
-                        &field_ids.agent,
-                        &FieldValue::Text(agent_name.to_owned()),
-                    )
-                    .await
-            {
-                tracing::warn!(error = %e, "Failed to set Agent field");
-            }
-
-            // Set StoryPoints if provided.
-            if let Some(sp) = story_points
-                && let Err(e) = client
-                    .update_field(
-                        project_id,
-                        item_id,
-                        &field_ids.story_points,
-                        &FieldValue::Number(sp),
-                    )
-                    .await
-            {
-                tracing::warn!(error = %e, "Failed to set StoryPoints field");
-            }
-
-            // Set DeferUntil if provided.
-            if let Some(du) = defer_until
-                && let Err(e) = client
-                    .update_field(
-                        project_id,
-                        item_id,
-                        &field_ids.defer_until,
-                        &FieldValue::Date(du),
-                    )
-                    .await
-            {
-                tracing::warn!(error = %e, "Failed to set DeferUntil field");
-            }
-        }
-    };
-}
-
-#[cfg(feature = "test-hooks")]
-define_set_project_fields!(pub);
-
-#[cfg(not(feature = "test-hooks"))]
-define_set_project_fields!(pub(crate));
+// `set_project_fields` was promoted from this module to
+// `unblock_github::projects::set_project_fields` by `unblock-q1c` so live
+// integration test fixtures in the `unblock-github` crate (which cannot
+// depend on `unblock-mcp`) can populate the canonical Projects V2 fields
+// after `create_issue`. The helper is re-exported below to keep existing
+// `unblock_mcp::server::set_project_fields` import paths working — the
+// canonical home is now `unblock_github::projects`.
+pub use unblock_github::projects::set_project_fields;
 
 /// Applies a [`BodySectionUpdate`] to a [`BodySections`] struct.
 ///
@@ -2106,6 +1977,12 @@ impl UnblockServer {
                                         &priority_owned,
                                         initial_status,
                                         effective_agent.as_deref(),
+                                        // PipelineStage is not set on
+                                        // create — it is driven by the
+                                        // `claim`/`update` flow per spec
+                                        // §6.4 / §8.3 (no PipelineStage
+                                        // default at create-time).
+                                        None,
                                         story_points,
                                         defer_until,
                                     )

--- a/crates/unblock-mcp/tests/e2e_workflow.rs
+++ b/crates/unblock-mcp/tests/e2e_workflow.rs
@@ -310,10 +310,11 @@ async fn e2e_workflow_all_10_tools() {
         .await
         && let Some(field_ids) = client.field_ids().await
     {
-        // NOTE: story_points / defer_until (the trailing `None, None` args here
-        // and at the analogous call sites for issues B and C below) are not
-        // exercised by this e2e test — only the priority/status/agent axes are
-        // validated end-to-end against the live GitHub Project.
+        // NOTE: pipeline_stage / story_points / defer_until (the trailing
+        // `None, None, None` args here and at the analogous call sites for
+        // issues B and C below) are not exercised by this e2e test — only
+        // the priority/status/agent axes are validated end-to-end against
+        // the live GitHub Project.
         set_project_fields(
             client.as_ref(),
             &project_info.id,
@@ -322,6 +323,7 @@ async fn e2e_workflow_all_10_tools() {
             "P1",
             unblock_core::types::Status::Ready.option_name(),
             Some("claude-code"),
+            None,
             None,
             None,
         )
@@ -378,6 +380,7 @@ async fn e2e_workflow_all_10_tools() {
             Some("claude-code"),
             None,
             None,
+            None,
         )
         .await;
     }
@@ -429,6 +432,7 @@ async fn e2e_workflow_all_10_tools() {
             &field_ids,
             "P3",
             unblock_core::types::Status::Ready.option_name(),
+            None,
             None,
             None,
             None,

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -50,6 +50,166 @@ fn qid(number: u64) -> QualifiedId {
     QualifiedId::new("test", "repo", number)
 }
 
+/// Bead `unblock-q1c`: live test fixture project-field populator.
+///
+/// Idempotently runs `setup_fields` (caches `field_ids` on the client),
+/// resolves the project's item ID for the just-created issue, and writes
+/// Priority + Status (+ optional Agent / `PipelineStage`) via
+/// [`unblock_github::projects::set_project_fields`]. Mirrors the canonical
+/// exemplar in `crates/unblock-mcp/tests/e2e_workflow.rs` so live integration
+/// fixtures populate the canonical Projects V2 fields after `create_issue`,
+/// instead of leaving the live board's Status / Priority / Agent / Pipeline
+/// columns empty (defeats the "live documentation" goal of `unblock-wgj.22`).
+///
+/// Best-effort by design: per-field failures inside `set_project_fields`
+/// are logged via `tracing::warn!` and do not return errors. If the issue
+/// has no `ProjectV2Item` yet (cross-repo, project not configured), the
+/// function returns `None` so the caller can either skip the populate step
+/// or treat the missing item as a soft failure.
+///
+/// **Gating contract.** Callers MUST gate on
+/// [`require_github_token_and_project`] before invoking this helper —
+/// `setup_fields` requires `UNBLOCK_PROJECT` to be exported and panics in
+/// the `resolve_project_info` step otherwise.
+async fn populate_project_fields(
+    client: &Arc<dyn GitHubApi>,
+    issue_node_id: &str,
+    priority: &str,
+    status_option_name: &str,
+    agent: Option<&str>,
+    pipeline_stage: Option<&str>,
+) -> Option<String> {
+    let project_info = client
+        .resolve_project_info()
+        .await
+        .expect("resolve_project_info should succeed (UNBLOCK_PROJECT exported)");
+
+    // Idempotent — safe to call once per test even if a sibling test in the
+    // same process already ran setup_fields. Cache hit short-circuits the
+    // per-field round-trips; cache miss does the canonical 7-field setup.
+    if client.field_ids().await.is_none() {
+        let report = client
+            .setup_fields(&project_info.id)
+            .await
+            .expect("setup_fields should succeed");
+        client.set_field_ids(report.field_ids).await;
+    }
+
+    let field_ids = client
+        .field_ids()
+        .await
+        .expect("field_ids should be cached after setup_fields + set_field_ids");
+
+    let item_id = client
+        .get_project_item_id(issue_node_id, &project_info.id)
+        .await
+        .ok()?;
+
+    unblock_github::projects::set_project_fields(
+        client.as_ref(),
+        &project_info.id,
+        &item_id,
+        &field_ids,
+        priority,
+        status_option_name,
+        agent,
+        pipeline_stage,
+        None,
+        None,
+    )
+    .await;
+
+    Some(item_id)
+}
+
+/// Bead `unblock-q1c`: live-test re-fetch helper used by representative pin
+/// assertions to verify that `populate_project_fields` actually wrote the
+/// canonical Projects V2 field values. Mirrors the
+/// `fetch_field_value` helper in
+/// `crates/unblock-github/tests/integration.rs` but uses a fresh reqwest
+/// [`reqwest::Client`] sourced from the live `GITHUB_TOKEN` so this test
+/// crate doesn't need to reach into `GitHubClient::http()` (which is
+/// `pub(crate)` to the `unblock-github` crate).
+///
+/// Returns `Some(value)` if found, `None` otherwise.
+async fn fetch_field_value_via_graphql(
+    client: &Arc<dyn GitHubApi>,
+    item_id: &str,
+    field_id: &str,
+) -> Option<String> {
+    let token = std::env::var("GITHUB_TOKEN").ok()?;
+
+    let query = "
+        query ItemFieldValue($itemId: ID!) {
+            node(id: $itemId) {
+                ... on ProjectV2Item {
+                    fieldValues(first: 30) {
+                        nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                                field { ... on ProjectV2SingleSelectField { id } }
+                                name
+                            }
+                            ... on ProjectV2ItemFieldTextValue {
+                                field { ... on ProjectV2Field { id } }
+                                text
+                            }
+                            ... on ProjectV2ItemFieldNumberValue {
+                                field { ... on ProjectV2Field { id } }
+                                number
+                            }
+                            ... on ProjectV2ItemFieldDateValue {
+                                field { ... on ProjectV2Field { id } }
+                                date
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ";
+
+    let body = serde_json::json!({
+        "query": query,
+        "variables": { "itemId": item_id },
+    });
+
+    let http = reqwest::Client::new();
+    let response: serde_json::Value = http
+        .post(client.graphql_url())
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .expect("GraphQL request should succeed")
+        .json()
+        .await
+        .expect("GraphQL response should be valid JSON");
+
+    let nodes = response["data"]["node"]["fieldValues"]["nodes"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+
+    for node in &nodes {
+        if node["field"]["id"].as_str() == Some(field_id) {
+            if let Some(name) = node["name"].as_str() {
+                return Some(name.to_owned());
+            }
+            if let Some(text) = node["text"].as_str() {
+                return Some(text.to_owned());
+            }
+            if let Some(number) = node["number"].as_f64() {
+                return Some(number.to_string());
+            }
+            if let Some(date) = node["date"].as_str() {
+                return Some(date.to_owned());
+            }
+        }
+    }
+
+    None
+}
+
 /// Build a minimal `Issue` for testing (used to populate the cache).
 fn test_issue(number: u64, state: IssueState) -> unblock_core::types::Issue {
     unblock_core::types::Issue {
@@ -202,7 +362,10 @@ impl Drop for CloseIssueGuard {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn show_existing_issue_returns_all_fields_populated() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
@@ -238,6 +401,18 @@ async fn show_existing_issue_returns_all_fields_populated() {
     // not panic the guard) but *before* the asserts (so an assertion panic
     // still triggers cleanup).
     let mut guard = CloseIssueGuard::new(Arc::clone(&client), created.number);
+
+    // Bead `unblock-q1c`: populate Projects V2 fields. Bug fixture
+    // (Appendix B.3) → P0 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &created.node_id,
+        "P0",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Invoke the MCP `show` tool against the freshly provisioned fixture.
     let server = UnblockServer::new(state);
@@ -4351,12 +4526,17 @@ fn issue_ref_parse_invalid_returns_error() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn create_issue_with_all_params_and_refetch() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board AND so the representative pin
+    // assertion below (re-fetch via `fetch_field_value_via_graphql`) has
+    // a project to query.
+    if !require_github_token_and_project() {
         return;
     }
 
     let state = test_server_state().await;
-    let client = &state.github;
+    let client = Arc::clone(&state.github);
 
     // Realistic Bug fixture (spec Appendix B.3 — unblock-wgj.22).
     let title = format!(
@@ -4398,6 +4578,57 @@ async fn create_issue_with_all_params_and_refetch() {
         issue.number, issue.title, issue.url
     );
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Bug fixture
+    // (Appendix B.3) → P0 + Backlog (canonical create-time Status per
+    // spec §8.3) + integration-fixture agent. This test acts as the
+    // representative fields-populated invariant pin point for the
+    // `unblock-mcp` live integration suite.
+    let item_id = populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P0",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await
+    .expect("populate_project_fields should resolve a ProjectV2Item ID");
+
+    // Re-fetch the field values via GraphQL and assert the populate path
+    // actually wrote each field — `set_project_fields` is best-effort and
+    // only logs warnings on per-field failures, so the round-trip read is
+    // the only way to fail-fast on a regression that breaks the populate
+    // flow (bead `unblock-q1c` Risks).
+    let resolved_field_ids = client
+        .field_ids()
+        .await
+        .expect("field_ids should be cached after populate_project_fields");
+
+    let priority_value =
+        fetch_field_value_via_graphql(&client, &item_id, &resolved_field_ids.priority.field_id)
+            .await;
+    assert_eq!(
+        priority_value.as_deref(),
+        Some("P0 - Critical"),
+        "Priority should be populated to canonical 'P0 - Critical' after populate_project_fields"
+    );
+
+    let status_value =
+        fetch_field_value_via_graphql(&client, &item_id, &resolved_field_ids.status.field_id).await;
+    assert_eq!(
+        status_value.as_deref(),
+        Some(Status::Backlog.option_name()),
+        "Status should be populated to canonical Backlog after populate_project_fields"
+    );
+
+    let agent_value =
+        fetch_field_value_via_graphql(&client, &item_id, &resolved_field_ids.agent).await;
+    assert_eq!(
+        agent_value.as_deref(),
+        Some("integration-fixture"),
+        "Agent should be populated to 'integration-fixture' after populate_project_fields"
+    );
+
     // Re-fetch and verify.
     let refetched = client
         .fetch_issue(issue.number)
@@ -4417,12 +4648,15 @@ async fn create_issue_with_all_params_and_refetch() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn create_issue_with_blocked_by_local() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
     let state = test_server_state().await;
-    let client = &state.github;
+    let client = Arc::clone(&state.github);
 
     // Create blocker issue first.
     // Spec Appendix B.3 — `issue_type` matches the realistic title
@@ -4444,7 +4678,24 @@ async fn create_issue_with_blocked_by_local() {
         .await
         .expect("create blocker issue should succeed");
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Refactor fixture
+    // (Appendix B.3) → P1 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &blocking_issue.node_id,
+        "P1",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     // Create blocked issue.
+    //
+    // Bead `unblock-q1c` DRIFT-D closure: `issue_type` populated with
+    // canonical Task (was `None`, contradicting Appendix B.3 "all 8
+    // IssueType variants exercised") to match the realistic title
+    // (`Add OAuth callback handler` — Task in Appendix B.3).
     let dependent_title = format!(
         "Add OAuth callback handler {}",
         chrono::Utc::now().timestamp()
@@ -4456,10 +4707,21 @@ async fn create_issue_with_blocked_by_local() {
             labels: fixture_labels(&["test"]),
             milestone: None,
             assignees: Vec::new(),
-            issue_type: None,
+            issue_type: Some(IssueType::Task.canonical_name().to_owned()),
         })
         .await
         .expect("create blocked issue should succeed");
+
+    // Task fixture (Appendix B.3) → P2 + Backlog.
+    populate_project_fields(
+        &client,
+        &dependent_issue.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Add blocking relationship.
     client
@@ -4504,12 +4766,15 @@ async fn create_issue_with_blocked_by_local() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn create_issue_with_blocked_by_cross_repo() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
     let state = test_server_state().await;
-    let client = &state.github;
+    let client = Arc::clone(&state.github);
 
     // Extract owner/repo from the client so we can construct a CrossRepo ref
     // pointing at the same repo.
@@ -4536,7 +4801,24 @@ async fn create_issue_with_blocked_by_cross_repo() {
         .await
         .expect("create blocker issue should succeed");
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Spike fixture
+    // (Appendix B.3) → P2 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &blocking_issue.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     // Create dependent issue.
+    //
+    // Bead `unblock-q1c` DRIFT-D closure: `issue_type` populated with
+    // canonical Task (was `None`, contradicting Appendix B.3 "all 8
+    // IssueType variants exercised") to match the realistic title
+    // (`Add OAuth token validation` — Task in Appendix B.3).
     let dependent_title = format!(
         "Add OAuth token validation {}",
         chrono::Utc::now().timestamp()
@@ -4548,10 +4830,21 @@ async fn create_issue_with_blocked_by_cross_repo() {
             labels: fixture_labels(&["test"]),
             milestone: None,
             assignees: Vec::new(),
-            issue_type: None,
+            issue_type: Some(IssueType::Task.canonical_name().to_owned()),
         })
         .await
         .expect("create blocked issue should succeed");
+
+    // Task fixture (Appendix B.3) → P2 + Backlog.
+    populate_project_fields(
+        &client,
+        &dependent_issue.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Build a CrossRepo IssueRef pointing at the blocker in the same repo.
     // This exercises the full cross-repo GraphQL resolution code path
@@ -4599,12 +4892,15 @@ async fn create_issue_with_blocked_by_cross_repo() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn create_issue_with_parent_sub_issue() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
     let state = test_server_state().await;
-    let client = &state.github;
+    let client = Arc::clone(&state.github);
 
     // Create parent issue.
     // Spec Appendix B.3 — Epic+Task hierarchy. The parent "OAuth login
@@ -4628,6 +4924,18 @@ async fn create_issue_with_parent_sub_issue() {
         .await
         .expect("create parent issue should succeed");
 
+    // Bead `unblock-q1c`: populate Projects V2 fields. Epic parent
+    // (Appendix B.3) → P1 + Backlog + integration-fixture agent.
+    populate_project_fields(
+        &client,
+        &parent.node_id,
+        "P1",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
+
     // Create child issue.
     let child_title = format!(
         "Add OAuth callback handler {}",
@@ -4644,6 +4952,17 @@ async fn create_issue_with_parent_sub_issue() {
         })
         .await
         .expect("create child issue should succeed");
+
+    // Task child (Appendix B.3) → P2 + Backlog.
+    populate_project_fields(
+        &client,
+        &child.node_id,
+        "P2",
+        Status::Backlog.option_name(),
+        Some("integration-fixture"),
+        None,
+    )
+    .await;
 
     // Add parent relationship.
     client
@@ -4686,12 +5005,15 @@ async fn create_issue_with_parent_sub_issue() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn create_issue_with_defaults() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board.
+    if !require_github_token_and_project() {
         return;
     }
 
     let state = test_server_state().await;
-    let client = &state.github;
+    let client = Arc::clone(&state.github);
 
     let title = format!(
         "Bump dependency versions {}",
@@ -4713,6 +5035,10 @@ async fn create_issue_with_defaults() {
             labels: Vec::new(),
             milestone: None,
             assignees: Vec::new(),
+            // Intentionally `None` — this test specifically exercises the
+            // omit branch on `issue_type` (per `unblock-q1c` Sherlock
+            // investigation, this is the canonical "create-with-defaults"
+            // edge case for the §8.3 absence-leaves-unmodified rule).
             issue_type: None,
         })
         .await
@@ -4723,7 +5049,22 @@ async fn create_issue_with_defaults() {
     // still triggers cleanup). The guard fire-and-forgets the close on
     // drop; on the success path we disarm and explicitly close below so
     // the cleanup is awaited inside the test runtime.
-    let mut guard = CloseIssueGuard::new(Arc::clone(client), issue.number);
+    let mut guard = CloseIssueGuard::new(Arc::clone(&client), issue.number);
+
+    // Bead `unblock-q1c`: populate Projects V2 fields. Chore-style fixture
+    // (Appendix B.3) → P4 + Backlog. Agent intentionally `None` to
+    // exercise the §8.1 / §8.3 absence-leaves-unmodified leg of the
+    // precedence chain (matches the canonical e2e_workflow.rs pattern
+    // for issue C).
+    populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P4",
+        Status::Backlog.option_name(),
+        None,
+        None,
+    )
+    .await;
 
     assert_eq!(issue.title, title);
     assert!(issue.number > 0);
@@ -4787,12 +5128,18 @@ async fn ensure_labels_creates_missing_labels() {
 #[tokio::test]
 #[ignore = "live GitHub API — opt-in via cargo test --workspace -- --ignored with GITHUB_TOKEN + UNBLOCK_REPO"]
 async fn create_issue_appears_in_ready_set_after_rebuild() {
-    if !require_github_token() {
+    // Bead `unblock-q1c`: gates on `require_github_token_and_project` so
+    // the post-create `populate_project_fields` step can write Status /
+    // Priority / Agent on the live board. Critical here because the
+    // ready-set behaviour this test depends on requires `Status::Backlog`
+    // to be recorded (per spec §8.3 — Backlog is the canonical
+    // create-time Status).
+    if !require_github_token_and_project() {
         return;
     }
 
     let state = test_server_state().await;
-    let client = &state.github;
+    let client = Arc::clone(&state.github);
 
     let title = format!(
         "Document Projects V2 setup workflow {}",
@@ -4813,6 +5160,20 @@ async fn create_issue_appears_in_ready_set_after_rebuild() {
         })
         .await
         .expect("create_issue should succeed");
+
+    // Bead `unblock-q1c`: populate Projects V2 fields. Docs fixture
+    // (Appendix B.3) → P3 + Backlog. Agent intentionally `None` to
+    // exercise the §8.3 absence-leaves-unmodified edge case (matches the
+    // canonical e2e_workflow.rs pattern for issue C).
+    populate_project_fields(
+        &client,
+        &issue.node_id,
+        "P3",
+        Status::Backlog.option_name(),
+        None,
+        None,
+    )
+    .await;
 
     // Rebuild cache.
     unblock_mcp::tools::rebuild_cache(&state).await;

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -173,10 +173,21 @@ async fn fetch_field_value_via_graphql(
         "variables": { "itemId": item_id },
     });
 
-    let http = reqwest::Client::new();
+    // GitHub's GraphQL API rejects requests without a User-Agent and
+    // returns a non-JSON HTML error page (causing a Decode error at
+    // `.json()`). The sister helper in `unblock-github/tests/integration.rs`
+    // reuses `GitHubClient::http()`, which is built with a User-Agent in
+    // `crates/unblock-github/src/client.rs`. Mirror that contract here so
+    // the live pin assertion at `create_issue_with_all_params_and_refetch`
+    // does not panic on the API gateway's HTML response.
+    let http = reqwest::Client::builder()
+        .user_agent(concat!("unblock-mcp-tests/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("reqwest client build");
     let response: serde_json::Value = http
         .post(client.graphql_url())
         .bearer_auth(&token)
+        .header("Accept", "application/vnd.github+json")
         .json(&body)
         .send()
         .await


### PR DESCRIPTION
## unblock-q1c: Live test fixtures bypass set_project_fields

Live integration test fixtures called `create_issue` (REST direct) but never followed up with `set_project_fields`, so the Projects V2 SingleSelect/Text/Number/Date custom fields stayed empty on the live board (`No status` / `Choose an option` / `Enter text...`). Only `e2e_workflow.rs` ran the full `setup_fields → set_field_ids → create_issue → set_project_fields` sequence.

### What was done
- Promoted `set_project_fields` from `unblock_mcp::server` (macro-gated `pub` / `pub(crate)`) to a public free function on `unblock_github::projects`. Required because `unblock-github` cannot depend on `unblock-mcp` (cyclic dep), so the helper had to live in the lower crate to break the cycle and remain reachable from the github crate's live test fixtures.
- Extended the signature with `pipeline_stage: Option<&str>` (4th SingleSelect arg, between `agent` and `story_points`). Same omit-empty contract as `agent`.
- Migrated ~16 live test fixture sites in `crates/unblock-github/tests/integration.rs` and `crates/unblock-mcp/tests/integration.rs` to invoke `set_project_fields` after `create_issue` via a new `populate_project_fields` helper. Each test gates on `require_github_token_and_project` (was: just `require_github_token`) because field writes need `UNBLOCK_PROJECT`. CI already exports it.
- Added representative fields-populated invariant pin assertions in `create_issue_returns_issue_with_correct_fields` (github) and `create_issue_with_all_params_and_refetch` (mcp) — both re-fetch Priority/Status/Agent via GraphQL and assert canonical values. `set_project_fields` is best-effort (logs warnings on per-field failures), so the round-trip read is the only fail-fast mechanism for a regression in the populate flow.
- Closed DRIFT-D in 4 fixtures by setting canonical `IssueType` where titles matched Appendix B.3 (Spike for `Investigate flaky checkout test`, Task for `Add OAuth callback handler` and `Add OAuth token validation`).

### Files changed
- `crates/unblock-github/src/projects.rs`
- `crates/unblock-github/tests/integration.rs`
- `crates/unblock-mcp/src/server.rs`
- `crates/unblock-mcp/tests/e2e_workflow.rs`
- `crates/unblock-mcp/tests/integration.rs`

### Decisions
- Followed the bead's prescribed Approach B + 1 (promote helper to `unblock_github::projects` + add `pipeline_stage` parameter). User-confirmed in the bead design notes.

### Deviations
- None — implemented as spec.

### Pub API change tracking (CLAUDE.md)
- `API: set_project_fields() promoted to pub fn in unblock_github::projects (additive, no callers broken — server.rs:2101 swaps to the new location; unblock_mcp::server re-exports the symbol so existing import paths in tests still resolve).`
- `API: set_project_fields signature extended with pipeline_stage: Option<&str> parameter.`

## Test plan
- [x] `cargo fmt --check --all` clean
- [x] `cargo clippy --workspace --all-targets --features unblock-mcp/test-hooks -- -D warnings` clean
- [x] `cargo test --workspace --features unblock-mcp/test-hooks` — all 226 + 196 + 303 + 80 + 32 + 4 non-live tests pass; 34 + 18 + 2 + 1 + 1 + 1 + 2 ignored (live-required) tests stay ignored on default run
- [x] `cargo doc --no-deps --workspace` clean (only the pre-existing unrelated `unblock-resilience` warning)
- [ ] **Live verification (post-merge / pre-merge depending on reviewer):** `scripts/setup-test-project.sh --wipe-issues` then `GITHUB_TOKEN=… UNBLOCK_REPO=websublime/unblock-test UNBLOCK_PROJECT=… cargo test --workspace --features unblock-mcp/test-hooks -- --ignored` and visually inspect the live board for clean Status/Priority/Agent columns.