### PR TITLE
unblock-tv8.3: A-3 schema migrations 0020-0090 (eight Postgres schemas)

### DIFF
--- a/apps/api/auth/migrations/0020_auth.up.sql
+++ b/apps/api/auth/migrations/0020_auth.up.sql
@@ -1,0 +1,66 @@
+-- Schema `auth` — identities, OAuth tokens, sessions.
+-- Canonical DDL: docs/SPEC.md § 9.4.1.
+-- See docs/specs/01-spec-backend-mvp.md § 3.2 / § 3.3 for migration rules.
+-- Per § 3.3: no down.sql; CREATE SCHEMA IF NOT EXISTS is the only IF-NOT-EXISTS
+-- usage permitted after 0010_bootstrap; subsequent CREATE TABLE / CREATE INDEX
+-- statements assume a fresh schema.
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+-- Identities. Single primary identity per user (PRD FR-2).
+CREATE TABLE auth.users (
+    id                  text         PRIMARY KEY,                          -- ULID
+    primary_provider    text         NOT NULL,                             -- 'github' | 'gitlab'
+    primary_provider_id text         NOT NULL,                             -- provider-side user id
+    email               text         NOT NULL,
+    display_name        text         NOT NULL,
+    avatar_url          text,
+    created_at          timestamptz  NOT NULL DEFAULT now(),
+    updated_at          timestamptz  NOT NULL DEFAULT now(),
+    deleted_at          timestamptz,                                       -- soft delete
+    CONSTRAINT users_primary_provider_chk
+        CHECK (primary_provider IN ('github', 'gitlab')),
+    CONSTRAINT users_primary_provider_unique
+        UNIQUE (primary_provider, primary_provider_id)
+);
+CREATE UNIQUE INDEX users_email_active_uniq
+    ON auth.users (lower(email))
+    WHERE deleted_at IS NULL;
+
+-- OAuth tokens (encrypted at rest). Linked to users; multiple providers per user
+-- supported, but only one is primary per FR-2 (others are event-source attachments).
+CREATE TABLE auth.oauth_tokens (
+    id                text         PRIMARY KEY,                            -- ULID
+    user_id           text         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    provider          text         NOT NULL,                               -- 'github' | 'gitlab'
+    access_token_enc  bytea        NOT NULL,                               -- pgp_sym_encrypt(...)
+    refresh_token_enc bytea,                                               -- nullable; not all providers issue refresh tokens
+    scopes            text[]       NOT NULL DEFAULT '{}',
+    expires_at        timestamptz,
+    created_at        timestamptz  NOT NULL DEFAULT now(),
+    rotated_at        timestamptz,                                         -- last refresh
+    CONSTRAINT oauth_tokens_provider_chk
+        CHECK (provider IN ('github', 'gitlab')),
+    CONSTRAINT oauth_tokens_user_provider_uniq
+        UNIQUE (user_id, provider)
+);
+CREATE INDEX oauth_tokens_user_idx ON auth.oauth_tokens (user_id);
+
+-- Sessions. HttpOnly cookie payload references the session id; rotation is
+-- expressed as a new row + revocation of the previous one.
+CREATE TABLE auth.sessions (
+    id           text         PRIMARY KEY,                                 -- ULID; opaque session id
+    user_id      text         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    issued_at    timestamptz  NOT NULL DEFAULT now(),
+    last_seen_at timestamptz  NOT NULL DEFAULT now(),
+    expires_at   timestamptz  NOT NULL,
+    revoked_at   timestamptz,
+    user_agent   text,
+    ip_inet      inet,
+    CONSTRAINT sessions_expiry_chk
+        CHECK (expires_at > issued_at)
+);
+-- Partial index: only active sessions matter for the auth hot path.
+CREATE INDEX sessions_active_user_idx
+    ON auth.sessions (user_id, last_seen_at DESC)
+    WHERE revoked_at IS NULL;

--- a/apps/api/auth/migrations/0030_org.up.sql
+++ b/apps/api/auth/migrations/0030_org.up.sql
@@ -1,0 +1,61 @@
+-- Schema `org` — organizations, members, projects, project_members.
+-- Canonical DDL: docs/SPEC.md § 9.4.2.
+-- FK direction: org -> auth (already migrated in 0020).
+
+CREATE SCHEMA IF NOT EXISTS org;
+
+CREATE TABLE org.organizations (
+    id          text         PRIMARY KEY,                                  -- ULID
+    slug        text         NOT NULL,
+    name        text         NOT NULL,
+    description text,
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    updated_at  timestamptz  NOT NULL DEFAULT now(),
+    deleted_at  timestamptz,
+    CONSTRAINT organizations_slug_uniq UNIQUE (slug)
+);
+
+-- Roles are encoded as text + CHECK (per § 9.4.0). 4 roles at v1.0.
+CREATE TABLE org.members (
+    id         text         PRIMARY KEY,                                   -- ULID
+    org_id     text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    user_id    text         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    role       text         NOT NULL,                                      -- 'owner' | 'admin' | 'member' | 'viewer'
+    invited_by text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT members_role_chk
+        CHECK (role IN ('owner', 'admin', 'member', 'viewer')),
+    CONSTRAINT members_org_user_uniq
+        UNIQUE (org_id, user_id)
+);
+CREATE INDEX members_user_idx ON org.members (user_id);
+CREATE INDEX members_org_role_idx ON org.members (org_id, role);
+
+CREATE TABLE org.projects (
+    id          text         PRIMARY KEY,                                  -- ULID
+    org_id      text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    slug        text         NOT NULL,
+    name        text         NOT NULL,
+    description text,
+    archived_at timestamptz,
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    updated_at  timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT projects_org_slug_uniq UNIQUE (org_id, slug)
+);
+CREATE INDEX projects_org_active_idx
+    ON org.projects (org_id)
+    WHERE archived_at IS NULL;
+
+-- Project-level role override. Effective role = max(org role, project role).
+CREATE TABLE org.project_members (
+    id         text         PRIMARY KEY,                                   -- ULID
+    project_id text         NOT NULL REFERENCES org.projects(id) ON DELETE CASCADE,
+    user_id    text         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    role       text         NOT NULL,                                      -- 'owner' | 'admin' | 'member' | 'viewer'
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT project_members_role_chk
+        CHECK (role IN ('owner', 'admin', 'member', 'viewer')),
+    CONSTRAINT project_members_project_user_uniq
+        UNIQUE (project_id, user_id)
+);
+CREATE INDEX project_members_user_idx ON org.project_members (user_id);

