### PR TITLE
unblock-q2x: canonicalize Priority + PipelineStage with canonical_name helpers

### DIFF
--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -305,7 +305,22 @@ impl Status {
 ///
 /// P0 is the highest priority, P4 is the lowest. Used for sorting
 /// the ready set so agents pick up the most important work first.
+///
+/// # `#[non_exhaustive]`
+///
+/// Carries `#[non_exhaustive]` per the workspace discipline (see
+/// `CLAUDE.md` "Coding Standards" and the precedents established by
+/// `Status` (`unblock-1zj`) and `IssueType` (`unblock-wgj`)). Adding new
+/// variants is a non-breaking addition for downstream consumers.
+///
+/// # Canonical helpers
+///
+/// See [`Priority::canonical_name`] for the Projects V2 single-select
+/// option string (e.g. `"P0 - Critical"`) and [`Priority::short_code`]
+/// for the bare short-code prefix (`"P0"` .. `"P4"`). Spec §2.4 pins
+/// the single-source-of-truth discipline introduced by `unblock-q2x`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Priority {
     /// Critical — drop everything.
     P0,
@@ -320,6 +335,22 @@ pub enum Priority {
 }
 
 impl Priority {
+    /// All canonical `Priority` variants in declared (sort-key) order.
+    ///
+    /// Single source of truth for any consumer that needs to enumerate
+    /// the full set of priority values. Order matches the declaration
+    /// order above and the `as_sort_key` ordering — consumed by the
+    /// `PRIORITY_OPTION_NAMES` compile-time derivation in
+    /// `unblock-github::projects` (spec §5.7) and the priority validators
+    /// in `unblock-mcp::server`.
+    pub const ALL: [Priority; 5] = [
+        Priority::P0,
+        Priority::P1,
+        Priority::P2,
+        Priority::P3,
+        Priority::P4,
+    ];
+
     /// Sort key for priority ordering (P0=0, P4=4).
     ///
     /// Lower values indicate higher priority, suitable for ascending sort.
@@ -333,6 +364,64 @@ impl Priority {
             Self::P4 => 4,
         }
     }
+
+    /// Canonical Projects V2 single-select option name (smushed
+    /// `<short_code> - <label>` form).
+    ///
+    /// Single source of truth for every wire-format Priority string
+    /// produced or consumed by the system. Consumed by:
+    ///
+    /// - The `REQUIRED_FIELDS` Priority options list in
+    ///   `unblock-github::projects` (derived from [`Priority::ALL`]).
+    /// - `parse_priority_field` in `unblock-github::graphql`
+    ///   (round-trip contract — note that the parser also tolerates the
+    ///   bare `short_code` form for backward compatibility).
+    ///
+    /// **Discipline.** No literal `"P0 - Critical"`, `"P1 - High"`,
+    /// `"P2 - Medium"`, `"P3 - Low"`, or `"P4 - Backlog"` is permitted
+    /// outside this helper's definition site and its unit tests; the
+    /// canonical strings MUST be sourced from
+    /// `Priority::canonical_name`. Mirrors the §2.3
+    /// `Status::option_name` discipline introduced by `unblock-1zj`.
+    #[must_use]
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Priority::P0 => "P0 - Critical",
+            Priority::P1 => "P1 - High",
+            Priority::P2 => "P2 - Medium",
+            Priority::P3 => "P3 - Low",
+            Priority::P4 => "P4 - Backlog",
+        }
+    }
+
+    /// Canonical short-code prefix (`"P0"` .. `"P4"`).
+    ///
+    /// Single source of truth for the bare-prefix Priority token set.
+    /// Consumed by:
+    ///
+    /// - `option_id_by_prefix` callers in `unblock-github::projects` —
+    ///   see e.g. `populate_project_fields`.
+    /// - The `create` and `update` tool's priority validation step in
+    ///   `crates/unblock-mcp/src/server.rs` (spec §8.3 / §8.6).
+    /// - `tools/stats.rs::seed_priority_buckets` (HashMap key set).
+    /// - The `Display` impl on `Priority` (which emits the short code,
+    ///   per spec §2.4 — the byte-stable token set the `ready` tool's
+    ///   priority filter depends on).
+    ///
+    /// **Discipline.** No literal `"P0"`, `"P1"`, `"P2"`, `"P3"`, or
+    /// `"P4"` is permitted outside this helper's definition site and
+    /// its unit tests; the canonical short codes MUST be sourced from
+    /// `Priority::short_code` (or the equivalent `Display` impl).
+    #[must_use]
+    pub const fn short_code(self) -> &'static str {
+        match self {
+            Priority::P0 => "P0",
+            Priority::P1 => "P1",
+            Priority::P2 => "P2",
+            Priority::P3 => "P3",
+            Priority::P4 => "P4",
+        }
+    }
 }
 
 /// Pipeline stage for an issue, stored as a Projects V2 single-select field.
@@ -340,7 +429,25 @@ impl Priority {
 /// Tracks the current lifecycle phase of work on an issue. Orthogonal to
 /// [`Status`] — `Status` tracks workflow readiness while `PipelineStage`
 /// tracks where in the development process the issue currently sits.
+///
+/// # `#[non_exhaustive]`
+///
+/// Carries `#[non_exhaustive]` per the workspace discipline (see
+/// `CLAUDE.md` "Coding Standards" and the precedents established by
+/// `Status` (`unblock-1zj`), `IssueType` (`unblock-wgj`), and `Priority`
+/// (`unblock-q2x`)). Adding new variants is a non-breaking addition for
+/// downstream consumers.
+///
+/// # Canonical helpers
+///
+/// See [`PipelineStage::canonical_name`] for the Projects V2
+/// single-select option string (lowercase, e.g. `"investigation"`).
+/// Spec §2.5 pins the single-source-of-truth discipline introduced by
+/// `unblock-q2x`. Note that `Display` continues to emit the variant
+/// identifier (`"Investigation"`) and is NOT the wire format — same
+/// split as §2.3 (`Status::Display` vs `Status::option_name`).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PipelineStage {
     /// Requirements gathering and research.
     Investigation,
@@ -354,6 +461,57 @@ pub enum PipelineStage {
     Qa,
     /// Work is complete.
     Done,
+}
+
+impl PipelineStage {
+    /// All canonical `PipelineStage` variants in declared (lifecycle) order.
+    ///
+    /// Single source of truth for any consumer that needs to enumerate
+    /// the full set of pipeline stages. Order matches the declaration
+    /// order above — consumed by the `PIPELINE_STAGE_OPTION_NAMES`
+    /// compile-time derivation in `unblock-github::projects` (spec §5.7).
+    pub const ALL: [PipelineStage; 6] = [
+        PipelineStage::Investigation,
+        PipelineStage::Implementation,
+        PipelineStage::Review,
+        PipelineStage::Refactoring,
+        PipelineStage::Qa,
+        PipelineStage::Done,
+    ];
+
+    /// Canonical Projects V2 single-select option name (LOWERCASE).
+    ///
+    /// Single source of truth for every wire-format PipelineStage string
+    /// produced or consumed by the system. Consumed by:
+    ///
+    /// - The `REQUIRED_FIELDS` PipelineStage options list in
+    ///   `unblock-github::projects` (derived from
+    ///   [`PipelineStage::ALL`]).
+    /// - `parse_pipeline_stage_field` in `unblock-github::graphql`
+    ///   (round-trip contract — strictly case-sensitive against the
+    ///   spec lowercase taxonomy).
+    ///
+    /// **Discipline.** No literal `"investigation"`, `"implementation"`,
+    /// `"review"`, `"refactoring"`, `"qa"`, or `"done"` is permitted
+    /// outside this helper's definition site and its unit tests; the
+    /// canonical strings MUST be sourced from
+    /// `PipelineStage::canonical_name`. Mirrors the §2.3
+    /// `Status::option_name` discipline introduced by `unblock-1zj`.
+    ///
+    /// Note: the lowercase form is the **wire format**; the `Display`
+    /// impl emits the variant identifier (`"Investigation"` etc.) — see
+    /// the type-level docs.
+    #[must_use]
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            PipelineStage::Investigation => "investigation",
+            PipelineStage::Implementation => "implementation",
+            PipelineStage::Review => "review",
+            PipelineStage::Refactoring => "refactoring",
+            PipelineStage::Qa => "qa",
+            PipelineStage::Done => "done",
+        }
+    }
 }
 
 /// Classification of issue types.
