### PR TITLE
unblock-tv8.1: Encore app init and service skeletons

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,1 +1,4 @@
 /.encore
+encore.gen.go
+encore.gen.cue
+/encore.gen

--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -1,0 +1,114 @@
+// Package auth owns the auth schema and is the sole migration-owner service
+// for the unblock database. The canonical migration directory at
+// apps/api/auth/migrations/ holds the migration set for every schema
+// (auth, org, workitems, deps, providers, mcp, boards, memory). Other
+// services consume the database via sqldb.Named("unblock"); see SPEC §3.1.
+//
+// In P01 task A-1 this package only declares the //encore:api skeletons
+// for the four private RPCs (Validate, ExchangeOAuthCode, IssueAPIKey,
+// RevokeAPIKey) so Encore recognises auth as a service. Bodies return
+// errNotImplemented; the bootstrap migration and sqldb.NewDatabase call
+// land in task A-2 (unblock-tv8.2) — see SPEC §3.2.
+package auth
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// errNotImplemented is the sentinel returned by every P01 A-1 skeleton
+// body. Real implementations land in subsequent beads (B-1..D-3).
+var errNotImplemented = errors.New("auth: not implemented in P01 A-1 skeleton")
+
+// Identity is the resolved caller record carried inside the Encore mesh.
+// Locked shape per SPEC §4.1.
+type Identity struct {
+	UserID    string // ULID
+	OrgID     string // ULID — primary org binding for this auth event
+	Role      string // "owner" | "admin" | "member" | "viewer"
+	AgentKind string // empty for human sessions; AgentKind value for API-key callers
+}
+
+// ValidateRequest is the input to Validate. SPEC §4.1.
+type ValidateRequest struct {
+	Token     string // either auth.sessions.id (browser BFF) or raw API key
+	TokenKind string // "session" | "api_key"
+}
+
+// ValidateResponse is the output of Validate. SPEC §4.1.
+type ValidateResponse struct {
+	Identity Identity
+}
+
+// Validate accepts an opaque token (session id OR raw API key) and resolves
+// it to an Identity. Returns ErrUnauthenticated on miss / revoked / expired.
+//
+//encore:api private method=POST path=/auth.Validate
+func Validate(ctx context.Context, req *ValidateRequest) (*ValidateResponse, error) {
+	return nil, errNotImplemented
+}
+
+// ExchangeOAuthCodeRequest is the input to ExchangeOAuthCode. SPEC §4.1.
+type ExchangeOAuthCodeRequest struct {
+	Provider     string // "github" | "gitlab"
+	Code         string
+	PKCEVerifier string
+	UserAgent    string
+	IPAddress    string
+}
+
+// ExchangeOAuthCodeResponse is the output of ExchangeOAuthCode. SPEC §4.1.
+type ExchangeOAuthCodeResponse struct {
+	SessionID string // ULID; opaque; used as Bearer for private RPCs
+	UserID    string // ULID
+	ExpiresAt time.Time
+}
+
+// ExchangeOAuthCode is called by the Astro Action /auth/[provider]/callback
+// (P05) and by P01 integration tests. Verifies PKCE, exchanges the code for
+// a provider access token, upserts auth.users + auth.oauth_tokens, and
+// issues a new auth.sessions row. Returns the opaque session id.
+//
+//encore:api private method=POST path=/auth.ExchangeOAuthCode
+func ExchangeOAuthCode(ctx context.Context, req *ExchangeOAuthCodeRequest) (*ExchangeOAuthCodeResponse, error) {
+	return nil, errNotImplemented
+}
+
+// IssueAPIKeyRequest is the input to IssueAPIKey. SPEC §4.1.
+type IssueAPIKeyRequest struct {
+	OrgID        string // ULID
+	IssuedToUser string // ULID; nullable (org-level service key)
+	Label        string // human-readable, e.g. "claude-code-laptop"
+	AgentKind    string // AgentKind value
+	Scopes       []string
+	ExpiresAt    *time.Time // nullable; default: never
+}
+
+// IssueAPIKeyResponse is the output of IssueAPIKey. SPEC §4.1.
+type IssueAPIKeyResponse struct {
+	KeyID     string // ULID (mcp.api_keys.id)
+	KeyPrefix string // first 8 chars of the raw key
+	RawKey    string // FULL raw key — returned ONCE; never persisted in clear
+}
+
+// IssueAPIKey creates a new mcp.api_keys row. Called by the seeder CLI
+// (P01) and by future operator surfaces. Returns the raw key ONCE — the
+// caller stores it; subsequent reads return only the prefix and metadata.
+//
+//encore:api private method=POST path=/auth.IssueAPIKey
+func IssueAPIKey(ctx context.Context, req *IssueAPIKeyRequest) (*IssueAPIKeyResponse, error) {
+	return nil, errNotImplemented
+}
+
+// RevokeAPIKeyRequest is the input to RevokeAPIKey. SPEC §4.1.
+type RevokeAPIKeyRequest struct {
+	KeyID string // ULID
+}
+
+// RevokeAPIKey flips revoked_at; idempotent.
+//
+//encore:api private method=POST path=/auth.RevokeAPIKey
+func RevokeAPIKey(ctx context.Context, req *RevokeAPIKeyRequest) error {
+	return errNotImplemented
+}