--- a/apps/api/auth/migrations/0040_workitems.up.sql
+++ b/apps/api/auth/migrations/0040_workitems.up.sql
@@ -1,0 +1,233 @@
+-- Schema `workitems` — milestones, items, labels, item_labels, comments.
+-- Canonical DDL: docs/SPEC.md § 9.4.3.
+-- FK direction: workitems -> org, auth (already migrated in 0020/0030).
+-- FTS DDL (AF1): per-table tsvector GENERATED ... STORED + GIN index inline
+-- below — items_fts_idx, comments_fts_idx (PG GIN cannot span tables; the
+-- search RPC uses UNION ALL across both indexes per docs/specs/01 § 3.4).
+
+CREATE SCHEMA IF NOT EXISTS workitems;
+
+-- Milestones are recursive (PRD § 6.3). Self-FK + scope FKs.
+CREATE TABLE workitems.milestones (
+    id                  text         PRIMARY KEY,                          -- ULID
+    parent_milestone_id text         REFERENCES workitems.milestones(id) ON DELETE SET NULL,
+    org_id              text         REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id          text         REFERENCES org.projects(id) ON DELETE CASCADE,
+    name                text         NOT NULL,
+    description         text,
+    start_date          date         NOT NULL,
+    end_date            date         NOT NULL,
+    cancelled_at        timestamptz,
+    cancelled_reason    text,
+    created_at          timestamptz  NOT NULL DEFAULT now(),
+    updated_at          timestamptz  NOT NULL DEFAULT now(),
+    -- M-INV-1: no self-loop
+    CONSTRAINT milestones_no_self_loop_chk
+        CHECK (parent_milestone_id IS NULL OR parent_milestone_id <> id),
+    -- Scope is XOR: org-wide OR project-local, never both, never neither.
+    CONSTRAINT milestones_scope_xor_chk
+        CHECK ((org_id IS NOT NULL AND project_id IS NULL)
+            OR (org_id IS NULL AND project_id IS NOT NULL)),
+    -- Date sanity
+    CONSTRAINT milestones_date_range_chk
+        CHECK (end_date >= start_date)
+);
+CREATE INDEX milestones_parent_idx       ON workitems.milestones (parent_milestone_id);
+CREATE INDEX milestones_org_idx          ON workitems.milestones (org_id);
+CREATE INDEX milestones_project_idx      ON workitems.milestones (project_id);
+CREATE INDEX milestones_active_idx
+    ON workitems.milestones (project_id, start_date)
+    WHERE cancelled_at IS NULL;
+-- Note: M-INV-2 (cycle prevention), M-INV-3 (range containment), M-INV-5 (scope match),
+-- M-INV-6 (max depth = 4), M-INV-7 (item-milestone scope reachability) are enforced
+-- in app code via recursive CTE checks at insert/update time. See SPEC § 9.4.9.
+
+-- Work items. The single most-touched table in the product.
+CREATE TABLE workitems.items (
+    id                   text         PRIMARY KEY,                         -- ULID
+    org_id               text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id           text         REFERENCES org.projects(id) ON DELETE CASCADE,
+    milestone_id         text         REFERENCES workitems.milestones(id) ON DELETE SET NULL,
+    parent_id            text         REFERENCES workitems.items(id) ON DELETE SET NULL,
+    discovered_from_id   text         REFERENCES workitems.items(id) ON DELETE SET NULL,
+    type                 text         NOT NULL DEFAULT 'task',             -- 'epic' | 'task' | 'finding'
+    title                text         NOT NULL,
+    body                 text         NOT NULL DEFAULT '',
+    -- § 6.1 enums
+    status               text         NOT NULL DEFAULT 'Backlog',          -- 'Backlog' | 'Ready' | 'InProgress' | 'Blocked' | 'Done'
+    priority             text         NOT NULL DEFAULT 'P3',               -- 'P0'..'P4'
+    pipeline_stage       text         NOT NULL DEFAULT 'Investigation',    -- § 6.1 PipelineStage values; SUBSCRIBER-MAINTAINED — derived from impl/review/qa/pipeline_state per § 5.7.1; do not write directly outside the cascade subscriber
+    agent_kind           text,                                             -- § 6.1 AgentKind values; nullable until claim
+    -- § 6.2 three orthogonal dimensions
+    impl_state           text         NOT NULL DEFAULT 'pending',          -- 'pending' | 'done'
+    review_state         text         NOT NULL DEFAULT 'pending',          -- 'pending' | 'approved' | 'needs_rework'
+    qa_state             text         NOT NULL DEFAULT 'pending',          -- 'pending' | 'passed' | 'failed'
+    pipeline_state       text         NOT NULL DEFAULT 'running',          -- 'running' | 'needs_human' | 'paused' | 'no_investigation'
+    -- § 6.6 finding fields
+    severity             text,                                             -- only meaningful when type='finding'
+    kind_of_finding      text,                                             -- 'review' | 'qa'; only when type='finding'
+    -- Claim
+    claimed_by_id        text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    claimed_by_agent     text,                                             -- AgentKind value of the claimer
+    claimed_at           timestamptz,
+    -- Cascade-materialised readiness (NOT a generated column; updated by deps subscriber)
+    is_ready             boolean      NOT NULL DEFAULT false,
+    -- Milestone audit (collapsed from the deleted item_milestone junction)
+    milestone_assigned_at timestamptz,
+    milestone_assigned_by text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    -- Lifecycle
+    created_at           timestamptz  NOT NULL DEFAULT now(),
+    updated_at           timestamptz  NOT NULL DEFAULT now(),
+    closed_at            timestamptz,
+    -- Constraints
+    CONSTRAINT items_no_self_parent_chk
+        CHECK (parent_id IS NULL OR parent_id <> id),
+    CONSTRAINT items_no_self_discovery_chk
+        CHECK (discovered_from_id IS NULL OR discovered_from_id <> id),
+    CONSTRAINT items_type_chk
+        CHECK (type IN ('epic', 'task', 'finding')),
+    CONSTRAINT items_status_chk
+        CHECK (status IN ('Backlog', 'Ready', 'InProgress', 'Blocked', 'Done')),
+    CONSTRAINT items_priority_chk
+        CHECK (priority IN ('P0', 'P1', 'P2', 'P3', 'P4')),
+    CONSTRAINT items_pipeline_stage_chk
+        CHECK (pipeline_stage IN ('Investigation', 'Implementation', 'Review', 'Quality', 'Deferred', 'Done')),
+    CONSTRAINT items_agent_kind_chk
+        CHECK (agent_kind IS NULL OR agent_kind IN ('claude-code', 'copilot', 'cursor', 'codex', 'aider', 'custom')),
+    CONSTRAINT items_impl_state_chk
+        CHECK (impl_state IN ('pending', 'done')),
+    CONSTRAINT items_review_state_chk
+        CHECK (review_state IN ('pending', 'approved', 'needs_rework')),
+    CONSTRAINT items_qa_state_chk
+        CHECK (qa_state IN ('pending', 'passed', 'failed')),
+    CONSTRAINT items_pipeline_state_chk
+        CHECK (pipeline_state IN ('running', 'needs_human', 'paused', 'no_investigation')),
+    CONSTRAINT items_severity_chk
+        CHECK (severity IS NULL
+            OR severity IN ('critical', 'major', 'minor', 'risk', 'extra', 'deviation')),
+    CONSTRAINT items_kind_of_finding_chk
+        CHECK (kind_of_finding IS NULL OR kind_of_finding IN ('review', 'qa')),
+    -- Findings must declare severity + originating bead + a parent epic.
+    -- PRD § 6.6 promises findings live "under the parent epic" — parent_id
+    -- is required, and the service layer asserts the parent's type='epic'
+    -- (deferred check; not expressible as a single-row CHECK).
+    CONSTRAINT items_finding_required_fields_chk
+        CHECK (
+            (type <> 'finding')
+            OR (severity IS NOT NULL
+                AND kind_of_finding IS NOT NULL
+                AND discovered_from_id IS NOT NULL
+                AND parent_id IS NOT NULL)
+        ),
+    -- A claim implies status InProgress or Done. The (claimed_by_id NULL,
+    -- status Done) combination is also legal: closing an item via the
+    -- override path or via cascade promotion may finalise an item that was
+    -- never claimed. Conversely, once claimed, an item's claim audit is
+    -- preserved through close — `claimed_by_id` and `claimed_at` are NOT
+    -- nulled on close. (Research AF3: the asymmetry is intentional; close
+    -- preserves the claim history so the audit trail of who completed the
+    -- work survives indefinitely.)
+    CONSTRAINT items_claim_status_chk
+        CHECK (
+            (claimed_by_id IS NULL AND claimed_at IS NULL)
+            OR (claimed_by_id IS NOT NULL AND claimed_at IS NOT NULL AND status IN ('InProgress', 'Done'))
+        )
+);
+-- Hot-path indexes
+CREATE INDEX items_org_status_idx        ON workitems.items (org_id, status);
+CREATE INDEX items_project_status_idx    ON workitems.items (project_id, status);
+CREATE INDEX items_milestone_idx         ON workitems.items (milestone_id);
+CREATE INDEX items_parent_idx            ON workitems.items (parent_id);
+CREATE INDEX items_discovered_from_idx   ON workitems.items (discovered_from_id);
+CREATE INDEX items_claimed_by_idx        ON workitems.items (claimed_by_id);
+-- Partial index: the `ready` MCP tool's hot path. p99 < 2 s depends on this.
+CREATE INDEX items_ready_partial_idx
+    ON workitems.items (org_id, project_id, priority)
+    WHERE is_ready = true AND status = 'Ready' AND closed_at IS NULL;
+-- Full-text search backing the `search` MCP tool (research AF1). Generated
+-- column over title + body; GIN-indexed. Multi-table search at query time
+-- uses UNION ALL across this index and `comments_fts_idx` (PG GIN cannot
+-- span two tables); per-row trigram fallback covers fuzzy match.
+ALTER TABLE workitems.items ADD COLUMN fts tsvector
+    GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(body,  '')), 'B')
+    ) STORED;
+CREATE INDEX items_fts_idx ON workitems.items USING GIN (fts);
+-- Partial index: in-progress board view.
+CREATE INDEX items_in_progress_idx
+    ON workitems.items (org_id, project_id, claimed_at DESC)
+    WHERE status = 'InProgress';
+
+-- User-facing labels (PRD § 6.4). Scope is org XOR project.
+CREATE TABLE workitems.labels (
+    id          text         PRIMARY KEY,                                  -- ULID
+    org_id      text         REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id  text         REFERENCES org.projects(id) ON DELETE CASCADE,
+    name        text         NOT NULL,
+    color       text         NOT NULL,                                     -- hex, '#rrggbb'
+    description text,
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT labels_scope_xor_chk
+        CHECK ((org_id IS NOT NULL AND project_id IS NULL)
+            OR (org_id IS NULL AND project_id IS NOT NULL)),
+    CONSTRAINT labels_color_chk
+        CHECK (color ~ '^#[0-9a-fA-F]{6}$')
+);
+CREATE UNIQUE INDEX labels_org_name_uniq
+    ON workitems.labels (org_id, lower(name))
+    WHERE org_id IS NOT NULL;
+CREATE UNIQUE INDEX labels_project_name_uniq
+    ON workitems.labels (project_id, lower(name))
+    WHERE project_id IS NOT NULL;
+
+CREATE TABLE workitems.item_labels (
+    item_id    text         NOT NULL REFERENCES workitems.items(id) ON DELETE CASCADE,
+    label_id   text         NOT NULL REFERENCES workitems.labels(id) ON DELETE CASCADE,
+    applied_at timestamptz  NOT NULL DEFAULT now(),
+    applied_by text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    PRIMARY KEY (item_id, label_id)
+);
+CREATE INDEX item_labels_label_idx ON workitems.item_labels (label_id);
+
+-- Item ↔ milestone is 1:1 (per PRD § 6.3 "exactly one milestone"). Membership
+-- is represented as the `milestone_id` column on `workitems.items` plus the
+-- audit fields `milestone_assigned_at` / `milestone_assigned_by` on the
+-- same row (added to the items DDL above). No junction table — the
+-- earlier draft's parallel `item_milestone` table was redundant with the
+-- column and the two paths had asymmetric ON DELETE policies (SET NULL vs
+-- CASCADE) that risked drift. Single source of truth on the items row.
+-- (`items_milestone_idx` on `workitems.items (milestone_id)` is declared
+-- once with the items table indexes above; do not redeclare here.)
+
+-- Comments (PRD § 6.5). Append-only, (kind, status) orthogonal axes.
+CREATE TABLE workitems.comments (
+    id         text         PRIMARY KEY,                                   -- ULID
+    item_id    text         NOT NULL REFERENCES workitems.items(id) ON DELETE CASCADE,
+    parent_id  text         REFERENCES workitems.comments(id) ON DELETE SET NULL,
+    author_id  text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    author_agent text,                                                     -- AgentKind value if author is an agent
+    kind       text         NOT NULL,                                      -- PRD § 6.5 kind list
+    status     text         NOT NULL DEFAULT 'info',                       -- 'error' | 'warning' | 'info' | 'success'
+    body       text         NOT NULL,
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    updated_at timestamptz  NOT NULL DEFAULT now(),                            -- bumped on body edit; PRD FR-10
+    CONSTRAINT comments_no_self_parent_chk
+        CHECK (parent_id IS NULL OR parent_id <> id),
+    CONSTRAINT comments_kind_chk
+        CHECK (kind IN ('investigation', 'decision', 'deviation', 'completed',
+                        'review', 'qa', 'deferred', 'pr', 'needs-human',
+                        'override', 'general')),
+    CONSTRAINT comments_status_chk
+        CHECK (status IN ('error', 'warning', 'info', 'success')),
+    CONSTRAINT comments_author_chk
+        CHECK (author_id IS NOT NULL OR author_agent IS NOT NULL)
+);
+CREATE INDEX comments_item_created_idx ON workitems.comments (item_id, created_at);
+CREATE INDEX comments_parent_idx       ON workitems.comments (parent_id);
+CREATE INDEX comments_status_idx       ON workitems.comments (status);
+CREATE INDEX comments_kind_status_idx  ON workitems.comments (kind, status);
+-- Full-text search backing the `search` MCP tool (research AF1).
+ALTER TABLE workitems.comments ADD COLUMN fts tsvector
+    GENERATED ALWAYS AS (to_tsvector('english', coalesce(body, ''))) STORED;
+CREATE INDEX comments_fts_idx ON workitems.comments USING GIN (fts);