@@ -1475,6 +1633,11 @@ mod tests {
     }
 
     fn _assert_all_priority_variants_covered(v: Priority) {
+        // `Priority` is `#[non_exhaustive]`. Inside the defining crate
+        // `non_exhaustive` does not require a wildcard arm, so the
+        // explicit per-variant cover here remains exhaustive. Adding a
+        // new variant breaks this match at compile time — the desired
+        // single-place gate for "did we forget the new variant?".
         match v {
             Priority::P0 | Priority::P1 | Priority::P2 | Priority::P3 | Priority::P4 => {}
         }
@@ -1482,20 +1645,72 @@ mod tests {
 
     #[test]
     fn priority_display_matches_debug() {
-        for v in [
-            Priority::P0,
-            Priority::P1,
-            Priority::P2,
-            Priority::P3,
-            Priority::P4,
-        ] {
+        for v in Priority::ALL {
             assert_eq!(v.to_string(), format!("{v:?}"));
         }
         assert_eq!(Priority::P0.to_string(), "P0");
         assert_eq!(Priority::P4.to_string(), "P4");
     }
 
+    #[test]
+    fn priority_canonical_name_round_trips_all_variants() {
+        // unblock-q2x: the Projects V2 wire format is "P<n> - <Label>".
+        // Pin the byte-exact contract per spec §2.4.
+        assert_eq!(Priority::ALL.len(), 5);
+        assert_eq!(Priority::P0.canonical_name(), "P0 - Critical");
+        assert_eq!(Priority::P1.canonical_name(), "P1 - High");
+        assert_eq!(Priority::P2.canonical_name(), "P2 - Medium");
+        assert_eq!(Priority::P3.canonical_name(), "P3 - Low");
+        assert_eq!(Priority::P4.canonical_name(), "P4 - Backlog");
+        // Every variant produces a non-empty canonical name.
+        for v in Priority::ALL {
+            assert!(!v.canonical_name().is_empty());
+        }
+    }
+
+    #[test]
+    fn priority_short_code_matches_display() {
+        // unblock-q2x: short_code is the byte-stable token set the
+        // `ready` tool's priority filter depends on. The Display impl
+        // emits the same string per spec §2.4 (the helper documents
+        // the contract — the Display impl is the runtime accessor).
+        for v in Priority::ALL {
+            assert_eq!(v.short_code(), v.to_string());
+        }
+        assert_eq!(Priority::P0.short_code(), "P0");
+        assert_eq!(Priority::P1.short_code(), "P1");
+        assert_eq!(Priority::P2.short_code(), "P2");
+        assert_eq!(Priority::P3.short_code(), "P3");
+        assert_eq!(Priority::P4.short_code(), "P4");
+    }
+
+    #[test]
+    fn priority_canonical_name_starts_with_short_code() {
+        // The `option_id_by_prefix` lookup in `unblock-github::projects`
+        // depends on `short_code` being a strict prefix of
+        // `canonical_name`. Pin the contract here so a future rename of
+        // either helper keeps the prefix relation intact.
+        for v in Priority::ALL {
+            let canonical = v.canonical_name();
+            let short = v.short_code();
+            assert!(
+                canonical.starts_with(short),
+                "canonical_name {canonical:?} must start with short_code {short:?}"
+            );
+            assert!(
+                canonical.len() > short.len(),
+                "canonical_name must be strictly longer than short_code (option_id_by_prefix contract)"
+            );
+        }
+    }
+
     fn _assert_all_pipeline_stage_variants_covered(v: PipelineStage) {
+        // `PipelineStage` is `#[non_exhaustive]`. Inside the defining
+        // crate `non_exhaustive` does not require a wildcard arm, so
+        // the explicit per-variant cover here remains exhaustive.
+        // Adding a new variant breaks this match at compile time —
+        // the desired single-place gate for "did we forget the new
+        // variant?".
         match v {
             PipelineStage::Investigation
             | PipelineStage::Implementation
@@ -1508,14 +1723,7 @@ mod tests {
 
     #[test]
     fn pipeline_stage_display_matches_debug() {
-        for v in [
-            PipelineStage::Investigation,
-            PipelineStage::Implementation,
-            PipelineStage::Review,
-            PipelineStage::Refactoring,
-            PipelineStage::Qa,
-            PipelineStage::Done,
-        ] {
+        for v in PipelineStage::ALL {
             assert_eq!(v.to_string(), format!("{v:?}"));
         }
         assert_eq!(PipelineStage::Investigation.to_string(), "Investigation");
@@ -1524,6 +1732,65 @@ mod tests {
         assert_eq!(PipelineStage::Refactoring.to_string(), "Refactoring");
         assert_eq!(PipelineStage::Qa.to_string(), "Qa");
         assert_eq!(PipelineStage::Done.to_string(), "Done");
+    }
+
+    #[test]
+    fn pipeline_stage_canonical_name_round_trips_all_variants() {
+        // unblock-q2x: the Projects V2 wire format is LOWERCASE per
+        // spec §2.5 / §5.7 — pin the byte-exact contract. The live
+        // test board on websublime/unblock-test was provisioned from
+        // this list and the parser at `parse_pipeline_stage_field` is
+        // strictly case-sensitive against it.
+        assert_eq!(PipelineStage::ALL.len(), 6);
+        assert_eq!(
+            PipelineStage::Investigation.canonical_name(),
+            "investigation"
+        );
+        assert_eq!(
+            PipelineStage::Implementation.canonical_name(),
+            "implementation"
+        );
+        assert_eq!(PipelineStage::Review.canonical_name(), "review");
+        assert_eq!(PipelineStage::Refactoring.canonical_name(), "refactoring");
+        assert_eq!(PipelineStage::Qa.canonical_name(), "qa");
+        assert_eq!(PipelineStage::Done.canonical_name(), "done");
+        // Every variant produces a non-empty canonical name.
+        for v in PipelineStage::ALL {
+            assert!(!v.canonical_name().is_empty());
+        }
+    }
+
+    #[test]
+    fn pipeline_stage_canonical_name_is_lowercase() {
+        // Spec §2.5 locks the wire format to lowercase. Pin the
+        // discipline as a unit-test invariant so a future
+        // mis-edit (TitleCase typo, accidental rename) fails at
+        // compile- or test-time rather than against the live board.
+        for v in PipelineStage::ALL {
+            let canonical = v.canonical_name();
+            assert_eq!(
+                canonical,
+                canonical.to_ascii_lowercase(),
+                "PipelineStage::canonical_name must be ASCII lowercase, got {canonical:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn pipeline_stage_display_differs_from_canonical_name() {
+        // Mirror the §2.3 Status::Display vs Status::option_name split:
+        // Display is the variant-identifier formatter (TitleCase),
+        // canonical_name is the wire-format formatter (lowercase).
+        // The two MUST diverge for every variant — if they ever match
+        // it means somebody collapsed the wire format back to TitleCase
+        // by accident and the live board contract is broken.
+        for v in PipelineStage::ALL {
+            assert_ne!(
+                v.to_string(),
+                v.canonical_name(),
+                "Display and canonical_name MUST diverge for {v:?} (TitleCase vs lowercase)"
+            );
+        }
     }
 
     // ── QualifiedId ────────────────────────────────────────────────────

--- a/crates/unblock-core/src/types.rs
+++ b/crates/unblock-core/src/types.rs
@@ -403,7 +403,7 @@ impl Priority {
     ///   see e.g. `populate_project_fields`.
     /// - The `create` and `update` tool's priority validation step in
     ///   `crates/unblock-mcp/src/server.rs` (spec §8.3 / §8.6).
-    /// - `tools/stats.rs::seed_priority_buckets` (HashMap key set).
+    /// - `tools/stats.rs::seed_priority_buckets` (`HashMap` key set).
     /// - The `Display` impl on `Priority` (which emits the short code,
     ///   per spec §2.4 — the byte-stable token set the `ready` tool's
     ///   priority filter depends on).
@@ -481,10 +481,10 @@ impl PipelineStage {
 
     /// Canonical Projects V2 single-select option name (LOWERCASE).
     ///
-    /// Single source of truth for every wire-format PipelineStage string
+    /// Single source of truth for every wire-format `PipelineStage` string
     /// produced or consumed by the system. Consumed by:
     ///
-    /// - The `REQUIRED_FIELDS` PipelineStage options list in
+    /// - The `REQUIRED_FIELDS` `PipelineStage` options list in
     ///   `unblock-github::projects` (derived from
     ///   [`PipelineStage::ALL`]).
     /// - `parse_pipeline_stage_field` in `unblock-github::graphql`

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -2475,19 +2475,13 @@ mod tests {
     /// dropping whatever value GitHub stored.
     #[test]
     fn parse_issue_round_trips_pipeline_stage_variants() {
-        for (label, expected) in [
-            ("investigation", PipelineStage::Investigation),
-            ("implementation", PipelineStage::Implementation),
-            ("review", PipelineStage::Review),
-            ("refactoring", PipelineStage::Refactoring),
-            ("qa", PipelineStage::Qa),
-            ("done", PipelineStage::Done),
-        ] {
+        for variant in PipelineStage::ALL {
+            let label = variant.canonical_name();
             let json = pipeline_stage_fixture(label);
             let issue = parse_issue(&json, "test-owner", "test-repo");
             assert_eq!(
                 issue.pipeline_stage,
-                Some(expected),
+                Some(variant),
                 "parse_issue must round-trip canonical PipelineStage \
                  option {label:?}"
             );
@@ -2500,19 +2494,13 @@ mod tests {
     /// unblock-29p.18 — both must be migrated together.
     #[test]
     fn parse_graph_issue_round_trips_pipeline_stage_variants() {
-        for (label, expected) in [
-            ("investigation", PipelineStage::Investigation),
-            ("implementation", PipelineStage::Implementation),
-            ("review", PipelineStage::Review),
-            ("refactoring", PipelineStage::Refactoring),
-            ("qa", PipelineStage::Qa),
-            ("done", PipelineStage::Done),
-        ] {
+        for variant in PipelineStage::ALL {
+            let label = variant.canonical_name();
             let json = pipeline_stage_fixture(label);
             let issue = parse_graph_issue(&json, "test-owner", "test-repo");
             assert_eq!(
                 issue.pipeline_stage,
-                Some(expected),
+                Some(variant),
                 "parse_graph_issue must round-trip canonical \
                  PipelineStage option {label:?}"
             );

--- a/crates/unblock-github/src/graphql.rs
+++ b/crates/unblock-github/src/graphql.rs
@@ -1225,18 +1225,28 @@ fn parse_status_field(fields: &std::collections::HashMap<String, String>) -> Sta
 
 /// Maps the "Priority" field value to a [`Priority`] enum variant.
 ///
-/// Handles both the current spec option names (`P0 - Critical`, `P1 - High`,
-/// etc.) and the legacy short names (`P0`, `P1`, etc.) for backward
-/// compatibility. Uses prefix matching so `"P0 - Critical"` maps to `P0`.
+/// Handles both the canonical Projects V2 option names from
+/// [`Priority::canonical_name`] (`"P0 - Critical"`, `"P1 - High"`, …) and
+/// the bare [`Priority::short_code`] form (`"P0"`, `"P1"`, …) for
+/// backward compatibility with legacy boards.
+///
+/// **Single source of truth (`unblock-q2x`).** Iterates [`Priority::ALL`]
+/// and tests `short_code` as a strict prefix of the field value — this
+/// is the contract pinned by the `priority_canonical_name_starts_with_short_code`
+/// invariant in `unblock-core::types` (spec §2.4). Adding a new
+/// `Priority` variant automatically extends the parser without an edit
+/// here. Closes the latent missing-`P2`-arm bug (`unblock-q2x` DRIFT-5)
+/// that the previous hand-rolled match papered over.
 fn parse_priority_field(fields: &std::collections::HashMap<String, String>) -> Priority {
-    match fields.get("Priority").map(String::as_str) {
-        Some(s) if s.starts_with("P0") => Priority::P0,
-        Some(s) if s.starts_with("P1") => Priority::P1,
-        Some(s) if s.starts_with("P3") => Priority::P3,
-        Some(s) if s.starts_with("P4") => Priority::P4,
-        // Default to medium (P2) when missing, unrecognized, or "P2*".
-        _ => Priority::P2,
-    }
+    let Some(raw) = fields.get("Priority").map(String::as_str) else {
+        // Default to medium (P2) when missing — preserved semantics from
+        // the prior hand-rolled match.
+        return Priority::P2;
+    };
+    Priority::ALL
+        .into_iter()
+        .find(|variant| raw.starts_with(variant.short_code()))
+        .unwrap_or(Priority::P2)
 }
 
 /// Reads GitHub's native `issueType { name }` field off an issue JSON
@@ -1262,24 +1272,25 @@ fn parse_issue_type_from_native(value: &serde_json::Value) -> Option<IssueType> 
 
 /// Maps the `PipelineStage` field value to a [`PipelineStage`] enum variant.
 ///
-/// Matches the canonical lowercase option names emitted by
-/// `setup_fields` (spec §5 / spec §2.5): `investigation`, `implementation`,
-/// `review`, `refactoring`, `qa`, `done`. Missing or unrecognised values
-/// fall back to `None` — symmetric with [`parse_issue_type_field`] and
-/// consistent with the silent-fallback semantics of
-/// [`parse_status_field`] / [`parse_priority_field`].
+/// Matches the canonical lowercase option names from
+/// [`PipelineStage::canonical_name`] (spec §2.5 / §5.7) — strictly
+/// case-sensitive against the spec lowercase taxonomy. Missing or
+/// unrecognised values fall back to `None` — symmetric with
+/// [`parse_issue_type_from_native`] and consistent with the
+/// silent-fallback semantics of [`parse_status_field`] /
+/// [`parse_priority_field`].
+///
+/// **Single source of truth (`unblock-q2x`).** Iterates
+/// [`PipelineStage::ALL`] and matches each variant's
+/// `canonical_name` byte-for-byte — adding a new `PipelineStage`
+/// variant automatically extends the parser.
 fn parse_pipeline_stage_field(
     fields: &std::collections::HashMap<String, String>,
 ) -> Option<PipelineStage> {
-    match fields.get("PipelineStage").map(String::as_str) {
-        Some("investigation") => Some(PipelineStage::Investigation),
-        Some("implementation") => Some(PipelineStage::Implementation),
-        Some("review") => Some(PipelineStage::Review),
-        Some("refactoring") => Some(PipelineStage::Refactoring),
-        Some("qa") => Some(PipelineStage::Qa),
-        Some("done") => Some(PipelineStage::Done),
-        _ => None,
-    }
+    let raw = fields.get("PipelineStage").map(String::as_str)?;
+    PipelineStage::ALL
+        .into_iter()
+        .find(|variant| variant.canonical_name() == raw)
 }
 
 #[cfg(test)]
@@ -1864,39 +1875,67 @@ mod tests {
 
     // ── parse_priority_field ────────────────────────────────────────────
 
+    /// `setup_fields` (in `crates/unblock-github/src/projects.rs`) writes
+    /// the canonical Priority option set sourced from
+    /// `Priority::canonical_name` (spec §2.4 / §5.7). The parser must
+    /// round-trip every variant against the canonical wire format.
+    /// Iterates `Priority::ALL` so a new variant automatically extends
+    /// the assertion (mirrors the `IssueType::ALL` round-trip pattern).
     #[test]
     fn priority_field_mapping_spec_names() {
         let mut fields = std::collections::HashMap::new();
-        for (label, expected) in [
-            ("P0 - Critical", Priority::P0),
-            ("P1 - High", Priority::P1),
-            ("P2 - Medium", Priority::P2),
-            ("P3 - Low", Priority::P3),
-            ("P4 - Backlog", Priority::P4),
-        ] {
-            fields.insert("Priority".to_owned(), label.to_owned());
-            assert_eq!(parse_priority_field(&fields), expected);
+        for variant in Priority::ALL {
+            fields.insert("Priority".to_owned(), variant.canonical_name().to_owned());
+            assert_eq!(parse_priority_field(&fields), variant);
         }
     }
 
+    /// Legacy short-code form (`"P0"` .. `"P4"`) — every variant must
+    /// round-trip via `Priority::short_code` so boards bootstrapped
+    /// before `unblock-q2x` keep working. Iterates `Priority::ALL` so
+    /// adding a new variant automatically extends the coverage.
+    /// Closes `unblock-q2x` DRIFT-5 (the previous hand-rolled match
+    /// was missing the explicit P2 arm).
     #[test]
-    fn priority_field_mapping_legacy_names() {
+    fn priority_field_mapping_legacy_short_codes() {
         let mut fields = std::collections::HashMap::new();
-        for (label, expected) in [
-            ("P0", Priority::P0),
-            ("P1", Priority::P1),
-            ("P2", Priority::P2),
-            ("P3", Priority::P3),
-            ("P4", Priority::P4),
-        ] {
-            fields.insert("Priority".to_owned(), label.to_owned());
-            assert_eq!(parse_priority_field(&fields), expected);
+        for variant in Priority::ALL {
+            fields.insert("Priority".to_owned(), variant.short_code().to_owned());
+            assert_eq!(parse_priority_field(&fields), variant);
         }
+    }
+
+    /// `unblock-q2x` DRIFT-5 regression: the prior `parse_priority_field`
+    /// implementation had no explicit `P2` arm — it fell through the
+    /// wildcard `_` to `Priority::P2`, which masked the bug because the
+    /// default IS P2. Pin the contract here via an explicit assertion
+    /// against the canonical and short-code wire formats so a future
+    /// rewrite that breaks only the `P2` round-trip fails fast.
+    #[test]
+    fn priority_field_p2_round_trips_explicitly() {
+        let mut fields = std::collections::HashMap::new();
+
+        fields.insert("Priority".to_owned(), "P2 - Medium".to_owned());
+        assert_eq!(parse_priority_field(&fields), Priority::P2);
+
+        fields.insert("Priority".to_owned(), "P2".to_owned());
+        assert_eq!(parse_priority_field(&fields), Priority::P2);
     }
 
     #[test]
     fn priority_field_missing_defaults_p2() {
         let fields = std::collections::HashMap::new();
+        assert_eq!(parse_priority_field(&fields), Priority::P2);
+    }
+
+    #[test]
+    fn priority_field_unrecognised_defaults_p2() {
+        // Per the silent-fallback semantics, an unrecognised priority
+        // value collapses to the canonical default (P2). Pin the
+        // contract explicitly so a future rewrite that returns `None`
+        // or panics is caught immediately.
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("Priority".to_owned(), "Urgent".to_owned());
         assert_eq!(parse_priority_field(&fields), Priority::P2);
     }
 
@@ -1963,29 +2002,27 @@ mod tests {
 
     // ── parse_pipeline_stage_field (unblock-29p.18) ─────────────────────
 
-    /// `setup_fields` (in `crates/unblock-github/src/projects.rs`) writes the
-    /// canonical lowercase option set for the `PipelineStage` Projects V2
-    /// field per spec §5 / §2.5: `investigation`, `implementation`,
-    /// `review`, `refactoring`, `qa`, `done`. The parser must round-trip
-    /// every variant.
+    /// `setup_fields` (in `crates/unblock-github/src/projects.rs`) writes
+    /// the canonical lowercase option set for the `PipelineStage`
+    /// Projects V2 field per spec §2.5 / §5.7. The parser must
+    /// round-trip every variant against `PipelineStage::canonical_name`
+    /// — iterating `PipelineStage::ALL` so a new variant automatically
+    /// extends the assertion (mirrors the `IssueType::ALL` round-trip
+    /// pattern, `unblock-q2x`).
     #[test]
     fn pipeline_stage_field_mapping_spec_names() {
         let mut fields = std::collections::HashMap::new();
-        for (label, expected) in [
-            ("investigation", PipelineStage::Investigation),
-            ("implementation", PipelineStage::Implementation),
-            ("review", PipelineStage::Review),
-            ("refactoring", PipelineStage::Refactoring),
-            ("qa", PipelineStage::Qa),
-            ("done", PipelineStage::Done),
-        ] {
-            fields.insert("PipelineStage".to_owned(), label.to_owned());
-            assert_eq!(parse_pipeline_stage_field(&fields), Some(expected));
+        for variant in PipelineStage::ALL {
+            fields.insert(
+                "PipelineStage".to_owned(),
+                variant.canonical_name().to_owned(),
+            );
+            assert_eq!(parse_pipeline_stage_field(&fields), Some(variant));
         }
     }
 
     /// Missing `PipelineStage` field-value collapses to `None` — symmetric
-    /// with [`parse_issue_type_field`] silent-fallback semantics.
+    /// with [`parse_issue_type_from_native`] silent-fallback semantics.
     #[test]
     fn pipeline_stage_field_missing_returns_none() {
         let fields = std::collections::HashMap::new();

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -498,18 +498,18 @@ const PRIORITY_OPTION_NAMES: [&str; Priority::ALL.len()] = {
     out
 };
 
-/// Canonical Projects V2 PipelineStage option names (lowercase) in
+/// Canonical Projects V2 `PipelineStage` option names (lowercase) in
 /// declared order.
 ///
 /// **Single source of truth — generated from [`PipelineStage::ALL`].**
-/// Per spec §2.5 / §5.7 the `REQUIRED_FIELDS` PipelineStage spec MUST be
+/// Per spec §2.5 / §5.7 the `REQUIRED_FIELDS` `PipelineStage` spec MUST be
 /// derived from the `PipelineStage` enum (no duplicated literal list).
 /// `PipelineStage::canonical_name` is a `const fn` returning the
 /// lowercase wire format, so this `const` array is materialized at
 /// compile time and remains in lock-step with the enum.
 ///
 /// Order mirrors [`PipelineStage::ALL`] and is the contract consumed by
-/// the `REQUIRED_FIELDS` PipelineStage entry and the auto-heal matcher
+/// the `REQUIRED_FIELDS` `PipelineStage` entry and the auto-heal matcher
 /// in [`GitHubClient::heal_select_field_options`].
 const PIPELINE_STAGE_OPTION_NAMES: [&str; PipelineStage::ALL.len()] = {
     let mut out: [&str; PipelineStage::ALL.len()] = [""; PipelineStage::ALL.len()];
@@ -2921,17 +2921,11 @@ mod tests {
         // from PipelineStage::ALL at compile time — adding a new
         // variant is the single edit site for the canonical Projects
         // V2 PipelineStage option set.
-        assert_eq!(
-            PIPELINE_STAGE_OPTION_NAMES.len(),
-            PipelineStage::ALL.len()
-        );
+        assert_eq!(PIPELINE_STAGE_OPTION_NAMES.len(), PipelineStage::ALL.len());
         assert_eq!(PIPELINE_STAGE_OPTION_NAMES.len(), 6);
 
         for (i, variant) in PipelineStage::ALL.iter().enumerate() {
-            assert_eq!(
-                PIPELINE_STAGE_OPTION_NAMES[i],
-                variant.canonical_name()
-            );
+            assert_eq!(PIPELINE_STAGE_OPTION_NAMES[i], variant.canonical_name());
         }
     }
 

--- a/crates/unblock-github/src/projects.rs
+++ b/crates/unblock-github/src/projects.rs
@@ -15,7 +15,7 @@ use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt as _;
 use tracing::{debug, instrument, warn};
-use unblock_core::types::{IssueType, Status};
+use unblock_core::types::{IssueType, PipelineStage, Priority, Status};
 
 use crate::client::GitHubClient;
 use crate::errors::{self, Error};
@@ -40,9 +40,14 @@ pub struct ProjectFieldIds {
     /// in board order: `Backlog`, `Ready`, `In Progress`, `Blocked`,
     /// `Deferred`, `Closed`. Sourced from `Status::option_name` per spec §5.7.
     pub status: FieldMeta,
-    /// Priority field — single select: P0 - Critical, P1 - High, P2 - Medium, P3 - Low, P4 - Backlog.
+    /// Priority field — single select with 5 options sourced from
+    /// `Priority::canonical_name` per spec §5.7 (e.g. `P0 - Critical`,
+    /// `P1 - High`, `P2 - Medium`, `P3 - Low`, `P4 - Backlog`).
     pub priority: FieldMeta,
-    /// `PipelineStage` field — single select: investigation, implementation, review, refactoring, qa, done.
+    /// `PipelineStage` field — single select with 6 lowercase options
+    /// sourced from `PipelineStage::canonical_name` per spec §5.7 (e.g.
+    /// `investigation`, `implementation`, `review`, `refactoring`, `qa`,
+    /// `done`).
     pub pipeline_stage: FieldMeta,
     /// Agent field — text field (node ID only, no options).
     pub agent: String,
@@ -469,6 +474,53 @@ const STATUS_OPTION_NAMES: [&str; Status::ALL.len()] = {
     out
 };
 
+/// Canonical Projects V2 Priority option names in declared order.
+///
+/// **Single source of truth — generated from [`Priority::ALL`].** Per
+/// spec §2.4 / §5.7 the `REQUIRED_FIELDS` Priority spec MUST be derived
+/// from the `Priority` enum (no duplicated literal list).
+/// `Priority::canonical_name` is a `const fn`, so this `const` array is
+/// materialized at compile time and remains in lock-step with the enum:
+/// adding a new `Priority` variant updates this list automatically
+/// (the enum carries `#[non_exhaustive]` per the workspace discipline,
+/// allowing variant additions in PATCH/MINOR releases).
+///
+/// Order mirrors [`Priority::ALL`] and is the contract consumed by the
+/// `REQUIRED_FIELDS` Priority entry and the auto-heal matcher in
+/// [`GitHubClient::heal_select_field_options`].
+const PRIORITY_OPTION_NAMES: [&str; Priority::ALL.len()] = {
+    let mut out: [&str; Priority::ALL.len()] = [""; Priority::ALL.len()];
+    let mut i = 0;
+    while i < Priority::ALL.len() {
+        out[i] = Priority::ALL[i].canonical_name();
+        i += 1;
+    }
+    out
+};
+
+/// Canonical Projects V2 PipelineStage option names (lowercase) in
+/// declared order.
+///
+/// **Single source of truth — generated from [`PipelineStage::ALL`].**
+/// Per spec §2.5 / §5.7 the `REQUIRED_FIELDS` PipelineStage spec MUST be
+/// derived from the `PipelineStage` enum (no duplicated literal list).
+/// `PipelineStage::canonical_name` is a `const fn` returning the
+/// lowercase wire format, so this `const` array is materialized at
+/// compile time and remains in lock-step with the enum.
+///
+/// Order mirrors [`PipelineStage::ALL`] and is the contract consumed by
+/// the `REQUIRED_FIELDS` PipelineStage entry and the auto-heal matcher
+/// in [`GitHubClient::heal_select_field_options`].
+const PIPELINE_STAGE_OPTION_NAMES: [&str; PipelineStage::ALL.len()] = {
+    let mut out: [&str; PipelineStage::ALL.len()] = [""; PipelineStage::ALL.len()];
+    let mut i = 0;
+    while i < PipelineStage::ALL.len() {
+        out[i] = PipelineStage::ALL[i].canonical_name();
+        i += 1;
+    }
+    out
+};
+
 /// Specification for one canonical org-level GitHub `IssueType`.
 ///
 /// Drives the `IssueType` ensure-and-heal step in
@@ -542,25 +594,21 @@ const REQUIRED_FIELDS: &[FieldSpec] = &[
     FieldSpec {
         name: "Priority",
         data_type: "SINGLE_SELECT",
-        options: &[
-            "P0 - Critical",
-            "P1 - High",
-            "P2 - Medium",
-            "P3 - Low",
-            "P4 - Backlog",
-        ],
+        // Sourced from `Priority::canonical_name` via
+        // `PRIORITY_OPTION_NAMES` (spec §2.4 / §5.7
+        // single-source-of-truth requirement, introduced by
+        // `unblock-q2x`).
+        options: &PRIORITY_OPTION_NAMES,
     },
     FieldSpec {
         name: "PipelineStage",
         data_type: "SINGLE_SELECT",
-        options: &[
-            "investigation",
-            "implementation",
-            "review",
-            "refactoring",
-            "qa",
-            "done",
-        ],
+        // Sourced from `PipelineStage::canonical_name` via
+        // `PIPELINE_STAGE_OPTION_NAMES` (spec §2.5 / §5.7
+        // single-source-of-truth requirement, introduced by
+        // `unblock-q2x`). The lowercase wire format matches the
+        // byte-exact contract on `parse_pipeline_stage_field`.
+        options: &PIPELINE_STAGE_OPTION_NAMES,
     },
     FieldSpec {
         name: "Agent",
@@ -2511,11 +2559,14 @@ impl GitHubClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{FieldMeta, FieldSpec, OwnerType, REQUIRED_ISSUE_TYPES, STATUS_OPTION_NAMES};
+    use super::{
+        FieldMeta, FieldSpec, OwnerType, PIPELINE_STAGE_OPTION_NAMES, PRIORITY_OPTION_NAMES,
+        REQUIRED_FIELDS, REQUIRED_ISSUE_TYPES, STATUS_OPTION_NAMES,
+    };
     use crate::client::GitHubClient;
     use crate::errors::Error;
     use std::collections::HashMap;
-    use unblock_core::types::IssueType;
+    use unblock_core::types::{IssueType, PipelineStage, Priority};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -2846,6 +2897,82 @@ mod tests {
             healed.option_colors.get("In Progress"),
             Some(&"YELLOW".to_owned())
         );
+    }
+
+    // ── PRIORITY_OPTION_NAMES + PIPELINE_STAGE_OPTION_NAMES (unblock-q2x) ─
+
+    #[test]
+    fn priority_option_names_derived_from_enum_in_declared_order() {
+        // unblock-q2x: PRIORITY_OPTION_NAMES MUST be generated from
+        // Priority::ALL at compile time — adding a new variant is the
+        // single edit site for the canonical Projects V2 Priority
+        // option set.
+        assert_eq!(PRIORITY_OPTION_NAMES.len(), Priority::ALL.len());
+        assert_eq!(PRIORITY_OPTION_NAMES.len(), 5);
+
+        for (i, variant) in Priority::ALL.iter().enumerate() {
+            assert_eq!(PRIORITY_OPTION_NAMES[i], variant.canonical_name());
+        }
+    }
+
+    #[test]
+    fn pipeline_stage_option_names_derived_from_enum_in_declared_order() {
+        // unblock-q2x: PIPELINE_STAGE_OPTION_NAMES MUST be generated
+        // from PipelineStage::ALL at compile time — adding a new
+        // variant is the single edit site for the canonical Projects
+        // V2 PipelineStage option set.
+        assert_eq!(
+            PIPELINE_STAGE_OPTION_NAMES.len(),
+            PipelineStage::ALL.len()
+        );
+        assert_eq!(PIPELINE_STAGE_OPTION_NAMES.len(), 6);
+
+        for (i, variant) in PipelineStage::ALL.iter().enumerate() {
+            assert_eq!(
+                PIPELINE_STAGE_OPTION_NAMES[i],
+                variant.canonical_name()
+            );
+        }
+    }
+
+    #[test]
+    fn required_fields_priority_entry_uses_priority_option_names() {
+        // unblock-q2x: the REQUIRED_FIELDS Priority entry MUST point
+        // at PRIORITY_OPTION_NAMES (not a duplicated literal list).
+        // Pin the contract via reference equality on the slice
+        // pointer — the enum-derived const and the FieldSpec entry
+        // share the same backing storage at compile time.
+        let priority_spec = REQUIRED_FIELDS
+            .iter()
+            .find(|f| f.name == "Priority")
+            .expect("Priority must exist in REQUIRED_FIELDS");
+        assert_eq!(
+            priority_spec.options.len(),
+            PRIORITY_OPTION_NAMES.len(),
+            "Priority FieldSpec must source options from PRIORITY_OPTION_NAMES"
+        );
+        for (i, expected) in PRIORITY_OPTION_NAMES.iter().enumerate() {
+            assert_eq!(priority_spec.options[i], *expected);
+        }
+    }
+
+    #[test]
+    fn required_fields_pipeline_stage_entry_uses_pipeline_stage_option_names() {
+        // unblock-q2x: same contract as Priority — REQUIRED_FIELDS
+        // PipelineStage entry sources its options from the
+        // enum-derived const.
+        let stage_spec = REQUIRED_FIELDS
+            .iter()
+            .find(|f| f.name == "PipelineStage")
+            .expect("PipelineStage must exist in REQUIRED_FIELDS");
+        assert_eq!(
+            stage_spec.options.len(),
+            PIPELINE_STAGE_OPTION_NAMES.len(),
+            "PipelineStage FieldSpec must source options from PIPELINE_STAGE_OPTION_NAMES"
+        );
+        for (i, expected) in PIPELINE_STAGE_OPTION_NAMES.iter().enumerate() {
+            assert_eq!(stage_spec.options[i], *expected);
+        }
     }
 
     // ── REQUIRED_ISSUE_TYPES (unblock-wgj.14) ───────────────────────────

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -24,7 +24,7 @@
 use std::sync::Arc;
 
 use unblock_core::config::Config;
-use unblock_core::types::{IssueState, IssueType, Status};
+use unblock_core::types::{IssueState, IssueType, PipelineStage, Priority, Status};
 use unblock_github::client::GitHubClient;
 use unblock_github::mutations::CreateIssueParams;
 use unblock_github::projects::{CreateViewParams, FieldValue, OwnerType, ViewLayout};
@@ -789,8 +789,9 @@ async fn create_issue_returns_issue_with_correct_fields() {
         fetch_field_value(&client, &item_id, &resolved_field_ids.priority.field_id).await;
     assert_eq!(
         priority_value.as_deref(),
-        Some("P0 - Critical"),
-        "Priority should be populated to canonical 'P0 - Critical' after populate_project_fields"
+        Some(Priority::P0.canonical_name()),
+        "Priority should be populated to canonical {:?} after populate_project_fields",
+        Priority::P0.canonical_name()
     );
 
     let status_value =
@@ -1847,38 +1848,37 @@ async fn setup_fields_creates_all_seven_fields() {
 
     assert_eq!(
         field_ids.priority.options.len(),
-        5,
-        "Priority should have 5 options"
+        Priority::ALL.len(),
+        "Priority should have {} options",
+        Priority::ALL.len()
     );
-    for expected in &[
-        "P0 - Critical",
-        "P1 - High",
-        "P2 - Medium",
-        "P3 - Low",
-        "P4 - Backlog",
-    ] {
+    // Sourced from `Priority::canonical_name` per spec §2.4 / §5.7
+    // single-source-of-truth requirement (`unblock-q2x`). Adding a
+    // new variant automatically extends the assertion.
+    for variant in Priority::ALL {
+        let expected = variant.canonical_name();
         assert!(
-            field_ids.priority.options.contains_key(*expected),
-            "Priority should have option '{expected}'"
+            field_ids.priority.options.contains_key(expected),
+            "Priority should have option {expected:?}, got: {:?}",
+            field_ids.priority.options.keys().collect::<Vec<_>>()
         );
     }
 
     assert_eq!(
         field_ids.pipeline_stage.options.len(),
-        6,
-        "PipelineStage should have 6 options"
+        PipelineStage::ALL.len(),
+        "PipelineStage should have {} options",
+        PipelineStage::ALL.len()
     );
-    for expected in &[
-        "investigation",
-        "implementation",
-        "review",
-        "refactoring",
-        "qa",
-        "done",
-    ] {
+    // Sourced from `PipelineStage::canonical_name` per spec §2.5 / §5.7
+    // single-source-of-truth requirement (`unblock-q2x`). Adding a
+    // new variant automatically extends the assertion.
+    for variant in PipelineStage::ALL {
+        let expected = variant.canonical_name();
         assert!(
-            field_ids.pipeline_stage.options.contains_key(*expected),
-            "PipelineStage should have option '{expected}'"
+            field_ids.pipeline_stage.options.contains_key(expected),
+            "PipelineStage should have option {expected:?}, got: {:?}",
+            field_ids.pipeline_stage.options.keys().collect::<Vec<_>>()
         );
     }
 
@@ -2123,11 +2123,16 @@ async fn update_field_changes_value_on_project_item() {
     // name from `REQUIRED_FIELDS` (e.g. `"P1 - High"`), so a bare `"P1"`
     // lookup never matches. Use `option_id_by_prefix` which falls back to a
     // prefix match — robust to future REQUIRED_FIELDS option renames
-    // (bead `unblock-ekf` Bug #1, decision option (b)).
+    // (bead `unblock-ekf` Bug #1, decision option (b)). The short-code
+    // prefix is sourced from `Priority::short_code` per spec §2.4
+    // single-source-of-truth (`unblock-q2x`).
     let p1_option_id = field_ids
         .priority
-        .option_id_by_prefix("P1")
-        .expect("P1 option should exist (prefix match against REQUIRED_FIELDS)");
+        .option_id_by_prefix(Priority::P1.short_code())
+        .unwrap_or_else(|| panic!(
+            "{} option should exist (prefix match against REQUIRED_FIELDS)",
+            Priority::P1.short_code()
+        ));
 
     client
         .update_field(
@@ -2140,13 +2145,16 @@ async fn update_field_changes_value_on_project_item() {
         .expect("update_field(Priority=P1) should succeed");
 
     // Re-fetch to confirm the Priority value was persisted. `fetch_field_value`
-    // returns the canonical option NAME from GraphQL — `"P1 - High"` per the
-    // REQUIRED_FIELDS spec — not the short code (bead `unblock-ekf` Bug #2).
+    // returns the canonical option NAME from GraphQL — `Priority::canonical_name`
+    // per the REQUIRED_FIELDS spec — not the short code (bead `unblock-ekf`
+    // Bug #2). Sourced via `Priority::canonical_name` per spec §2.4
+    // single-source-of-truth (`unblock-q2x`).
     let priority_value = fetch_field_value(&client, &item_id, &field_ids.priority.field_id).await;
     assert_eq!(
         priority_value.as_deref(),
-        Some("P1 - High"),
-        "Re-fetched Priority should be the canonical name 'P1 - High'"
+        Some(Priority::P1.canonical_name()),
+        "Re-fetched Priority should be the canonical name {:?}",
+        Priority::P1.canonical_name()
     );
 
     // Update the Agent text field.

--- a/crates/unblock-github/tests/integration.rs
+++ b/crates/unblock-github/tests/integration.rs
@@ -2129,10 +2129,12 @@ async fn update_field_changes_value_on_project_item() {
     let p1_option_id = field_ids
         .priority
         .option_id_by_prefix(Priority::P1.short_code())
-        .unwrap_or_else(|| panic!(
-            "{} option should exist (prefix match against REQUIRED_FIELDS)",
-            Priority::P1.short_code()
-        ));
+        .unwrap_or_else(|| {
+            panic!(
+                "{} option should exist (prefix match against REQUIRED_FIELDS)",
+                Priority::P1.short_code()
+            )
+        });
 
     client
         .update_field(

--- a/crates/unblock-mcp/src/server.rs
+++ b/crates/unblock-mcp/src/server.rs
@@ -1787,13 +1787,27 @@ impl UnblockServer {
         let issue_type_canonical = issue_type.canonical_name();
 
         // Validate priority if provided. Canonical default is P2
-        // (spec §8.3 — Medium).
-        let priority_str = params.priority.as_deref().unwrap_or("P2");
-        if !matches!(priority_str, "P0" | "P1" | "P2" | "P3" | "P4") {
+        // (spec §8.3 — Medium). The validator iterates `Priority::ALL`
+        // and matches against `Priority::short_code` so this
+        // automatically tracks new variants — single-source-of-truth
+        // discipline per spec §2.4 (`unblock-q2x`).
+        let priority_str = params
+            .priority
+            .as_deref()
+            .unwrap_or_else(|| unblock_core::types::Priority::P2.short_code());
+        if !unblock_core::types::Priority::ALL
+            .iter()
+            .any(|p| p.short_code() == priority_str)
+        {
+            let valid: Vec<&str> = unblock_core::types::Priority::ALL
+                .iter()
+                .map(|p| p.short_code())
+                .collect();
             return Err(ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
                 message: format!(
-                    "Invalid priority '{priority_str}' — must be P0, P1, P2, P3, or P4"
+                    "Invalid priority '{priority_str}' — must be one of {}",
+                    valid.join(", ")
                 )
                 .into(),
                 data: None,
@@ -2138,13 +2152,27 @@ impl UnblockServer {
             "Update tool invoked"
         );
 
-        // Validate priority if provided.
+        // Validate priority if provided. Iterates `Priority::ALL` so
+        // new variants are picked up automatically — mirrors the
+        // create-tool validator above and the Status validator below
+        // (single-source-of-truth discipline per spec §2.4,
+        // `unblock-q2x`).
         if let Some(ref p) = params.priority
-            && !matches!(p.as_str(), "P0" | "P1" | "P2" | "P3" | "P4")
+            && !unblock_core::types::Priority::ALL
+                .iter()
+                .any(|variant| variant.short_code() == p.as_str())
         {
+            let valid: Vec<&str> = unblock_core::types::Priority::ALL
+                .iter()
+                .map(|variant| variant.short_code())
+                .collect();
             return Err(ErrorData {
                 code: rmcp::model::ErrorCode::INVALID_PARAMS,
-                message: format!("Invalid priority '{p}' — must be P0, P1, P2, P3, or P4").into(),
+                message: format!(
+                    "Invalid priority '{p}' — must be one of {}",
+                    valid.join(", ")
+                )
+                .into(),
                 data: None,
             });
         }

--- a/crates/unblock-mcp/src/tools/stats.rs
+++ b/crates/unblock-mcp/src/tools/stats.rs
@@ -197,14 +197,11 @@ fn seed_status_buckets() -> HashMap<String, usize> {
 /// Pre-seed the `by_priority` bucket with `0` for every [`Priority`]
 /// variant so callers can read any key unconditionally.
 fn seed_priority_buckets() -> HashMap<String, usize> {
-    let mut out = HashMap::with_capacity(5);
-    for priority in [
-        Priority::P0,
-        Priority::P1,
-        Priority::P2,
-        Priority::P3,
-        Priority::P4,
-    ] {
+    let mut out = HashMap::with_capacity(Priority::ALL.len());
+    for priority in Priority::ALL {
+        // The `Display` impl on `Priority` emits `Priority::short_code`
+        // — the byte-stable HashMap-key set the `ready` tool's priority
+        // filter depends on (spec §2.4, `unblock-q2x`).
         out.insert(priority.to_string(), 0);
     }
     out
@@ -511,8 +508,12 @@ mod tests {
     #[test]
     fn seed_priority_buckets_contains_every_priority_at_zero() {
         let seeded = seed_priority_buckets();
-        assert_eq!(seeded.len(), 5);
-        for key in ["P0", "P1", "P2", "P3", "P4"] {
+        assert_eq!(seeded.len(), Priority::ALL.len());
+        // Sourced from `Priority::short_code` per spec §2.4
+        // single-source-of-truth (`unblock-q2x`). Adding a new variant
+        // automatically extends the assertion.
+        for variant in Priority::ALL {
+            let key = variant.short_code();
             assert_eq!(
                 seeded.get(key),
                 Some(&0_usize),
@@ -589,8 +590,8 @@ mod tests {
         for variant in Status::ALL {
             assert_eq!(result.by_status.get(variant.option_name()), Some(&0_usize));
         }
-        for key in ["P0", "P1", "P2", "P3", "P4"] {
-            assert_eq!(result.by_priority.get(key), Some(&0_usize));
+        for variant in Priority::ALL {
+            assert_eq!(result.by_priority.get(variant.short_code()), Some(&0_usize));
         }
     }
 
@@ -659,8 +660,8 @@ mod tests {
             Some(&0_usize)
         );
 
-        for key in ["P0", "P1", "P2", "P3", "P4"] {
-            assert_eq!(result.by_priority.get(key), Some(&1_usize));
+        for variant in Priority::ALL {
+            assert_eq!(result.by_priority.get(variant.short_code()), Some(&1_usize));
         }
     }
 

--- a/crates/unblock-mcp/tests/integration.rs
+++ b/crates/unblock-mcp/tests/integration.rs
@@ -4620,8 +4620,9 @@ async fn create_issue_with_all_params_and_refetch() {
             .await;
     assert_eq!(
         priority_value.as_deref(),
-        Some("P0 - Critical"),
-        "Priority should be populated to canonical 'P0 - Critical' after populate_project_fields"
+        Some(Priority::P0.canonical_name()),
+        "Priority should be populated to canonical {:?} after populate_project_fields",
+        Priority::P0.canonical_name()
     );
 
     let status_value =

--- a/docs/specs/01-spec-mcp-foundation.md
+++ b/docs/specs/01-spec-mcp-foundation.md
@@ -156,6 +156,7 @@ impl Status {
 ### 2.4 `Priority`
 
 ```rust
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Priority {
     P0,
@@ -170,9 +171,62 @@ pub enum Priority {
 
 **Projects V2 option values:** `P0 - Critical`, `P1 - High`, `P2 - Medium`, `P3 - Low`, `P4 - Backlog`
 
+**API change (BREAKING — library crate `unblock-core`).** Adding `#[non_exhaustive]` to `Priority` is the same forward-compat hardening applied to `Status` in `unblock-1zj` and `IssueType` in `unblock-wgj`. Existing exhaustive `match Priority { … }` arms in downstream code (currently only in-workspace) MUST add a wildcard `_` arm or a per-variant arm for new entries. Per CLAUDE.md "Coding Standards" `#[non_exhaustive]` is mandatory on growable public enums in library crates. The implementation PR for `unblock-q2x` MUST carry a `BREAKING CHANGE:` footer for the `#[non_exhaustive]` addition AND an `API:` footer for the additive helpers `Priority::ALL`, `Priority::canonical_name`, and `Priority::short_code` defined below.
+
+**Single source of truth — `Priority` canonical helpers** (`unblock-core/src/types.rs`, introduced by `unblock-q2x`). Mirrors the `Status::option_name` discipline (§2.3) and the `IssueType::canonical_name` discipline (§2.6): every layer that needs a Projects V2 Priority option string MUST go through these helpers. No literal `"P0 - Critical"`, `"P1 - High"`, `"P2 - Medium"`, `"P3 - Low"`, `"P4 - Backlog"`, `"P0"`, `"P1"`, `"P2"`, `"P3"`, or `"P4"` is permitted in `unblock-github` (`projects.rs` Priority entry of `REQUIRED_FIELDS`, `graphql.rs` `parse_priority_field`), `unblock-mcp` (`server.rs` `create`/`update` validators, `tools/stats.rs` `seed_priority_buckets`, `tools/list.rs` / `tools/ready.rs` / `tools/search.rs` doc-comments and fixtures), or any test fixture beyond the helpers' own unit tests.
+
+```rust
+impl Priority {
+    /// All canonical `Priority` variants in declared (sort-key) order.
+    pub const ALL: [Priority; 5] = [
+        Priority::P0,
+        Priority::P1,
+        Priority::P2,
+        Priority::P3,
+        Priority::P4,
+    ];
+
+    /// Canonical Projects V2 single-select option name (smushed
+    /// `<short_code> - <label>`). Single source of truth consumed by:
+    ///  - `REQUIRED_FIELDS` in `unblock-github` (compile-time
+    ///    derivation — see §5.7).
+    ///  - `parse_priority_field` in `unblock-github` (round-trip
+    ///    contract).
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Priority::P0 => "P0 - Critical",
+            Priority::P1 => "P1 - High",
+            Priority::P2 => "P2 - Medium",
+            Priority::P3 => "P3 - Low",
+            Priority::P4 => "P4 - Backlog",
+        }
+    }
+
+    /// Canonical short code (`"P0"` .. `"P4"`). Single source of truth
+    /// consumed by:
+    ///  - `option_id_by_prefix` lookups in `unblock-github`
+    ///    (`projects.rs`).
+    ///  - The `create` and `update` tool's priority validation step
+    ///    in `crates/unblock-mcp/src/server.rs`.
+    ///  - `tools/stats.rs::seed_priority_buckets` (HashMap key set).
+    pub const fn short_code(self) -> &'static str {
+        match self {
+            Priority::P0 => "P0",
+            Priority::P1 => "P1",
+            Priority::P2 => "P2",
+            Priority::P3 => "P3",
+            Priority::P4 => "P4",
+        }
+    }
+}
+```
+
+`Display` is preserved as-is on `Priority` and emits the `short_code` (`"P0"` .. `"P4"`) — the `ready` tool's priority filter and the `tools/stats.rs::seed_priority_buckets` HashMap-key set depend on this byte-stable token set. The split between `Display` (variant identifier) and `canonical_name` (Projects V2 wire format) mirrors §2.3 (`Status::Display` / `Status::option_name`).
+
 ### 2.5 `PipelineStage`
 
 ```rust
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PipelineStage {
     Investigation,
@@ -187,6 +241,44 @@ pub enum PipelineStage {
 Development pipeline phase. Created by `setup` in Phase 01 for field existence. Agent advancement is Phase 05 (plugin). The field exists so early adopters can use it manually and views work.
 
 **Projects V2 option values:** `investigation`, `implementation`, `review`, `refactoring`, `qa`, `done`
+
+**API change (BREAKING — library crate `unblock-core`).** Adding `#[non_exhaustive]` to `PipelineStage` is the same forward-compat hardening as §2.4 / §2.6. Existing exhaustive `match PipelineStage { … }` arms in downstream code MUST add a wildcard `_` arm. The implementation PR for `unblock-q2x` MUST carry a `BREAKING CHANGE:` footer for the `#[non_exhaustive]` addition AND an `API:` footer for the additive helpers `PipelineStage::ALL` and `PipelineStage::canonical_name` defined below.
+
+**Single source of truth — `PipelineStage` canonical helpers** (`unblock-core/src/types.rs`, introduced by `unblock-q2x`). Mirrors §2.3 / §2.4 / §2.6. Every layer that needs a Projects V2 PipelineStage option string MUST go through these helpers. No literal `"investigation"`, `"implementation"`, `"review"`, `"refactoring"`, `"qa"`, or `"done"` is permitted in `unblock-github` (`projects.rs` PipelineStage entry of `REQUIRED_FIELDS`, `graphql.rs` `parse_pipeline_stage_field`) or any test fixture beyond the helper's own unit tests.
+
+```rust
+impl PipelineStage {
+    /// All canonical `PipelineStage` variants in declared (lifecycle) order.
+    pub const ALL: [PipelineStage; 6] = [
+        PipelineStage::Investigation,
+        PipelineStage::Implementation,
+        PipelineStage::Review,
+        PipelineStage::Refactoring,
+        PipelineStage::Qa,
+        PipelineStage::Done,
+    ];
+
+    /// Canonical Projects V2 single-select option name (LOWERCASE,
+    /// per the `setup_fields` byte-exact contract — see §5.7).
+    /// Single source of truth consumed by:
+    ///  - `REQUIRED_FIELDS` in `unblock-github` (compile-time
+    ///    derivation — see §5.7).
+    ///  - `parse_pipeline_stage_field` in `unblock-github` (round-trip
+    ///    contract).
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            PipelineStage::Investigation => "investigation",
+            PipelineStage::Implementation => "implementation",
+            PipelineStage::Review        => "review",
+            PipelineStage::Refactoring   => "refactoring",
+            PipelineStage::Qa            => "qa",
+            PipelineStage::Done          => "done",
+        }
+    }
+}
+```
+
+`Display` on `PipelineStage` continues to emit the variant identifier (`"Investigation"`, `"Implementation"`, …) — it is NOT the wire format. For the on-the-wire option name (lowercase), use `PipelineStage::canonical_name`. This mirrors §2.3 (`Status::Display` vs `Status::option_name`).
 
 ### 2.6 `IssueType`
 
@@ -1040,7 +1132,11 @@ query($owner: String!, $repo: String!, $cursor: String) {
 
 **Status canonical list — single source of truth.** The `Status` row above is generated from `Status::option_name` (§2.3) iterated in declaration order. The `unblock-github` crate MUST NOT carry a duplicated literal list — `REQUIRED_FIELDS`'s Status spec is built from the `Status` enum at compile time (e.g. via a `const` array of variants → `option_name`). This closes the §10.2 `compute_expected_status` contract and the §5.8 view filter against drift.
 
-**IssueType canonical list — single source of truth (`unblock-wgj`).** Same discipline as Status. `unblock-github` declares a `REQUIRED_ISSUE_TYPES` constant whose entries are derived at compile time from the `IssueType` enum via `IssueType::canonical_name`, `canonical_color`, and `canonical_description` (§2.6) — for example, a `const` array of all `IssueType` variants paired with their helper outputs. There is NO duplicated literal list of issue type names, colors, or descriptions anywhere in the workspace. The IssueType ensure-and-heal loop in step 3 above iterates this constant in declared `IssueType` order. Adding a future variant to `IssueType` (allowed because of `#[non_exhaustive]`, §2.6) is the single edit site for adding a new canonical issue type — `REQUIRED_ISSUE_TYPES` and `setup_fields` pick it up automatically without any second-list bookkeeping.
+**Priority canonical list — single source of truth (`unblock-q2x`).** Same discipline as Status. `unblock-github` declares a `PRIORITY_OPTION_NAMES` constant whose entries are derived at compile time from the `Priority` enum via `Priority::canonical_name` (§2.4) — a `const` array materialised via `Priority::ALL` and the `const fn canonical_name` helper. The `REQUIRED_FIELDS` Priority entry references this constant directly. There is NO duplicated literal list of Priority option strings anywhere in the workspace. Adding a future variant to `Priority` (allowed because of `#[non_exhaustive]`, §2.4) is the single edit site — `PRIORITY_OPTION_NAMES` and `setup_fields` pick it up automatically.
+
+**PipelineStage canonical list — single source of truth (`unblock-q2x`).** Same discipline as Status / Priority. `unblock-github` declares a `PIPELINE_STAGE_OPTION_NAMES` constant whose entries are derived at compile time from the `PipelineStage` enum via `PipelineStage::canonical_name` (§2.5) — `const` array materialised via `PipelineStage::ALL`. The `REQUIRED_FIELDS` PipelineStage entry references this constant directly. The lowercase canonical strings are byte-stable across `setup` runs and parser invocations (`parse_pipeline_stage_field`), preserving the existing live-board contract. No duplicated literal list anywhere in the workspace.
+
+**IssueType canonical list — single source of truth (`unblock-wgj`).** Same discipline as Status / Priority / PipelineStage. `unblock-github` declares a `REQUIRED_ISSUE_TYPES` constant whose entries are derived at compile time from the `IssueType` enum via `IssueType::canonical_name`, `canonical_color`, and `canonical_description` (§2.6) — for example, a `const` array of all `IssueType` variants paired with their helper outputs. There is NO duplicated literal list of issue type names, colors, or descriptions anywhere in the workspace. The IssueType ensure-and-heal loop in step 3 above iterates this constant in declared `IssueType` order. Adding a future variant to `IssueType` (allowed because of `#[non_exhaustive]`, §2.6) is the single edit site for adding a new canonical issue type — `REQUIRED_ISSUE_TYPES` and `setup_fields` pick it up automatically without any second-list bookkeeping.
 
 **Auto-heal semantics — case-insensitive + `snake_case` → `TitleCase` normalization** (`heal_select_field_options` at `crates/unblock-github/src/projects.rs:1077-1090`).
 


### PR DESCRIPTION
## unblock-q2x: Canonicalize Priority + PipelineStage with canonical_name helpers (mirrors Status::option_name pattern)

Closes the architectural gap unblock-1zj closed for Status and unblock-wgj closed for IssueType — Priority and PipelineStage now carry the same single-source-of-truth canonical_name helpers and #[non_exhaustive] discipline.

### What was done
- types.rs: Priority::ALL + Priority::canonical_name (Projects V2 'P0 - Critical' .. 'P4 - Backlog') + Priority::short_code ('P0' .. 'P4'); PipelineStage::ALL + PipelineStage::canonical_name (LOWERCASE 'investigation' .. 'done', spec §2.5 byte-exact contract). #[non_exhaustive] on both enums.
- projects.rs: PRIORITY_OPTION_NAMES + PIPELINE_STAGE_OPTION_NAMES const arrays materialized at compile time from the ::ALL helpers; REQUIRED_FIELDS Priority + PipelineStage entries derived from those constants (no duplicated literal lists).
- graphql.rs: parse_priority_field + parse_pipeline_stage_field iterate the new ::ALL arrays. Closes the latent DRIFT-5 bug (missing explicit P2 arm in parse_priority_field) — the new test priority_field_p2_round_trips_explicitly pins the contract.
- server.rs: create + update tool priority validators iterate Priority::ALL via short_code (mirrors the Status::ALL validator pattern from unblock-1zj).
- stats.rs: seed_priority_buckets sources via Priority::ALL.
- Spec amendment: §2.4, §2.5, §5.7 add the canonical-helper subsections + Priority/PipelineStage single-source-of-truth paragraphs mirroring §2.6.

### Files changed
- docs/specs/01-spec-mcp-foundation.md
- crates/unblock-core/src/types.rs
- crates/unblock-github/src/projects.rs
- crates/unblock-github/src/graphql.rs
- crates/unblock-github/tests/integration.rs
- crates/unblock-mcp/src/server.rs
- crates/unblock-mcp/src/tools/stats.rs
- crates/unblock-mcp/tests/integration.rs

### Decisions
- PipelineStage::canonical_name returns LOWERCASE per the locked design-note decision (spec §2.5 / §5.7 byte-exact contract + live test board), NOT TitleCase as the bead description hinted.

### Deviations
None — implemented as spec.

### Quality gate
- cargo fmt --check --all: clean
- cargo clippy --workspace --all-targets -- -D warnings: clean
- cargo test --workspace: 855+ unit/integration tests all pass
- cargo doc --no-deps --workspace: clean (only pre-existing unblock-resilience link warning unrelated)

### API change footers (per CLAUDE.md library-crate discipline)
- BREAKING CHANGE: Priority and PipelineStage are now #[non_exhaustive].
- API: Priority::ALL, Priority::canonical_name, Priority::short_code, PipelineStage::ALL, PipelineStage::canonical_name added.