--- a/apps/api/auth/migrations/.gitkeep
+++ b/apps/api/auth/migrations/.gitkeep
@@ -1,0 +1,3 @@
+# Canonical migration directory for the entire `unblock` database.
+# All eight schemas migrate from this directory; see SPEC §3.1, §3.2.
+# 0010_bootstrap.up.sql lands in task A-2 (unblock-tv8.2).

--- a/apps/api/boards/.gitkeep
+++ b/apps/api/boards/.gitkeep
@@ -1,0 +1,3 @@
+# Schema-only service in P01 — no Go files yet.
+# Service code lands in P05. Schema DDL ships via auth/migrations/0080_boards.up.sql.
+# See SPEC §4.6.

--- a/apps/api/deps/deps.go
+++ b/apps/api/deps/deps.go
@@ -1,0 +1,146 @@
+// Package deps owns the deps schema and the cycle-detection +
+// cascade-publishing primitives. See SPEC §4.5 for the full RPC surface
+// and §6.5 for the cycle-detection CTE.
+//
+// In P01 task A-1 this package only declares the //encore:api skeletons so
+// Encore recognises deps as a service. Bodies return errNotImplemented;
+// real wiring (sqldb.Named("unblock"), cycle CTE, advisory locks, cascade
+// Pub/Sub publisher) lands in C-1, C-2, C-3.
+package deps
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// errNotImplemented is the sentinel returned by every P01 A-1 skeleton body.
+var errNotImplemented = errors.New("deps: not implemented in P01 A-1 skeleton")
+
+// Edge is the canonical dependency edge row shape. SPEC §4.5.
+type Edge struct {
+	ID        string
+	FromItem  string
+	ToItem    string
+	Kind      string // "blocks" | "related"
+	CreatedAt time.Time
+	CreatedBy string
+}
+
+// AddEdgeRequest is the input to AddEdge. SPEC §4.5.
+type AddEdgeRequest struct {
+	OrgID     string
+	ProjectID string
+	FromItem  string
+	ToItem    string
+	Kind      string // "blocks" | "related"; default "blocks"
+}
+
+// AddEdge acquires the per-project advisory lock (AF5), runs the
+// depth-counter reachability CTE (C5), inserts the edge, and emits
+// deps.cascade.requested when the to_item's readiness flips. SPEC §4.5.
+//
+//encore:api private method=POST path=/deps.AddEdge
+func AddEdge(ctx context.Context, req *AddEdgeRequest) (*Edge, error) {
+	return nil, errNotImplemented
+}
+
+// RemoveEdgeRequest is the input to RemoveEdge. SPEC §4.5. Pass either
+// EdgeID OR (FromItem + ToItem + Kind), exactly one path.
+type RemoveEdgeRequest struct {
+	EdgeID   string
+	FromItem string
+	ToItem   string
+	Kind     string
+}
+
+// RemoveEdgeResponse is the output of RemoveEdge. SPEC §4.5.
+type RemoveEdgeResponse struct {
+	Removed        bool
+	ToItemNowReady bool
+	ToItemID       string
+}
+
+// RemoveEdge deletes the edge, sync-inline recomputes is_ready for the
+// to_item, and writes a kind='edge_removed' cascade_events audit row in
+// the same transaction. Does NOT publish a Pub/Sub event. SPEC §4.5 / §6.2
+// Tool 12.
+//
+//encore:api private method=POST path=/deps.RemoveEdge
+func RemoveEdge(ctx context.Context, req *RemoveEdgeRequest) (*RemoveEdgeResponse, error) {
+	return nil, errNotImplemented
+}
+
+// IsReadyRequest is the input to IsReady. SPEC §4.5 wrote the signature as
+// `func IsReady(ctx, itemID string) (bool, error)`, but Encore requires
+// API request types to be named structs (E1354). This skeleton wraps
+// itemID in a request struct; the wire-shape (single item lookup) is
+// unchanged. See DEVIATION trail on bead unblock-tv8.1.
+type IsReadyRequest struct {
+	ItemID string
+}
+
+// IsReadyResponse is the output of IsReady. Encore also requires API
+// response types to be named structs (a bare `bool` is rejected).
+type IsReadyResponse struct {
+	IsReady bool
+}
+
+// IsReady is a read-side helper that returns the current is_ready value
+// (read directly from workitems.items, not recomputed). SPEC §4.5.
+//
+//encore:api private method=POST path=/deps.IsReady
+func IsReady(ctx context.Context, req *IsReadyRequest) (*IsReadyResponse, error) {
+	return nil, errNotImplemented
+}
+
+// ClosureRequest is the input to Closure. SPEC §4.5.
+type ClosureRequest struct {
+	ItemID    string
+	Direction string // "incoming" | "outgoing"
+	MaxDepth  int    // 1..256; default 256
+}
+
+// ClosureResponse is the output of Closure. SPEC §4.5.
+type ClosureResponse struct {
+	ItemIDs []string
+}
+
+// Closure returns the transitive 'blocks' closure for an item. SPEC §4.5.
+//
+//encore:api private method=POST path=/deps.Closure
+func Closure(ctx context.Context, req *ClosureRequest) (*ClosureResponse, error) {
+	return nil, errNotImplemented
+}
+
+// RecentCascadeEventsRequest is the input to RecentCascadeEvents. SPEC §4.5.
+type RecentCascadeEventsRequest struct {
+	OrgID     string
+	ProjectID string
+	Limit     int // capped at 50; default 50
+}
+
+// CascadeEventRow is one row of a RecentCascadeEvents response. SPEC §4.5.
+type CascadeEventRow struct {
+	ID                string
+	EventID           string
+	TriggeredByItemID string
+	AffectedItemIDs   []string
+	CascadedCount     int
+	TriggeredAt       time.Time
+	TraceID           string
+}
+
+// RecentCascadeEventsResponse is the output of RecentCascadeEvents. SPEC §4.5.
+type RecentCascadeEventsResponse struct {
+	Events []CascadeEventRow
+}
+
+// RecentCascadeEvents returns the last 50 deps.cascade_events rows for the
+// org/project, ordered by triggered_at DESC. AF2 closure — used by the
+// prime MCP tool. SPEC §4.5.
+//
+//encore:api private method=POST path=/deps.RecentCascadeEvents
+func RecentCascadeEvents(ctx context.Context, req *RecentCascadeEventsRequest) (*RecentCascadeEventsResponse, error) {
+	return nil, errNotImplemented
+}