--- a/apps/api/auth/migrations/0050_deps.up.sql
+++ b/apps/api/auth/migrations/0050_deps.up.sql
@@ -1,0 +1,105 @@
+-- Schema `deps` — dependencies, cycles, cascade_events.
+-- Canonical DDL: docs/SPEC.md § 9.4.4.
+-- FK direction: deps -> workitems, org, auth (already migrated).
+-- cascade_events.kind discriminator ('close' | 'edge_removed') ships here
+-- per docs/specs/01-spec-backend-mvp.md § 6.3.2 (round-2 review).
+
+CREATE SCHEMA IF NOT EXISTS deps;
+
+-- Edges between work items. "from blocks to" semantics: from must be Done
+-- before to can become Ready.
+CREATE TABLE deps.dependencies (
+    id          text         PRIMARY KEY,                                  -- ULID
+    from_item   text         NOT NULL REFERENCES workitems.items(id) ON DELETE CASCADE,
+    to_item     text         NOT NULL REFERENCES workitems.items(id) ON DELETE CASCADE,
+    kind        text         NOT NULL DEFAULT 'blocks',                    -- 'blocks' | 'related' (related not enforced for ready)
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    created_by  text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    CONSTRAINT dependencies_no_self_loop_chk
+        CHECK (from_item <> to_item),
+    CONSTRAINT dependencies_kind_chk
+        CHECK (kind IN ('blocks', 'related')),
+    CONSTRAINT dependencies_pair_uniq
+        UNIQUE (from_item, to_item, kind)
+);
+CREATE INDEX dependencies_from_idx ON deps.dependencies (from_item);
+CREATE INDEX dependencies_to_idx   ON deps.dependencies (to_item);
+-- Partial index: the cycle-detection CTE only walks 'blocks' edges.
+CREATE INDEX dependencies_blocks_to_idx
+    ON deps.dependencies (to_item, from_item)
+    WHERE kind = 'blocks';
+
+-- Cycle audit. When the cycle-prevention CTE rejects a write, we record the
+-- attempted edge for forensics. The CTE itself is in SPEC § 9.4.9.
+CREATE TABLE deps.cycles (
+    id           text         PRIMARY KEY,                                 -- ULID
+    detected_at  timestamptz  NOT NULL DEFAULT now(),
+    from_item    text         NOT NULL,                                    -- not FK (the row may not exist)
+    to_item      text         NOT NULL,
+    cycle_path   text[]       NOT NULL,                                    -- ordered list of item ids forming the cycle
+    rejected_by  text         REFERENCES auth.users(id) ON DELETE SET NULL
+);
+CREATE INDEX cycles_detected_idx ON deps.cycles (detected_at DESC);
+
+-- Cascade events audit (PRD M-5 — "cascade events per day"). Every successful
+-- run of the cascade subscriber (Law 1) writes one row here. The M-5 metric
+-- query aggregates this table grouped by (org_id, date_trunc('day', triggered_at));
+-- this decouples the metric from the observability stack so the number is
+-- reproducible from Postgres alone, even after retention windows on traces
+-- have rolled over. The table is also used as a forensic record when a
+-- cascade affects a surprising set of items.
+CREATE TABLE deps.cascade_events (
+    id                    text         PRIMARY KEY,                       -- ULID (audit row id)
+    -- Publisher-generated event id (ULID) carried as a typed field on the
+    -- Pub/Sub message payload. Encore Go's subscriber handler signature does
+    -- NOT expose envelope metadata (research C1), so the publisher embeds
+    -- this id at emit time and the subscriber reads it from the payload.
+    -- The (event_id, triggered_by_item_id) UNIQUE constraint below is the
+    -- structural mitigation for at-least-once redelivery (AR-11).
+    event_id              text         NOT NULL,
+    -- Cascade kind discriminator. Added in round-2 review iterations:
+    --   'close'        — written by the cascade subscriber when a close
+    --                    event (Tool 6 / workitems.Close) arrives via
+    --                    Pub/Sub; walks the forward 'blocks' closure
+    --                    (multi-hop, possibly large affected set).
+    --   'edge_removed' — written INLINE by Tool 12 (remove_dependency)
+    --                    in the same SQL transaction as DELETE FROM
+    --                    deps.dependencies; single-hop only (the direct
+    --                    to_item is the only candidate to flip ready).
+    -- Future kinds (e.g. 'state_change' for Pub/Sub-driven state-cascade
+    -- writes deferred to P02+) extend the CHECK constraint additively in
+    -- their own phase migration.
+    kind                  text         NOT NULL,
+    org_id                text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id            text         REFERENCES org.projects(id) ON DELETE SET NULL,
+    triggered_by_item_id  text         REFERENCES workitems.items(id) ON DELETE SET NULL,
+    -- The full set of items whose `is_ready` flipped to true as a result.
+    -- Stored as text[] (item ULIDs). For M-5 the cardinality matters more
+    -- than the membership; cardinality is denormalised in `cascaded_count`
+    -- so the metric query never needs to inspect the array.
+    affected_item_ids     text[]       NOT NULL DEFAULT '{}',
+    cascaded_count        integer      NOT NULL DEFAULT 0,
+    triggered_at          timestamptz  NOT NULL DEFAULT now(),
+    trace_id              text,                                            -- correlates with mcp.tool_calls.trace_id
+    CONSTRAINT cascade_events_kind_chk
+        CHECK (kind IN ('close', 'edge_removed')),
+    CONSTRAINT cascade_events_count_chk
+        CHECK (cascaded_count >= 0),
+    -- AR-11 idempotency key. A redelivered Pub/Sub message carries the same
+    -- payload bytes (including event_id), so the second insert is rejected
+    -- by this constraint and the subscriber's UPDATE pass is a no-op on a
+    -- stable graph.
+    CONSTRAINT cascade_events_event_trigger_uniq
+        UNIQUE (event_id, triggered_by_item_id)
+);
+-- Hot-path index for the M-5 metric query (per-org, by day).
+CREATE INDEX cascade_events_org_triggered_idx
+    ON deps.cascade_events (org_id, triggered_at DESC);
+CREATE INDEX cascade_events_project_idx
+    ON deps.cascade_events (project_id, triggered_at DESC)
+    WHERE project_id IS NOT NULL;
+-- Partial index: cascades that actually moved the graph (cascaded_count > 0).
+-- M-5's "non-zero on the median active org" target reads through this index.
+CREATE INDEX cascade_events_nonzero_idx
+    ON deps.cascade_events (org_id, triggered_at DESC)
+    WHERE cascaded_count > 0;