--- a/apps/api/mcp/mcp.go
+++ b/apps/api/mcp/mcp.go
@@ -1,0 +1,38 @@
+// Package mcp owns the public Streamable HTTP MCP endpoint at /mcp and the
+// 14 P01 tool handlers. See SPEC §4.3 (transport, auth, hot path) and §6.2
+// (tool catalogue).
+//
+// In P01 task A-1 this package only declares the //encore:api raw endpoint
+// skeleton so Encore recognises mcp as a service. The handler currently
+// rejects every method with 405 (Allow: POST, GET) — POST/GET dispatch
+// into the Go MCP SDK lands in D-1 (unblock-tv8.16) per SPEC §4.3.1.
+//
+// Per round-2 review (L7-W2 closure) the endpoint uses a single
+// //encore:api annotation with `method=*` so HTTP-method routing happens
+// inside the function body. Encore's raw-endpoint convention is one
+// annotation per function; stacked POST+GET annotations are not supported
+// by the Encore parser.
+package mcp
+
+import "net/http"
+
+// MCPHandler is the single MCP entry point. Both POST and GET hit the same
+// handler; HTTP-method dispatch happens inside the function body. The Go
+// MCP SDK delegates land in task D-1 — until then the skeleton replies 405
+// for every request (the auth handler in §4.3.3 will short-circuit before
+// this body runs once Bearer auth wires up in B-1/D-1).
+//
+//encore:api public raw path=/mcp
+func MCPHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost, http.MethodGet:
+		// TODO(D-1, unblock-tv8.16): delegate to Go MCP SDK Streamable
+		// HTTP transport adapter (POST = client→server, GET = server-
+		// initiated SSE). Until the SDK is pinned, fall through to 405
+		// so callers get a deterministic skeleton response.
+		fallthrough
+	default:
+		w.Header().Set("Allow", "POST, GET")
+		http.Error(w, "mcp: not implemented in P01 A-1 skeleton", http.StatusMethodNotAllowed)
+	}
+}