--- a/apps/api/auth/migrations/0060_providers.up.sql
+++ b/apps/api/auth/migrations/0060_providers.up.sql
@@ -1,0 +1,93 @@
+-- Schema `providers` — installations, events, mappings.
+-- Canonical DDL: docs/SPEC.md § 9.4.5.
+-- SCHEMA-ONLY in P01 (no service code in apps/api/providers/ until P02).
+-- FK direction: providers -> org, workitems, auth (already migrated).
+
+CREATE SCHEMA IF NOT EXISTS providers;
+
+CREATE TABLE providers.installations (
+    id                  text         PRIMARY KEY,                          -- ULID
+    org_id              text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id          text         REFERENCES org.projects(id) ON DELETE CASCADE,
+    provider            text         NOT NULL,                             -- 'github' | 'gitlab'
+    provider_account    text         NOT NULL,                             -- e.g. 'websublime'
+    provider_repo       text,                                              -- nullable for org-level installs
+    installation_id_enc bytea        NOT NULL,                             -- pgp_sym_encrypt(provider_installation_id)
+    webhook_secret_enc  bytea        NOT NULL,                             -- per-install HMAC secret
+    installed_by        text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    installed_at        timestamptz  NOT NULL DEFAULT now(),
+    revoked_at          timestamptz,
+    CONSTRAINT installations_provider_chk
+        CHECK (provider IN ('github', 'gitlab')),
+    CONSTRAINT installations_target_uniq
+        UNIQUE (provider, provider_account, provider_repo)
+);
+CREATE INDEX installations_org_idx ON providers.installations (org_id);
+
+-- Webhook events. Audit + dedup. Idempotency on (provider, delivery_id).
+CREATE TABLE providers.events (
+    id              text         PRIMARY KEY,                              -- ULID (our id, not provider's)
+    installation_id text         NOT NULL REFERENCES providers.installations(id) ON DELETE CASCADE,
+    provider        text         NOT NULL,                                 -- denormalised for hot lookup
+    delivery_id     text         NOT NULL,                                 -- e.g. X-GitHub-Delivery
+    event_type      text         NOT NULL,                                 -- e.g. 'issues.opened'
+    payload         jsonb        NOT NULL,
+    signature_ok    boolean      NOT NULL,
+    received_at     timestamptz  NOT NULL DEFAULT now(),
+    processed_at    timestamptz,
+    error           text,
+    CONSTRAINT events_provider_chk
+        CHECK (provider IN ('github', 'gitlab')),
+    CONSTRAINT events_delivery_uniq
+        UNIQUE (provider, delivery_id)
+);
+CREATE INDEX events_installation_received_idx
+    ON providers.events (installation_id, received_at DESC);
+CREATE INDEX events_unprocessed_idx
+    ON providers.events (received_at)
+    WHERE processed_at IS NULL;
+CREATE INDEX events_payload_gin_idx ON providers.events USING gin (payload);
+
+-- PII retention policy on providers.events.payload (referenced from AR-13/14):
+-- raw webhook payloads can carry user emails, repo metadata, and OAuth-related
+-- fields. The retention policy is:
+--   * Raw payload retained 90 days from `received_at`.
+--   * After 90 days a scheduled job (Encore cron, runs daily) replaces the
+--     payload with a metadata-only digest:
+--         { "event_type": <string>, "actor_login": <hash>, "repo": <hash>,
+--           "delivery_id": <string>, "digest_at": <ts> }
+--     The digest preserves the audit's debugging value (we still know which
+--     event type came from which installation when) without retaining
+--     identifying free-text payload fields.
+--   * Email addresses and any matched credential patterns are redacted
+--     **on insert** by a per-row sanitiser running before the row is
+--     committed. The 90-day truncation is the second layer; the sanitiser
+--     is the first.
+-- The exact digest schema and the redactor pattern set land in the P02 spec.
+-- A test asserts that a payload older than 90 days has been digested.
+
+-- Provider ↔ work item mapping. Bidirectional sync key.
+CREATE TABLE providers.mappings (
+    id              text         PRIMARY KEY,                              -- ULID
+    installation_id text         NOT NULL REFERENCES providers.installations(id) ON DELETE CASCADE,
+    item_id         text         NOT NULL REFERENCES workitems.items(id) ON DELETE CASCADE,
+    provider        text         NOT NULL,
+    provider_kind   text         NOT NULL,                                 -- 'issue' | 'pull_request'
+    provider_id     text         NOT NULL,                                 -- provider-side id (string for portability)
+    provider_url    text         NOT NULL,
+    last_synced_at  timestamptz,
+    drift_detected_at timestamptz,
+    CONSTRAINT mappings_provider_chk
+        CHECK (provider IN ('github', 'gitlab')),
+    CONSTRAINT mappings_kind_chk
+        CHECK (provider_kind IN ('issue', 'pull_request')),
+    CONSTRAINT mappings_external_uniq
+        UNIQUE (provider, provider_kind, provider_id),
+    CONSTRAINT mappings_item_provider_uniq
+        UNIQUE (item_id, provider, provider_kind)
+);
+CREATE INDEX mappings_item_idx          ON providers.mappings (item_id);
+CREATE INDEX mappings_installation_idx  ON providers.mappings (installation_id);
+CREATE INDEX mappings_drift_idx
+    ON providers.mappings (drift_detected_at)
+    WHERE drift_detected_at IS NOT NULL;

--- a/apps/api/auth/migrations/0070_mcp.up.sql
+++ b/apps/api/auth/migrations/0070_mcp.up.sql
@@ -1,0 +1,74 @@
+-- Schema `mcp` — api_keys, tool_calls.
+-- Canonical DDL: docs/SPEC.md § 9.4.6.
+-- FK direction: mcp -> auth, org, workitems (already migrated).
+-- key_hash is bytea HMAC-SHA256 (per research C7 — NOT argon2id).
+
+CREATE SCHEMA IF NOT EXISTS mcp;
+
+-- Per-agent API keys. The hot-path Bearer auth check.
+CREATE TABLE mcp.api_keys (
+    id              text         PRIMARY KEY,                              -- ULID
+    org_id          text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    issued_to_user  text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    label           text         NOT NULL,                                 -- e.g. 'claude-code-laptop'
+    agent_kind      text         NOT NULL,                                 -- AgentKind value
+    key_hash        bytea        NOT NULL,                                 -- HMAC-SHA256(server_secret, key); 32 bytes raw.
+                                                                           -- Argon2id is the wrong primitive here: keys are
+                                                                           -- 32-byte URL-safe random with 256 bits of entropy,
+                                                                           -- so brute force is mathematically infeasible
+                                                                           -- regardless of hash speed; argon2id's per-call
+                                                                           -- ~50ms cost would directly threaten NFR-1 (the
+                                                                           -- p99 < 2s budget is hot-path Bearer auth).
+                                                                           -- HMAC with a server-side secret prevents lookup
+                                                                           -- table attacks against a leaked key_hash dump
+                                                                           -- (research C7).
+    key_prefix      text         NOT NULL,                                 -- first 8 chars for hint UI
+    scopes          text[]       NOT NULL DEFAULT '{}',                    -- coarse scopes; tool-level RBAC is in mcp service
+    created_at      timestamptz  NOT NULL DEFAULT now(),
+    last_used_at    timestamptz,
+    -- Optional natural expiry. NULL means "never expires by default" — at
+    -- v1 we do not auto-rotate API keys. Lifecycle is operator-driven:
+    -- (a) issuance happens via the seeder CLI (P01) or the future web admin
+    --     surface (P05+); each issuance creates a row.
+    -- (b) Rotation is a manual two-step: issue a new key (new prefix), wait
+    --     for the agent operator to switch over, then set `revoked_at` on
+    --     the old row. Both rows coexist during the rollover window.
+    -- (c) There is no auto-refresh, no auto-rotate, and no key-expiry
+    --     scheduler in v1. `expires_at` is honoured if set (auth.Validate
+    --     refuses keys past `expires_at`) but the column defaults to NULL
+    --     and operators rarely set it. See research AF4.
+    expires_at      timestamptz,
+    revoked_at      timestamptz,
+    CONSTRAINT api_keys_agent_chk
+        CHECK (agent_kind IN ('claude-code', 'copilot', 'cursor', 'codex', 'aider', 'custom')),
+    CONSTRAINT api_keys_prefix_uniq UNIQUE (key_prefix)
+);
+CREATE INDEX api_keys_org_active_idx
+    ON mcp.api_keys (org_id, last_used_at DESC NULLS LAST)
+    WHERE revoked_at IS NULL;
+
+-- Tool-call audit. Every MCP call is recorded for forensics + state-machine
+-- rejections analysis (Layer 1, FR-9).
+CREATE TABLE mcp.tool_calls (
+    id           text         PRIMARY KEY,                                 -- ULID
+    api_key_id   text         REFERENCES mcp.api_keys(id) ON DELETE SET NULL,
+    org_id       text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id   text         REFERENCES org.projects(id) ON DELETE SET NULL,
+    item_id      text         REFERENCES workitems.items(id) ON DELETE SET NULL,
+    tool_name    text         NOT NULL,
+    arguments    jsonb        NOT NULL DEFAULT '{}'::jsonb,
+    result_kind  text         NOT NULL,                                    -- 'ok' | 'rejected' | 'error'
+    rejection_reason text,                                                 -- precondition name when result_kind='rejected'
+    error_code   text,
+    duration_ms  integer      NOT NULL,
+    trace_id     text,
+    called_at    timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT tool_calls_result_chk
+        CHECK (result_kind IN ('ok', 'rejected', 'error'))
+);
+CREATE INDEX tool_calls_org_called_idx     ON mcp.tool_calls (org_id, called_at DESC);
+CREATE INDEX tool_calls_item_idx           ON mcp.tool_calls (item_id);
+CREATE INDEX tool_calls_rejected_idx
+    ON mcp.tool_calls (org_id, called_at DESC)
+    WHERE result_kind = 'rejected';
+CREATE INDEX tool_calls_arguments_gin_idx  ON mcp.tool_calls USING gin (arguments);