--- a/apps/api/memory/.gitkeep
+++ b/apps/api/memory/.gitkeep
@@ -1,0 +1,3 @@
+# Schema-only service in P01 — no Go files yet.
+# Service code lands in P02. Schema DDL ships via auth/migrations/0090_memory.up.sql.
+# See SPEC §4.6.

--- a/apps/api/org/org.go
+++ b/apps/api/org/org.go
@@ -1,0 +1,98 @@
+// Package org owns the org schema. Holds organizations, members, projects,
+// and the canonical Authorize RBAC predicate consumed by every other service.
+// See SPEC §4.2 for full RPC surface.
+//
+// In P01 task A-1 this package only declares the //encore:api skeletons so
+// Encore recognises org as a service. Bodies return errNotImplemented;
+// real wiring (sqldb.Named("unblock"), bodies, RBAC matrix) lands in B-1
+// and following beads.
+package org
+
+import (
+	"context"
+	"errors"
+
+	"encore.app/auth"
+)
+
+// errNotImplemented is the sentinel returned by every P01 A-1 skeleton body.
+var errNotImplemented = errors.New("org: not implemented in P01 A-1 skeleton")
+
+// Organization is the canonical org row shape. SPEC §4.2.
+type Organization struct {
+	ID   string // ULID
+	Name string
+	Slug string
+}
+
+// Project is the canonical project row shape. SPEC §4.2.
+type Project struct {
+	ID    string // ULID
+	OrgID string // ULID
+	Name  string
+	Slug  string
+}
+
+// CreateOrganizationRequest is the input to CreateOrganization. SPEC §4.2.
+type CreateOrganizationRequest struct {
+	Name string
+	Slug string
+}
+
+//encore:api private method=POST path=/org.CreateOrganization
+func CreateOrganization(ctx context.Context, req *CreateOrganizationRequest) (*Organization, error) {
+	return nil, errNotImplemented
+}
+
+// CreateProjectRequest is the input to CreateProject. SPEC §4.2.
+type CreateProjectRequest struct {
+	OrgID string
+	Name  string
+	Slug  string
+}
+
+//encore:api private method=POST path=/org.CreateProject
+func CreateProject(ctx context.Context, req *CreateProjectRequest) (*Project, error) {
+	return nil, errNotImplemented
+}
+
+//encore:api private method=GET path=/org.GetOrganization/:id
+func GetOrganization(ctx context.Context, id string) (*Organization, error) {
+	return nil, errNotImplemented
+}
+
+//encore:api private method=GET path=/org.GetProject/:id
+func GetProject(ctx context.Context, id string) (*Project, error) {
+	return nil, errNotImplemented
+}
+
+// AddMemberRequest is the input to AddMember. SPEC §4.2.
+type AddMemberRequest struct {
+	OrgID  string
+	UserID string
+	Role   string // "owner" | "admin" | "member" | "viewer"
+}
+
+//encore:api private method=POST path=/org.AddMember
+func AddMember(ctx context.Context, req *AddMemberRequest) error {
+	return errNotImplemented
+}
+
+// AuthorizeRequest is the input to Authorize. SPEC §4.2.
+type AuthorizeRequest struct {
+	Identity  auth.Identity
+	Resource  string // "workitems.items" | "deps.dependencies" | etc.
+	Action    string // "read" | "write" | "delete"
+	OrgID     string
+	ProjectID string // optional
+}
+
+// Authorize is the canonical RBAC predicate. Called by every other service
+// before reading or writing a resource. Returns nil on permit;
+// ErrForbidden on deny. The org_id of the resource is matched against the
+// identity's org_id; cross-tenant calls are rejected here.
+//
+//encore:api private method=POST path=/org.Authorize
+func Authorize(ctx context.Context, req *AuthorizeRequest) error {
+	return errNotImplemented
+}