--- a/apps/api/auth/migrations/0080_boards.up.sql
+++ b/apps/api/auth/migrations/0080_boards.up.sql
@@ -1,0 +1,45 @@
+-- Schema `boards` — boards, columns.
+-- Canonical DDL: docs/SPEC.md § 9.4.7.
+-- SCHEMA-ONLY in P01 (no service code in apps/api/boards/ until P05).
+-- FK direction: boards -> org, auth (already migrated).
+
+CREATE SCHEMA IF NOT EXISTS boards;
+
+CREATE TABLE boards.boards (
+    id          text         PRIMARY KEY,                                  -- ULID
+    org_id      text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id  text         REFERENCES org.projects(id) ON DELETE CASCADE,
+    user_id     text         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE, -- saved per user
+    name        text         NOT NULL,
+    description text,
+    filters     jsonb        NOT NULL DEFAULT '{}'::jsonb,                 -- saved filter state (status, label, milestone, etc.)
+    layout      text         NOT NULL DEFAULT 'kanban',                    -- 'kanban' | 'list' | 'graph' | 'roadmap'
+    is_default  boolean      NOT NULL DEFAULT false,
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    updated_at  timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT boards_layout_chk
+        CHECK (layout IN ('kanban', 'list', 'graph', 'roadmap'))
+);
+CREATE INDEX boards_org_user_idx ON boards.boards (org_id, user_id);
+-- Only one default per (user, project) — partial unique.
+CREATE UNIQUE INDEX boards_default_per_user_project_uniq
+    ON boards.boards (user_id, COALESCE(project_id, ''))
+    WHERE is_default = true;
+
+-- Per-board column configuration (kanban). Columns are user-defined groupings;
+-- each column has a filter (e.g. by status, by label).
+CREATE TABLE boards.columns (
+    id           text         PRIMARY KEY,                                 -- ULID
+    board_id     text         NOT NULL REFERENCES boards.boards(id) ON DELETE CASCADE,
+    name         text         NOT NULL,
+    filter       jsonb        NOT NULL DEFAULT '{}'::jsonb,
+    position     integer      NOT NULL,
+    wip_limit    integer,                                                  -- nullable; null = unlimited
+    color        text,
+    created_at   timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT columns_position_chk CHECK (position >= 0),
+    CONSTRAINT columns_wip_chk      CHECK (wip_limit IS NULL OR wip_limit > 0),
+    CONSTRAINT columns_color_chk    CHECK (color IS NULL OR color ~ '^#[0-9a-fA-F]{6}$'),
+    CONSTRAINT columns_board_position_uniq UNIQUE (board_id, position)
+);
+CREATE INDEX columns_board_idx ON boards.columns (board_id, position);

--- a/apps/api/auth/migrations/0090_memory.up.sql
+++ b/apps/api/auth/migrations/0090_memory.up.sql
@@ -1,0 +1,82 @@
+-- Schema `memory` — entries, entry_refs.
+-- Canonical DDL: docs/SPEC.md § 9.4.8.
+-- SCHEMA-ONLY in P01 (no service code in apps/api/memory/ until P02).
+-- FK direction: memory -> auth, org (already migrated).
+-- pg_trgm prerequisite for entries_key_trgm_idx is met by 0010_bootstrap.
+
+CREATE SCHEMA IF NOT EXISTS memory;
+
+-- Scoped memory entries (PRD § 6 / FR-13). Three scope kinds.
+-- Value is encrypted at rest (NFR-7 sanitisation runs *before* encryption,
+-- so the plaintext stored is already sanitised; the *_enc column contains
+-- the sanitised plaintext encrypted with pgcrypto).
+CREATE TABLE memory.entries (
+    id          text         PRIMARY KEY,                                  -- ULID
+    scope       text         NOT NULL,                                     -- 'org' | 'project' | 'user'
+    org_id      text         REFERENCES org.organizations(id) ON DELETE CASCADE,
+    project_id  text         REFERENCES org.projects(id) ON DELETE CASCADE,
+    user_id     text         REFERENCES auth.users(id) ON DELETE CASCADE,
+    author_id   text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    author_agent text,                                                     -- AgentKind if written by an agent
+    key         text         NOT NULL,                                     -- short label / canonical fact name
+    value_enc   bytea        NOT NULL,                                     -- pgp_sym_encrypt(sanitised_plaintext)
+    value_size  integer      NOT NULL,                                     -- size of plaintext, bytes; ≤ 8192
+    tags        text[]       NOT NULL DEFAULT '{}',
+    -- tsvector built over the *plaintext* before encryption, stored alongside
+    -- to enable indexed full-text search without decrypt-on-search. The
+    -- ts_doc column holds *only* a tokenised, lowercased projection — not the
+    -- full plaintext — so its leakage surface is bounded to indexable terms.
+    ts_doc      tsvector     NOT NULL,
+    created_at  timestamptz  NOT NULL DEFAULT now(),
+    updated_at  timestamptz  NOT NULL DEFAULT now(),
+    expires_at  timestamptz,
+    CONSTRAINT entries_scope_chk
+        CHECK (scope IN ('org', 'project', 'user')),
+    -- Scope discriminator: exactly the right scope id is set.
+    CONSTRAINT entries_scope_target_chk CHECK (
+        (scope = 'org'     AND org_id IS NOT NULL AND project_id IS NULL  AND user_id IS NULL)
+     OR (scope = 'project' AND project_id IS NOT NULL AND org_id IS NULL  AND user_id IS NULL)
+     OR (scope = 'user'    AND user_id IS NOT NULL AND org_id IS NULL     AND project_id IS NULL)
+    ),
+    CONSTRAINT entries_size_chk CHECK (value_size > 0 AND value_size <= 8192),
+    -- Uniqueness per (scope target, key) — partial unique indexes below
+    CONSTRAINT entries_author_chk
+        CHECK (author_id IS NOT NULL OR author_agent IS NOT NULL)
+);
+-- Per-scope uniqueness on key
+CREATE UNIQUE INDEX entries_org_key_uniq
+    ON memory.entries (org_id, key)
+    WHERE scope = 'org';
+CREATE UNIQUE INDEX entries_project_key_uniq
+    ON memory.entries (project_id, key)
+    WHERE scope = 'project';
+CREATE UNIQUE INDEX entries_user_key_uniq
+    ON memory.entries (user_id, key)
+    WHERE scope = 'user';
+-- FTS index
+CREATE INDEX entries_ts_doc_gin_idx ON memory.entries USING gin (ts_doc);
+-- Tag index (GIN on text[])
+CREATE INDEX entries_tags_gin_idx   ON memory.entries USING gin (tags);
+-- Trigram index on key for fuzzy lookups (uses pg_trgm extension)
+CREATE INDEX entries_key_trgm_idx   ON memory.entries USING gin (key gin_trgm_ops);
+
+-- Cross-references: a memory entry can reference work items, comments, PRs,
+-- milestones, or be flagged as a general scope-level fact.
+-- Modeled as a polymorphic junction with a kind discriminator.
+CREATE TABLE memory.entry_refs (
+    id         text         PRIMARY KEY,                                   -- ULID
+    entry_id   text         NOT NULL REFERENCES memory.entries(id) ON DELETE CASCADE,
+    ref_kind   text         NOT NULL,                                      -- 'workitem' | 'comment' | 'pr' | 'milestone' | 'general'
+    ref_id     text         NOT NULL,                                      -- target id (no FK due to polymorphism;
+                                                                           -- referential integrity by service layer).
+                                                                           -- For ref_kind='general': ref_id holds the
+                                                                           -- parent entry's scope_id — i.e., the memory
+                                                                           -- is a general fact about its org/project/user
+                                                                           -- scope, not pinned to any specific entity.
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT entry_refs_kind_chk
+        CHECK (ref_kind IN ('workitem', 'comment', 'pr', 'milestone', 'general')),
+    CONSTRAINT entry_refs_unique UNIQUE (entry_id, ref_kind, ref_id)
+);
+CREATE INDEX entry_refs_entry_idx ON memory.entry_refs (entry_id);
+CREATE INDEX entry_refs_target_idx ON memory.entry_refs (ref_kind, ref_id);