--- a/apps/api/providers/.gitkeep
+++ b/apps/api/providers/.gitkeep
@@ -1,0 +1,3 @@
+# Schema-only service in P01 — no Go files yet.
+# Service code lands in P02. Schema DDL ships via auth/migrations/0060_providers.up.sql.
+# See SPEC §4.6.

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1,0 +1,355 @@
+// Package workitems owns the workitems schema (items, comments, labels,
+// milestones) and exposes the private RPCs called by MCP tool handlers.
+// See SPEC §4.4 for the full RPC surface.
+//
+// In P01 task A-1 this package only declares the //encore:api skeletons so
+// Encore recognises workitems as a service. Bodies return errNotImplemented;
+// real wiring (sqldb.Named("unblock"), bodies, FTS, milestones, claim
+// transaction, state-machine invariants) lands in B-1, B-2, and following.
+package workitems
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// errNotImplemented is the sentinel returned by every P01 A-1 skeleton body.
+var errNotImplemented = errors.New("workitems: not implemented in P01 A-1 skeleton")
+
+// Edge mirrors deps.Edge for the create-with-deps path. SPEC §4.4 / §4.5.
+// Duplicated locally (rather than imported from deps) to keep the
+// workitems → deps direction unidirectional in skeleton form; the real
+// Create handler in B-1 calls deps.AddEdge with the deps.Edge type.
+type Edge struct {
+	BlockerItemID string // from_item: must complete first
+	Kind          string // "blocks" | "related"; default "blocks"
+}
+
+// Item is the canonical work-item row shape. SPEC §4.4.
+type Item struct {
+	ID                  string
+	OrgID               string
+	ProjectID           string
+	MilestoneID         string
+	ParentID            string
+	DiscoveredFromID    string
+	Type                string
+	Title               string
+	Body                string
+	Status              string
+	Priority            string
+	PipelineStage       string
+	AgentKind           string
+	ImplState           string
+	ReviewState         string
+	QAState             string
+	PipelineState       string
+	Severity            string
+	KindOfFinding       string
+	ClaimedByID         string
+	ClaimedByAgent      string
+	ClaimedAt           *time.Time
+	IsReady             bool
+	MilestoneAssignedAt *time.Time
+	MilestoneAssignedBy string
+	Labels              []string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	ClosedAt            *time.Time
+}
+
+// CreateRequest is the input to Create. SPEC §4.4.
+type CreateRequest struct {
+	OrgID            string
+	ProjectID        string
+	ParentID         string
+	DiscoveredFromID string
+	Type             string
+	Title            string
+	Body             string
+	Priority         string
+	MilestoneID      string
+	Labels           []string
+	Dependencies     []Edge
+	Severity         string
+	KindOfFinding    string
+}
+
+//encore:api private method=POST path=/workitems.Create
+func Create(ctx context.Context, req *CreateRequest) (*Item, error) {
+	return nil, errNotImplemented
+}
+
+// UpdateRequest is the input to Update. SPEC §4.4.
+type UpdateRequest struct {
+	ItemID      string
+	Title       *string
+	Body        *string
+	Priority    *string
+	MilestoneID *string
+	Labels      *[]string
+}
+
+//encore:api private method=POST path=/workitems.Update
+func Update(ctx context.Context, req *UpdateRequest) (*Item, error) {
+	return nil, errNotImplemented
+}
+
+//encore:api private method=GET path=/workitems.Get/:id
+func Get(ctx context.Context, id string) (*Item, error) {
+	return nil, errNotImplemented
+}
+
+// Comment is the canonical comment row shape. SPEC §4.4.
+type Comment struct {
+	ID          string
+	ItemID      string
+	ParentID    string
+	AuthorID    string
+	AuthorAgent string
+	Kind        string
+	Status      string
+	Body        string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// GetTrailRequest is the input to GetTrail. SPEC §4.4.
+type GetTrailRequest struct {
+	ItemID string
+}
+
+// Trail is the comment + edges + findings bundle returned by GetTrail.
+// SPEC §4.4. DependenciesIn / DependenciesOut use the workitems.Edge type
+// in skeleton form; B-1 will widen to deps.Edge if richer fields are needed.
+type Trail struct {
+	Item            *Item
+	Comments        []Comment
+	DependenciesIn  []Edge
+	DependenciesOut []Edge
+	Findings        []Item
+}
+
+//encore:api private method=POST path=/workitems.GetTrail
+func GetTrail(ctx context.Context, req *GetTrailRequest) (*Trail, error) {
+	return nil, errNotImplemented
+}
+
+// AppendCommentRequest is the input to AppendComment. SPEC §4.4.
+type AppendCommentRequest struct {
+	ItemID      string
+	AuthorID    string
+	AuthorAgent string
+	ParentID    string
+	Kind        string
+	Status      string
+	Body        string
+}
+
+//encore:api private method=POST path=/workitems.AppendComment
+func AppendComment(ctx context.Context, req *AppendCommentRequest) (*Comment, error) {
+	return nil, errNotImplemented
+}
+
+// SetStateRequest is the input to SetStateColumns. SPEC §4.4.
+type SetStateRequest struct {
+	ItemID        string
+	ImplState     *string
+	ReviewState   *string
+	QAState       *string
+	PipelineState *string
+}
+
+// SetStateColumns writes one or more of (impl_state, review_state,
+// qa_state, pipeline_state) and recomputes pipeline_stage. Enforces the
+// five PRD §6.2 state-machine invariants in app code (round-2 D2). See
+// SPEC §4.4 / §6.2 Tool 13.
+//
+//encore:api private method=POST path=/workitems.SetStateColumns
+func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
+	return nil, errNotImplemented
+}
+
+// CloseRequest is the input to Close. SPEC §4.4.
+type CloseRequest struct {
+	ItemID string
+	Reason string
+}
+
+// Close sets status=Done, closed_at=now(), emits deps.cascade.requested.
+// MCP-layer precondition (AF3): rejects if claimed_by_id IS NULL.
+//
+//encore:api private method=POST path=/workitems.Close
+func Close(ctx context.Context, req *CloseRequest) (*Item, error) {
+	return nil, errNotImplemented
+}
+
+// ClaimRequest is the input to Claim. SPEC §4.4.
+type ClaimRequest struct {
+	ItemID        string
+	ClaimerUserID string
+	ClaimerAgent  string
+}
+
+// Claim performs the atomic claim transaction (SELECT FOR UPDATE) per
+// SPEC §5.5. Resets review_state and qa_state to "pending" when the item
+// being claimed has qa_state="failed" at lock time (round-2 D2 / PRD §6.2
+// invariant #3). See SPEC §4.4.
+//
+//encore:api private method=POST path=/workitems.Claim
+func Claim(ctx context.Context, req *ClaimRequest) (*Item, error) {
+	return nil, errNotImplemented
+}
+
+// ListRequest is the input to List. SPEC §4.4.
+type ListRequest struct {
+	OrgID         string
+	ProjectID     string
+	MilestoneID   string
+	Status        []string
+	PipelineStage []string
+	ClaimedBy     string
+	Labels        []string
+	Limit         int
+	Cursor        string
+}
+
+// ListResponse is the output of List. SPEC §4.4.
+type ListResponse struct {
+	Items      []Item
+	NextCursor string
+}
+
+//encore:api private method=POST path=/workitems.List
+func List(ctx context.Context, req *ListRequest) (*ListResponse, error) {
+	return nil, errNotImplemented
+}
+
+// SearchRequest is the input to Search. SPEC §4.4.
+type SearchRequest struct {
+	OrgID     string
+	ProjectID string
+	Query     string
+	Limit     int
+}
+
+// SearchHit is one row of a Search response. SPEC §4.4.
+type SearchHit struct {
+	ItemID    string
+	Source    string
+	CommentID string
+	Rank      float64
+	Snippet   string
+}
+
+// SearchResponse is the output of Search. SPEC §4.4.
+type SearchResponse struct {
+	Hits []SearchHit
+}
+
+// Search performs multi-table FTS per AF1 (UNION ALL over items_fts_idx
+// and comments_fts_idx). SPEC §4.4.
+//
+//encore:api private method=POST path=/workitems.Search
+func Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
+	return nil, errNotImplemented
+}
+
+// Milestone is the canonical milestone row shape. SPEC §4.4.1.
+type Milestone struct {
+	ID                string
+	ParentMilestoneID string
+	OrgID             string
+	ProjectID         string
+	Name              string
+	Description       string
+	StartDate         string
+	EndDate           string
+	CancelledAt       *time.Time
+	CancelledReason   string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+// CreateMilestoneRequest is the input to CreateMilestone. SPEC §4.4.1.
+type CreateMilestoneRequest struct {
+	OrgID             string
+	ProjectID         string
+	ParentMilestoneID string
+	Name              string
+	Description       string
+	StartDate         string
+	EndDate           string
+}
+
+// CreateMilestone enforces M-INV-1, M-INV-2, M-INV-3, M-INV-5, M-INV-6 in
+// app code. SPEC §4.4.1 / round-2 D1.
+//
+//encore:api private method=POST path=/workitems.CreateMilestone
+func CreateMilestone(ctx context.Context, req *CreateMilestoneRequest) (*Milestone, error) {
+	return nil, errNotImplemented
+}
+
+// UpdateMilestoneRequest is the input to UpdateMilestone. SPEC §4.4.1.
+type UpdateMilestoneRequest struct {
+	MilestoneID     string
+	Name            *string
+	Description     *string
+	StartDate       *string
+	EndDate         *string
+	CancelledAt     *time.Time
+	CancelledReason *string
+}
+
+//encore:api private method=POST path=/workitems.UpdateMilestone
+func UpdateMilestone(ctx context.Context, req *UpdateMilestoneRequest) (*Milestone, error) {
+	return nil, errNotImplemented
+}
+
+// AssignItemRequest is the input to AssignItem. SPEC §4.4.1.
+type AssignItemRequest struct {
+	ItemID         string
+	MilestoneID    string
+	AssignedByUser string
+}
+
+// AssignItem sets workitems.items.milestone_id atomically. Enforces
+// M-INV-7. SPEC §4.4.1.
+//
+//encore:api private method=POST path=/workitems.AssignItem
+func AssignItem(ctx context.Context, req *AssignItemRequest) error {
+	return errNotImplemented
+}
+
+// MilestoneTreeRequest is the input to MilestoneTree. SPEC §4.4.1.
+type MilestoneTreeRequest struct {
+	OrgID            string
+	ProjectID        string
+	RootMilestoneID  string
+	IncludeCancelled bool
+}
+
+// MilestoneNode is one node in the recursive milestone tree response.
+// SPEC §4.4.1.
+type MilestoneNode struct {
+	Milestone Milestone
+	Depth     int
+	Children  []MilestoneNode
+}
+
+// MilestoneTreeResponse is the output of MilestoneTree. SPEC §4.4.1.
+//
+// (The spec names the type `MilestoneTree` but Go disallows a function
+// and a top-level type sharing one name in the same package. The RPC
+// route, signature shape, and JSON-on-the-wire encoding are unchanged —
+// Encore serialises by field, not by type name. See DECISION trail on
+// bead unblock-tv8.1.)
+type MilestoneTreeResponse struct {
+	Roots []MilestoneNode
+}
+
+//encore:api private method=POST path=/workitems.MilestoneTree
+func MilestoneTree(ctx context.Context, req *MilestoneTreeRequest) (*MilestoneTreeResponse, error) {
+	return nil, errNotImplemented
+}


### PR DESCRIPTION
## unblock-tv8.1: A-1 Encore app init and service skeletons

Initialise the apps/api/ Encore Go workspace with all eight P01 service packages. Five live services carry //encore:api skeleton declarations matching the JSON-/RPC-locked signatures in SPEC §4.1–§4.5; three schema-only services ship as empty directories per SPEC §4.6.

### What was done
- auth: 4 private RPCs (Validate, ExchangeOAuthCode, IssueAPIKey, RevokeAPIKey) + Identity type
- org: 6 private RPCs (CreateOrganization, CreateProject, GetOrganization/:id, GetProject/:id, AddMember, Authorize)
- workitems: 16 private RPCs covering items, comments, state-machine, claim, search, and the 4 milestone RPCs (D1)
- deps: 5 private RPCs (AddEdge, RemoveEdge, IsReady, Closure, RecentCascadeEvents)
- mcp: single public raw endpoint at /mcp; HTTP-method dispatch in handler body (L7-W2)
- providers / boards / memory: empty directories with .gitkeep placeholders (no .go files in P01)
- auth/migrations/.gitkeep reserves the canonical migration directory; A-2 ships 0010_bootstrap.up.sql

### Files changed
- apps/api/.gitignore (added encore.gen.* ignores)
- apps/api/auth/auth.go (new)
- apps/api/auth/migrations/.gitkeep (new)
- apps/api/org/org.go (new)
- apps/api/workitems/workitems.go (new)
- apps/api/deps/deps.go (new)
- apps/api/mcp/mcp.go (new)
- apps/api/providers/.gitkeep (new)
- apps/api/boards/.gitkeep (new)
- apps/api/memory/.gitkeep (new)

### Decisions
- Deferred sqldb.NewDatabase("unblock", ...) and sqldb.Named("unblock") wiring entirely to A-2 (option (a) from the investigation). Encore's parser scans the Migrations: directory at parse time and rejects empty / non-existent ones. A-2 ships the bootstrap migration AND the NewDatabase + Named consumer calls atomically. The migration-owner contract is honoured structurally — auth/migrations/.gitkeep reserves the canonical location.

### Deviations
- workitems.IsReady scalar request/response wrapped in named structs (Encore E1354 — API request/response types must be named structs). Wire shape unchanged.
- mcp.MCPHandler uses bare path=/mcp with no method= clause (Encore v1.57.0 E1371 rejects method=* — only HTTP method names are accepted). Per ENCORE.md raw-endpoints docs, omitting method= accepts every HTTP method on the path — semantically identical to method=*. The L7-W2 closure (single annotation, dispatch inside the body) is preserved.
- workitems.MilestoneTree response type renamed to MilestoneTreeResponse to avoid the Go function/type identifier collision.

### Quality gates (run from apps/api/)
- go fmt ./... clean
- go vet ./... clean
- go test ./... all pass (no test files yet, compile-clean)
- encore check 0 findings; 30 API endpoints registered
- Smoke-tested POST/GET/PUT /mcp via curl → 405 + "mcp: not implemented in P01 A-1 skeleton" body, as designed