### PR DESCRIPTION
## unblock-tv8.3: A-3 — All eight schema migrations (0020-0090)

Adds the seven up-only migration files producing the eight Postgres schemas defined in docs/SPEC.md § 9.4.1-9.4.8: `auth`, `org`, `workitems`, `deps`, `providers`, `mcp`, `boards`, `memory`. All schemas migrate from a single owner directory (`apps/api/auth/migrations/`) per § 5.2.

### What was done
- 24 tables, 63 named constraints, 58 indexes — all match the canonical DDL byte-for-byte.
- AF1 FTS: `workitems.items.fts` and `workitems.comments.fts` are `GENERATED ALWAYS AS (...) STORED` tsvector columns with per-table GIN indexes (`items_fts_idx`, `comments_fts_idx`).
- `deps.cascade_events.kind` CHECK constraint accepts only `'close'` and `'edge_removed'` (round-2 review discriminator).
- AR-11 idempotency: `cascade_events_event_trigger_uniq UNIQUE (event_id, triggered_by_item_id)`.
- `mcp.api_keys.key_hash` is `bytea` (HMAC-SHA256, per research C7 — not argon2id).
- pg_trgm-backed `entries_key_trgm_idx` on `memory.entries(key)` (extension already provided by `0010_bootstrap`).
- Per phase spec § 3.3: no down.sql files; `CREATE SCHEMA IF NOT EXISTS` is the only `IF NOT EXISTS` usage after `0010`; subsequent `CREATE TABLE` / `CREATE INDEX` / `ALTER TABLE` assume fresh schemas.
- FK direction (`auth -> org -> workitems -> deps -> providers -> mcp -> boards -> memory`) resolves forward across the file ordering.
- `apps/api/{providers,boards,memory}/` remain schema-only — no `.go` files (per § 4.6).

### Files changed
- `apps/api/auth/migrations/0020_auth.up.sql`
- `apps/api/auth/migrations/0030_org.up.sql`
- `apps/api/auth/migrations/0040_workitems.up.sql`
- `apps/api/auth/migrations/0050_deps.up.sql`
- `apps/api/auth/migrations/0060_providers.up.sql`
- `apps/api/auth/migrations/0070_mcp.up.sql`
- `apps/api/auth/migrations/0080_boards.up.sql`
- `apps/api/auth/migrations/0090_memory.up.sql`

### Decisions
None — all DDL copied verbatim from canonical SPEC.md § 9.4 per phase spec § 3.3 (constraint names ARE the contract).

### Deviations
None — implemented as spec.

### Verification
- `encore check`: graph + topology + compile pass clean (DB cluster boot needs Docker, unavailable in this environment).
- `go build ./...` and `go vet ./...`: clean.
- Static audit: full table / constraint / index name diff vs docs/SPEC.md:1195-1960 — 24/24 tables, 63/63 constraints, 58/58 indexes match byte-for-byte.
- Functional `encore run` against a clean DB deferred to the QA gate (requires a Postgres-capable host).

Refs: bead unblock-tv8.3 · parent epic unblock-tv8 · docs/specs/01-spec-backend-mvp.md § 3.2-3.4 · docs/SPEC.md § 9.4.0-9.4.8.