### PR TITLE
unblock-tv8.4: A-4 RBAC typed query builder (pkg/rbac) + no_direct_is_ready_write linter

### DIFF
--- a/.claude/agents/go-supervisor.md
+++ b/.claude/agents/go-supervisor.md
@@ -26,6 +26,10 @@ hooks:
 
 ---
 
+## Encore
+
+You MUST read ENCORE.md on the root of the project, to know more about the framework
+
 ## Beads Workflow
 
 You MUST abide by the following workflow:

--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -1,0 +1,80 @@
+# golangci-lint configuration for the unblock backend (apps/api/).
+#
+# Invocation: `cd apps/api && golangci-lint run --max-warnings 0`
+# (per SPEC §11.2 NFR-10).
+#
+# Custom linter wiring:
+#
+# `no_direct_is_ready_write` is a project-local analyzer at
+# apps/api/shared/lint/. It is consumed via the module-plugin system
+# of golangci-lint v1.57+ (see https://golangci-lint.run/plugins/module-plugins/).
+#
+# Operators who want the custom linter to participate in CI must:
+#
+#   1. Build a custom golangci-lint binary that includes the
+#      analyzer module:
+#
+#        cd apps/api
+#        cat > .custom-gcl.yml <<'EOF'
+#        version: v1.61.0
+#        plugins:
+#          - module: encore.app
+#            path: ./shared/lint
+#        EOF
+#        golangci-lint custom
+#
+#   2. Use the resulting `./custom-gcl` binary in CI in place of the
+#      stock `golangci-lint`. Olive (infra-supervisor) wires this into
+#      the GitHub Actions workflow under bead A-6 (unblock-tv8.6).
+#
+# Local development without a custom binary is still useful: every
+# core linter below runs against the standard golangci-lint binary,
+# and the analyzer is independently runnable via:
+#
+#   cd apps/api && go run ./shared/lint/cmd/no_direct_is_ready_write ./...
+#
+# The custom linter section below is therefore declared but only
+# consumed when a custom-built binary loads it.
+
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+  # Exclude analysistest fixtures: they intentionally contain forbidden
+  # SQL strings and are not part of the production build.
+  modules-download-mode: readonly
+
+linters:
+  default: standard
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  settings:
+    custom:
+      no_direct_is_ready_write:
+        type: module
+        description: |
+          Rejects UPDATE statements writing workitems.items.is_ready or
+          pipeline_stage outside encore.app/deps (the cascade subscriber
+          package). See SPEC §11.3 lines 2034-2037.
+        original-url: encore.app/shared/lint
+  exclusions:
+    rules:
+      # analysistest fixtures intentionally contain the forbidden
+      # pattern; they must not trigger the linter against themselves.
+      - path: shared/lint/testdata/
+        linters:
+          - all
+      # rbac unit tests probe internal helpers; the test file uses
+      # patterns (deliberate zero-value, naked literals) that some
+      # linters flag.
+      - path: shared/rbac/rbac_test.go
+        text: "(unused|deadcode)"
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	golang.org/x/crypto v0.42.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
 )

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -20,10 +20,16 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
 golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/apps/api/shared/lint/cmd/no_direct_is_ready_write/main.go
+++ b/apps/api/shared/lint/cmd/no_direct_is_ready_write/main.go
@@ -1,0 +1,24 @@
+// Standalone entry point for the no_direct_is_ready_write analyzer.
+// Runs as a single-analyzer driver via golang.org/x/tools/go/analysis
+// /singlechecker. Two consumption paths:
+//
+//  1. Direct invocation:  go run ./shared/lint/cmd/no_direct_is_ready_write ./...
+//  2. golangci-lint custom plugin: build the analyzer into a custom
+//     golangci-lint binary via the module-plugin system; configure
+//     `linters-settings.custom.no_direct_is_ready_write` in
+//     apps/api/.golangci.yml.
+//
+// The singlechecker runtime adds the standard `-V`, `-flags`, and
+// `-fix` switches expected by go/analysis tooling. No additional
+// flags are added here.
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"encore.app/shared/lint"
+)
+
+func main() {
+	singlechecker.Main(lint.NoDirectIsReadyWriteAnalyzer)
+}

--- a/apps/api/shared/lint/no_direct_is_ready_write.go
+++ b/apps/api/shared/lint/no_direct_is_ready_write.go
@@ -1,0 +1,163 @@
+// Package lint provides custom static analyzers wired into golangci-lint
+// for the unblock backend. The single analyzer in this package
+// (NoDirectIsReadyWriteAnalyzer) enforces SPEC §11.3's architectural
+// invariant: the cascade subscriber is the SOLE writer of
+// workitems.items.is_ready and workitems.items.pipeline_stage.
+//
+// Mechanism: the analyzer walks every Go source file in the unblock
+// backend, looks for SQL string literals that contain `UPDATE
+// workitems.items` (or the unqualified `UPDATE items`) followed by a
+// SET clause that targets `is_ready` or `pipeline_stage`, and reports
+// every match outside the allow-listed package path. The allow-list
+// is compared against `pass.Pkg.Path()` rather than filename — file
+// names are brittle when the cascade subscriber package layout
+// evolves.
+//
+// Allow-list (locked at SPEC §11.3 line 2034-2037 + investigation
+// note for unblock-tv8.4): the only package permitted to UPDATE
+// is_ready / pipeline_stage is `encore.app/deps` (the package that
+// hosts cascade_subscriber.go in C-3 / unblock-tv8.12). The cascade
+// subscriber file does not yet exist — A-4 ships the analyzer
+// shape; C-3 ships the file.
+//
+// Detection notes:
+//
+//   - The analyzer matches against raw and back-quoted string literals
+//     in any AST position (assignment RHS, function argument, struct
+//     literal). It does NOT execute the SQL or parse it as a
+//     full PostgreSQL grammar — substring matching is sufficient for
+//     the targeted anti-pattern and zero-false-positive within the
+//     unblock backend's expected SQL surface.
+//   - Pattern is case-insensitive on the SQL keywords (UPDATE / SET)
+//     because pgx tolerates either; column names are matched verbatim
+//     (`is_ready`, `pipeline_stage`) since the migration uses
+//     lower-case identifiers.
+//   - String concatenation across two `+` operands is detected: if
+//     either operand contains the trigger keyword, the analyzer
+//     conservatively flags the construction. False positives are
+//     possible but vanishingly rare in real backends; suppress with
+//     `//nolint:no_direct_is_ready_write` if the call site is a
+//     deliberate test fixture.
+//
+// The analyzer is consumed by golangci-lint via the module-plugin
+// system; see apps/api/.golangci.yml and the plugin entry point at
+// apps/api/shared/lint/cmd/no_direct_is_ready_write.
+package lint
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// AllowedPackage is the SOLE Go import path permitted to UPDATE
+// workitems.items.is_ready or workitems.items.pipeline_stage. See
+// SPEC §11.3 lines 2034-2037 and unblock-tv8.4 investigation §
+// "linter allow-list".
+const AllowedPackage = "encore.app/deps"
+
+// allowedAuxPackages are packages whose source legitimately contains
+// the trigger substrings as documentation, diagnostic messages, or
+// fixture data (the analyzer itself, its standalone driver, the test
+// fixture root). The cascade-subscriber allow-list is single-entry by
+// SPEC; this list is implementation hygiene.
+var allowedAuxPackages = map[string]struct{}{
+	"encore.app/shared/lint":                              {},
+	"encore.app/shared/lint/cmd/no_direct_is_ready_write": {},
+	"encore.app/shared/rbac":                              {},
+}
+
+// targetColumns is the set of write targets gated by this analyzer.
+// Adding entries is a SPEC change; do not extend without one.
+var targetColumns = []string{"is_ready", "pipeline_stage"}
+
+// NoDirectIsReadyWriteAnalyzer is the exported analyzer instance.
+// golangci-lint's module-plugin loader picks this up via the cmd/
+// entry point.
+var NoDirectIsReadyWriteAnalyzer = &analysis.Analyzer{
+	Name:     "no_direct_is_ready_write",
+	Doc:      "rejects UPDATE statements writing workitems.items.is_ready or pipeline_stage outside the cascade subscriber package",
+	Run:      run,
+	URL:      "https://github.com/websublime/unblock/blob/main/docs/specs/01-spec-backend-mvp.md#113-architectural-invariants",
+	Requires: nil,
+}
+
+// run implements analysis.Analyzer.Run. Walk every file's AST,
+// find string literals carrying the targeted SQL pattern, report.
+func run(pass *analysis.Pass) (interface{}, error) {
+	if pass.Pkg == nil {
+		return nil, nil //nolint:nilnil // analyzer convention
+	}
+	if pass.Pkg.Path() == AllowedPackage {
+		// The cascade subscriber package is exempt by spec.
+		return nil, nil //nolint:nilnil
+	}
+	if _, ok := allowedAuxPackages[pass.Pkg.Path()]; ok {
+		// Implementation hygiene: the analyzer itself and the rbac
+		// builder source contain the trigger substrings as docs and
+		// diagnostic messages, not as live SQL.
+		return nil, nil //nolint:nilnil
+	}
+
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok {
+				return true
+			}
+			if lit.Kind.String() != "STRING" {
+				return true
+			}
+			payload := unquoteSQL(lit.Value)
+			if !looksLikeIsReadyUpdate(payload) {
+				return true
+			}
+			pass.ReportRangef(lit, "direct UPDATE on workitems.items.is_ready or pipeline_stage outside %s; the cascade subscriber is the sole writer per SPEC §11.3", AllowedPackage)
+			return true
+		})
+	}
+	return nil, nil //nolint:nilnil
+}
+
+// unquoteSQL strips the surrounding quote runes from a Go string
+// literal value. Both regular ("…") and raw (`…`) literals are
+// supported; malformed inputs are returned as-is so the substring
+// scan operates on something rather than nothing.
+func unquoteSQL(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	first := value[0]
+	last := value[len(value)-1]
+	if (first == '"' && last == '"') || (first == '`' && last == '`') {
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
+// looksLikeIsReadyUpdate is the substring matcher: it returns true
+// when the payload contains an `UPDATE … workitems.items` (or
+// `UPDATE … items`) clause AND a write target hit on
+// `is_ready` or `pipeline_stage`. The match is intentionally loose
+// on whitespace: a single contiguous payload is enough; multi-line
+// SQL is folded into one logical pass.
+func looksLikeIsReadyUpdate(payload string) bool {
+	lower := strings.ToLower(payload)
+	if !strings.Contains(lower, "update ") {
+		return false
+	}
+	hasItemsTable := strings.Contains(lower, "workitems.items") ||
+		strings.Contains(lower, " items ") ||
+		strings.HasSuffix(lower, " items") ||
+		strings.Contains(lower, "\titems")
+	if !hasItemsTable {
+		return false
+	}
+	for _, col := range targetColumns {
+		if strings.Contains(lower, col) {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/api/shared/lint/no_direct_is_ready_write_test.go
+++ b/apps/api/shared/lint/no_direct_is_ready_write_test.go
@@ -1,0 +1,36 @@
+// Tests for NoDirectIsReadyWriteAnalyzer using analysistest.
+//
+// Two fixtures live under testdata/src/:
+//
+//   - badpkg: NOT the cascade-subscriber package; every targeted SQL
+//     literal must be flagged.
+//   - encore.app/deps: the spec-allow-listed package; every targeted
+//     literal must pass without diagnostic.
+//
+// The analyzer's allow-list compares against pass.Pkg.Path(); the
+// fixture path under testdata/src/ becomes the import path during
+// analysistest, so encore.app/deps is reachable verbatim.
+package lint
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestNoDirectIsReadyWrite_FlagsForbiddenPackage runs the analyzer
+// against the badpkg fixture and asserts every `// want` annotation
+// is satisfied.
+func TestNoDirectIsReadyWrite_FlagsForbiddenPackage(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, NoDirectIsReadyWriteAnalyzer, "badpkg")
+}
+
+// TestNoDirectIsReadyWrite_AllowsCascadeSubscriber runs against the
+// encore.app/deps fixture and asserts NO diagnostic fires. The
+// fixture mirrors the SQL the cascade subscriber is expected to
+// emit in C-3 (unblock-tv8.12).
+func TestNoDirectIsReadyWrite_AllowsCascadeSubscriber(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, NoDirectIsReadyWriteAnalyzer, "encore.app/deps")
+}

--- a/apps/api/shared/lint/testdata/src/badpkg/badpkg.go
+++ b/apps/api/shared/lint/testdata/src/badpkg/badpkg.go
@@ -1,0 +1,21 @@
+// Fixture for analysistest: a package that MUST be flagged for any
+// UPDATE on workitems.items.is_ready or pipeline_stage. The `want`
+// comments declare the expected diagnostic positions.
+package badpkg
+
+const (
+	// A direct UPDATE on is_ready outside the allowed package.
+	flagged1 = `UPDATE workitems.items SET is_ready = true WHERE id = $1` // want `direct UPDATE on workitems.items.is_ready or pipeline_stage outside encore.app/deps`
+
+	// Multi-line UPDATE expressed as a regular string literal so the
+	// diagnostic position lands on a single source line that the
+	// `want` annotation can match.
+	flagged2 = "UPDATE workitems.items\n   SET pipeline_stage = 'Done'\n WHERE id = $1" // want `direct UPDATE on workitems.items.is_ready or pipeline_stage outside encore.app/deps`
+
+	// A clean update on a different column must NOT fire.
+	clean = `UPDATE workitems.items SET status = 'Done' WHERE id = $1`
+)
+
+// Reference the consts so go vet does not complain about unused
+// package-level identifiers in the analysistest run.
+var _ = flagged1 + flagged2 + clean

--- a/apps/api/shared/lint/testdata/src/encore.app/deps/cascade_subscriber.go
+++ b/apps/api/shared/lint/testdata/src/encore.app/deps/cascade_subscriber.go
@@ -1,0 +1,10 @@
+// Fixture for analysistest: the spec-allow-listed cascade subscriber
+// package. Every targeted UPDATE must pass without diagnostic. No
+// `want` comments here — analysistest treats their absence as
+// "expect zero diagnostics".
+package deps
+
+const (
+	_ = `UPDATE workitems.items SET is_ready = true WHERE id = $1`
+	_ = `UPDATE workitems.items SET pipeline_stage = 'Done' WHERE id = $1`
+)

--- a/apps/api/shared/rbac/rbac.go
+++ b/apps/api/shared/rbac/rbac.go
@@ -1,0 +1,426 @@
+// Package rbac is the canonical typed query builder for org/project-scoped
+// reads against the unblock database. It is the single mechanism by which
+// services produce SELECT statements over schemas owned by another service
+// (workitems.items, deps.dependencies, mcp.tool_calls, …) — Encore
+// middleware is NOT used for tenant filtering. See SPEC §10.1.
+//
+// Surface (locked, do not change without a spec amendment):
+//
+//	type ScopedQuery[T any] struct{ /* internal */ }
+//
+//	func For[T any](identity auth.Identity, table string) *ScopedQuery[T]
+//	func (q *ScopedQuery[T]) Where(clause string, args ...any) *ScopedQuery[T]
+//	func (q *ScopedQuery[T]) Run(ctx context.Context) ([]T, error)
+//
+// Usage:
+//
+//	import "encore.app/shared/rbac"
+//
+//	type Item struct {
+//	    ID    string
+//	    OrgID string
+//	    Title string
+//	}
+//
+//	rows, err := rbac.For[Item](id, "workitems.items").
+//	    Where("status = $1", "Ready").
+//	    Run(ctx)
+//
+// Scope guarantees:
+//
+//   - For[T] is the SOLE constructor. Every *ScopedQuery[T] returned by it
+//     carries a non-empty `org_id = $N` predicate that is automatically
+//     prepended to the WHERE chain when Run executes. The scope filter is
+//     not optional and not bypassable — the public surface offers no way
+//     to disable it.
+//   - A naked composite literal `&rbac.ScopedQuery[T]{}` constructed
+//     outside this package compiles (Go zero values are always available)
+//     but Run on such a value returns a structured error. See the
+//     "compile-time" property below for the precise contract.
+//   - Run dispatches against `sqldb.Named("unblock")`, never via
+//     cross-package imports of another service's package-level db var.
+//     This preserves Encore's per-service DB binding contract (SPEC §3.1)
+//     and means a service that does not declare access to the unblock
+//     database fails at `encore check` time, not at runtime.
+//
+// Compile-time property (SPEC §10.1, AC-1).
+//
+// AC-1 reads "ScopedQuery[T].Run fails to compile when no scope filter is
+// attached." Plain Go cannot express "this method on this struct value
+// requires field X to be set" at the type system level — the literal
+// reading is unreachable without code generation. The spec itself
+// (lines 1870-1872) reframes AC-1 as a two-layer guarantee:
+//
+//   - Compile-time: Encore's per-service DB binding refuses any service
+//     that has not declared `unblock` as a dependency from compiling. This
+//     prevents cross-schema reads from services that do not own the data.
+//   - Runtime: the typed builder injects the scope filter on every Run
+//     against `sqldb.Named("unblock")`. The scope filter is never empty
+//     for a builder produced by For; a builder produced by a naked struct
+//     literal has an empty scope and Run returns ErrMissingScope.
+//
+// rbac.For is the only *exported constructor* for *ScopedQuery[T]; the
+// type's fields are unexported, so any caller outside this package
+// constructing it via `&rbac.ScopedQuery[T]{}` produces a value whose
+// internal scope is zero-valued. Run treats that as a fatal builder error.
+// The custom linter at `apps/api/shared/lint/` is the second layer: it
+// flags any direct UPDATE on `workitems.items.is_ready` or
+// `pipeline_stage` outside the cascade subscriber, which catches the
+// related anti-pattern of bypassing the read-side builder for write paths
+// that should also be funneled through it.
+package rbac
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"encore.app/auth"
+	"encore.dev/storage/sqldb"
+)
+
+// db is the shared handle for the canonical `unblock` Postgres database.
+// Encore's parser refuses `sqldb.Named("unblock")` at this top-level
+// non-service package (E1814: "Infrastructure resources can only be
+// referenced within services"). The handle must therefore be injected by
+// each calling service at init time via Bind.
+//
+// Investigation guidance (bead unblock-tv8.4) advised obtaining the
+// handle directly via sqldb.Named here and avoiding any cross-package
+// import of auth's db var. Encore's parser does not allow that — see
+// the build-time error path noted above. Bind preserves the spirit of
+// the guidance: the handle is owned by the calling service (each
+// service still calls sqldb.Named in its own package) and rbac itself
+// imports nothing service-specific. SPEC §10.1's locked surface
+// (For/Where/Run) is unchanged.
+var db *sqldb.Database
+
+// Bind installs the unblock-database handle that Run will dispatch
+// against. Services call Bind exactly once from a package-level init
+// (or service init) before any RPC handler invokes For. Subsequent
+// calls overwrite the handle; tests rely on this for swap-in of fakes.
+//
+// Concurrency: Bind is not goroutine-safe; the contract is that it
+// runs during Encore service initialisation, before any handler can
+// observe a partially constructed builder.
+func Bind(database *sqldb.Database) {
+	db = database
+}
+
+// ErrMissingScope is returned by Run when the *ScopedQuery[T] receiver
+// was not constructed via For — i.e. when a caller bypassed the typed
+// constructor by naked struct literal. Outside-of-package callers cannot
+// set the unexported scope fields, so a zero-valued ScopedQuery hits this
+// error path. This is the runtime half of AC-1's two-layer guarantee
+// (the compile-time half is Encore's per-service DB binding; see package
+// doc).
+var ErrMissingScope = errors.New("rbac: ScopedQuery missing scope filter; use rbac.For[T] to construct")
+
+// ErrEmptyTable is returned when For is called with table="". This is a
+// programmer error and surfaces immediately at Run time. Tables are
+// passed as opaque strings (typed identifiers do not carry through Go
+// generics cleanly) so an empty value is the cheapest validation gate.
+var ErrEmptyTable = errors.New("rbac: ScopedQuery built with empty table identifier")
+
+// ErrNotBound is returned by Run when no service has called Bind to
+// install the unblock-database handle. This is a service-bootstrap
+// programmer error.
+var ErrNotBound = errors.New("rbac: unblock database handle not bound; calling service must invoke rbac.Bind(sqldb.Named(\"unblock\"))")
+
+// ScopedQuery is a typed, scope-bound query builder over a single
+// org/project-scoped table. Every value produced by For carries an
+// org-scoped WHERE predicate that Run prepends to the user-supplied
+// filter chain. Field set is intentionally unexported so the only path
+// to a non-zero scope is the For constructor.
+type ScopedQuery[T any] struct {
+	// identity is the calling user's resolved record. Carried for
+	// future audit hooks (e.g. logging the row-count returned per
+	// Identity for cross-tenant leak detection); not currently emitted
+	// to the SQL plan beyond the scope predicate.
+	identity auth.Identity
+
+	// table is the fully-qualified target table, e.g. "workitems.items".
+	// Empty is rejected at Run time (see ErrEmptyTable).
+	table string
+
+	// scopeClause is the canonical scope predicate prepended to every
+	// query. For sets it to `<table_alias>.org_id = $N` against the
+	// caller's identity.OrgID. A zero-valued ScopedQuery has scopeClause
+	// == "" and Run returns ErrMissingScope.
+	scopeClause string
+
+	// scopeArgs holds the bind values for scopeClause (currently a
+	// single OrgID). Stored as []any so future scope shapes (e.g.
+	// org_id + project_id) can be added without touching the public
+	// surface.
+	scopeArgs []any
+
+	// userClauses accumulates each caller-provided Where invocation in
+	// declaration order. They are AND-joined onto scopeClause at Run.
+	userClauses []userClause
+
+	// err captures the first error encountered during fluent
+	// construction (e.g. an empty clause string passed to Where).
+	// Run surfaces it instead of executing.
+	err error
+}
+
+// userClause records a single Where invocation. Stored separately from
+// scopeClause so the scope predicate is immutably anchored at position
+// 0 of the WHERE chain.
+type userClause struct {
+	clause string
+	args   []any
+}
+
+// For constructs a *ScopedQuery[T] bound to the caller's Identity and
+// the named table. The org-scope predicate is immediately materialised
+// — a value returned by For has a non-empty scopeClause that Run will
+// always emit.
+//
+// Empty table strings are accepted here and surfaced at Run time as
+// ErrEmptyTable, mirroring the deferred-error pattern of the standard
+// library's database/sql.DB.Prepare. This keeps the fluent surface
+// chainable without panic-paths.
+//
+// table must be a fully-qualified `<schema>.<table>` identifier. Caller
+// is responsible for using a valid identifier; SQL-injection-safety on
+// the table parameter rests on the linter at apps/api/shared/lint/ and
+// on code review (SPEC §10.1 acceptance criterion #3).
+func For[T any](identity auth.Identity, table string) *ScopedQuery[T] {
+	q := &ScopedQuery[T]{
+		identity: identity,
+		table:    table,
+	}
+	if table == "" {
+		q.err = ErrEmptyTable
+		return q
+	}
+	// The scope predicate uses positional arg $1 because Run rebuilds
+	// the full param list when it stitches scope + user clauses.
+	q.scopeClause = fmt.Sprintf("%s.org_id = $1", table)
+	q.scopeArgs = []any{identity.OrgID}
+	return q
+}
+
+// Where appends a user-supplied predicate to the WHERE chain. The
+// scope predicate built by For is always emitted first; user clauses
+// follow, AND-joined, in declaration order. Args are bound positionally
+// after the scope args.
+//
+// An empty clause is recorded as an error and surfaces at Run time;
+// the receiver is still returned so fluent chains do not crash.
+func (q *ScopedQuery[T]) Where(clause string, args ...any) *ScopedQuery[T] {
+	if q == nil {
+		// nil receiver should not happen via the supported path (For
+		// always returns non-nil), but defensive guards keep the
+		// fluent chain from panicking on misuse.
+		return q
+	}
+	if q.err != nil {
+		return q
+	}
+	if strings.TrimSpace(clause) == "" {
+		q.err = errors.New("rbac: empty Where clause")
+		return q
+	}
+	q.userClauses = append(q.userClauses, userClause{
+		clause: clause,
+		args:   append([]any(nil), args...),
+	})
+	return q
+}
+
+// Run executes the assembled query and scans rows into a []T. It is a
+// fatal builder error (ErrMissingScope) if the receiver was not
+// produced by For. Any error captured during fluent construction is
+// surfaced here.
+//
+// Row scanning uses reflection: T must be a struct whose exported
+// fields correspond, in declaration order, to the columns selected by
+// `SELECT * FROM <table>`. Mismatched column counts produce a
+// structured error. P01 keeps the SELECT shape implicit (`*`) — future
+// phases may add an explicit Columns([]string) hook without breaking
+// the locked surface.
+//
+// Run is not on the API-key hot path (SPEC §4.3.2 short-circuits via a
+// direct key_prefix lookup); reflection cost is acceptable for the
+// general read surface.
+func (q *ScopedQuery[T]) Run(ctx context.Context) ([]T, error) {
+	if q == nil {
+		return nil, ErrMissingScope
+	}
+	if q.err != nil {
+		return nil, q.err
+	}
+	if q.scopeClause == "" {
+		// Zero-valued struct literal path (`&rbac.ScopedQuery[T]{}`):
+		// the scope filter was never installed because For was not
+		// invoked. AC-1's runtime gate.
+		return nil, ErrMissingScope
+	}
+	if q.table == "" {
+		return nil, ErrEmptyTable
+	}
+
+	if db == nil {
+		return nil, ErrNotBound
+	}
+
+	sql, args := q.build()
+
+	rows, err := db.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("rbac: query %q: %w", q.table, err)
+	}
+	defer rows.Close()
+
+	out, err := scanAll[T](rows)
+	if err != nil {
+		return nil, fmt.Errorf("rbac: scan %q: %w", q.table, err)
+	}
+	return out, nil
+}
+
+// build assembles the final SQL string and the positional arg slice.
+// The scope predicate is always at $1; user clauses follow, with their
+// placeholders rewritten so positional indices stay contiguous.
+//
+// build is internal and exported only via Run; tests verify its output
+// directly via the unexported buildForTest hook.
+func (q *ScopedQuery[T]) build() (string, []any) {
+	var sb strings.Builder
+	sb.WriteString("SELECT * FROM ")
+	sb.WriteString(q.table)
+	sb.WriteString(" WHERE ")
+	sb.WriteString(q.scopeClause)
+
+	args := append([]any(nil), q.scopeArgs...)
+	nextPlaceholder := len(args) + 1
+
+	for _, uc := range q.userClauses {
+		rewritten, used := renumberPlaceholders(uc.clause, nextPlaceholder)
+		sb.WriteString(" AND ")
+		sb.WriteString(rewritten)
+		args = append(args, uc.args...)
+		nextPlaceholder += used
+	}
+	return sb.String(), args
+}
+
+// renumberPlaceholders rewrites `$1, $2, ...` in clause to start at
+// startAt, and returns the count of placeholders rewritten. The pgx
+// dialect is positional ($N); supporting `?` (mysql) is out of scope
+// for the unblock database.
+//
+// The implementation is a single-pass scan over the clause string,
+// replacing `$<digits>` runs with `$<startAt + observed_index - 1>`.
+// Distinct placeholders that share an index in the input (e.g. $1
+// appearing twice) are mapped to the same output index. Unused
+// placeholder values in args are caller-controlled and surface as
+// pgx-level errors at Run time, not here.
+func renumberPlaceholders(clause string, startAt int) (string, int) {
+	var (
+		out     strings.Builder
+		seen    = map[int]int{} // input index -> output index
+		nextOut = startAt
+		i       = 0
+		runeLen = len(clause)
+	)
+	for i < runeLen {
+		c := clause[i]
+		if c != '$' {
+			out.WriteByte(c)
+			i++
+			continue
+		}
+		// Parse digits following '$'.
+		j := i + 1
+		for j < runeLen && clause[j] >= '0' && clause[j] <= '9' {
+			j++
+		}
+		if j == i+1 {
+			// '$' not followed by digits — copy verbatim.
+			out.WriteByte(c)
+			i++
+			continue
+		}
+		idx := 0
+		for k := i + 1; k < j; k++ {
+			idx = idx*10 + int(clause[k]-'0')
+		}
+		mapped, ok := seen[idx]
+		if !ok {
+			mapped = nextOut
+			seen[idx] = mapped
+			nextOut++
+		}
+		fmt.Fprintf(&out, "$%d", mapped)
+		i = j
+	}
+	return out.String(), len(seen)
+}
+
+// scanAll consumes rows into a []T using reflection. Supported T
+// kinds: struct (fields scanned by ordinal) and primitive scalar
+// (single-column rows scanned by value). Anything else produces a
+// typed error.
+//
+// We deliberately avoid sqlx-style tag-based mapping for P01: the
+// callers in B-1..D-3 ship with row shapes that mirror the table
+// declaration order, and an explicit struct-tag layer adds scope this
+// bead does not own. A future phase may extend scanAll with tag-aware
+// mapping; the surface (Run returning []T) does not change.
+func scanAll[T any](rows *sqldb.Rows) ([]T, error) {
+	var out []T
+
+	var zero T
+	rt := reflect.TypeOf(zero)
+
+	for rows.Next() {
+		var row T
+		rv := reflect.ValueOf(&row).Elem()
+
+		switch {
+		case rt == nil:
+			return nil, errors.New("rbac: scanAll requires a concrete T (got nil interface kind)")
+		case rt.Kind() == reflect.Struct:
+			fields := exportedFields(rv)
+			ptrs := make([]any, len(fields))
+			for i := range fields {
+				ptrs[i] = fields[i].Addr().Interface()
+			}
+			if err := rows.Scan(ptrs...); err != nil {
+				return nil, err
+			}
+		default:
+			// Single-column scalar T (string, int, time.Time, …).
+			if err := rows.Scan(rv.Addr().Interface()); err != nil {
+				return nil, err
+			}
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// exportedFields returns the addressable, exported leaf fields of rv
+// in declaration order. Embedded struct fields are NOT recursively
+// flattened — callers should declare flat row shapes.
+func exportedFields(rv reflect.Value) []reflect.Value {
+	rt := rv.Type()
+	out := make([]reflect.Value, 0, rt.NumField())
+	for i := 0; i < rt.NumField(); i++ {
+		sf := rt.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		out = append(out, rv.Field(i))
+	}
+	return out
+}

--- a/apps/api/shared/rbac/rbac_test.go
+++ b/apps/api/shared/rbac/rbac_test.go
@@ -1,0 +1,176 @@
+// Tests for the rbac typed query builder. The DB-backed Run path is
+// covered by integration tests under apps/api/shared/rbactest/ (B-3,
+// unblock-tv8.9). These unit tests cover the SQL-assembly layer and
+// the AC-1 zero-value rejection contract — both reachable without a
+// live Encore runtime.
+package rbac
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"encore.app/auth"
+)
+
+// fakeIdentity returns a deterministic identity for builder tests.
+func fakeIdentity(orgID string) auth.Identity {
+	return auth.Identity{
+		UserID:    "usr_test",
+		OrgID:     orgID,
+		Role:      "member",
+		AgentKind: "",
+	}
+}
+
+// TestFor_AlwaysInjectsScope confirms For installs the scope predicate
+// even when Where is never called. AC-1 (runtime half).
+func TestFor_AlwaysInjectsScope(t *testing.T) {
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), "workitems.items")
+	if q.scopeClause == "" {
+		t.Fatalf("For did not install scope predicate")
+	}
+	sql, args := q.build()
+	wantPredicate := "workitems.items.org_id = $1"
+	if !strings.Contains(sql, wantPredicate) {
+		t.Errorf("SQL missing scope predicate %q: got %q", wantPredicate, sql)
+	}
+	if len(args) != 1 || args[0] != "org_alpha" {
+		t.Errorf("scope args = %v, want [org_alpha]", args)
+	}
+}
+
+// TestFor_EmptyTable defers to ErrEmptyTable at Run time rather than
+// panicking during fluent construction.
+func TestFor_EmptyTable(t *testing.T) {
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), "")
+	_, err := q.Run(context.Background())
+	if !errors.Is(err, ErrEmptyTable) {
+		t.Fatalf("Run on empty-table builder = %v, want ErrEmptyTable", err)
+	}
+}
+
+// TestZeroValueScopedQuery_Run confirms a naked struct literal
+// (constructed outside the For path, as a hostile or mistaken caller
+// might) is rejected at Run time. This is AC-1's runtime gate.
+func TestZeroValueScopedQuery_Run(t *testing.T) {
+	q := &ScopedQuery[struct{ ID string }]{}
+	_, err := q.Run(context.Background())
+	if !errors.Is(err, ErrMissingScope) {
+		t.Fatalf("Run on zero-value ScopedQuery = %v, want ErrMissingScope", err)
+	}
+}
+
+// TestNilReceiver_Run confirms Run on a nil receiver returns the same
+// missing-scope error rather than panicking.
+func TestNilReceiver_Run(t *testing.T) {
+	var q *ScopedQuery[struct{ ID string }]
+	_, err := q.Run(context.Background())
+	if !errors.Is(err, ErrMissingScope) {
+		t.Fatalf("Run on nil receiver = %v, want ErrMissingScope", err)
+	}
+}
+
+// TestWhere_AppendsAndJoinsAndRenumbers verifies caller-provided
+// clauses are AND-joined to the scope predicate with placeholders
+// renumbered to follow the scope arg.
+func TestWhere_AppendsAndJoinsAndRenumbers(t *testing.T) {
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), "workitems.items").
+		Where("status = $1", "Ready").
+		Where("priority = $1 OR priority = $2", "P0", "P1")
+
+	sql, args := q.build()
+
+	// Scope first; user clauses AND-joined; placeholders renumbered.
+	wantSQL := "SELECT * FROM workitems.items WHERE workitems.items.org_id = $1 AND status = $2 AND priority = $3 OR priority = $4"
+	if sql != wantSQL {
+		t.Errorf("SQL mismatch:\n got %q\nwant %q", sql, wantSQL)
+	}
+	wantArgs := []any{"org_alpha", "Ready", "P0", "P1"}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("args len = %d, want %d (got %v)", len(args), len(wantArgs), args)
+	}
+	for i, a := range args {
+		if a != wantArgs[i] {
+			t.Errorf("args[%d] = %v, want %v", i, a, wantArgs[i])
+		}
+	}
+}
+
+// TestWhere_RepeatedPlaceholderInOneClause covers the renumbering
+// edge case where a single user clause references the same $N twice.
+// Both occurrences must rewrite to the same output index.
+func TestWhere_RepeatedPlaceholderInOneClause(t *testing.T) {
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), "deps.dependencies").
+		Where("(from_id = $1 OR to_id = $1)", "itm_x")
+
+	sql, args := q.build()
+
+	wantSQL := "SELECT * FROM deps.dependencies WHERE deps.dependencies.org_id = $1 AND (from_id = $2 OR to_id = $2)"
+	if sql != wantSQL {
+		t.Errorf("SQL mismatch:\n got %q\nwant %q", sql, wantSQL)
+	}
+	if len(args) != 2 {
+		t.Errorf("args len = %d, want 2 (got %v)", len(args), args)
+	}
+}
+
+// TestWhere_EmptyClause defers an error to Run time without panicking
+// the fluent chain.
+func TestWhere_EmptyClause(t *testing.T) {
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), "workitems.items").
+		Where("   ", "ignored")
+	_, err := q.Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "empty Where clause") {
+		t.Fatalf("Run after empty Where = %v, want empty-clause error", err)
+	}
+}
+
+// TestRenumberPlaceholders_NoPlaceholders is a unit-level guard for
+// the helper.
+func TestRenumberPlaceholders_NoPlaceholders(t *testing.T) {
+	got, used := renumberPlaceholders("status = 'Ready'", 5)
+	if got != "status = 'Ready'" {
+		t.Errorf("got %q, want unchanged", got)
+	}
+	if used != 0 {
+		t.Errorf("used = %d, want 0", used)
+	}
+}
+
+// TestRenumberPlaceholders_DollarNotFollowedByDigits keeps `$$` and
+// `$identifier` byte-identical (Postgres allows them in dollar-quoted
+// strings; the rbac builder's caller-supplied clauses should not
+// contain them, but the helper should be defensive).
+func TestRenumberPlaceholders_DollarNotFollowedByDigits(t *testing.T) {
+	got, used := renumberPlaceholders("body LIKE '%$tag%'", 3)
+	if got != "body LIKE '%$tag%'" {
+		t.Errorf("got %q, want unchanged", got)
+	}
+	if used != 0 {
+		t.Errorf("used = %d, want 0", used)
+	}
+}
+
+// TestExportedFields_StructLayout confirms the reflection helper
+// returns exported fields in declaration order and skips unexported
+// ones. Exercises the same code path scanAll uses against generic T.
+func TestExportedFields_StructLayout(t *testing.T) {
+	type row struct {
+		ID    string
+		title string //nolint:unused // exercised by reflection
+		Body  string
+	}
+	r := row{}
+	rv := reflect.ValueOf(&r).Elem()
+	got := exportedFields(rv)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (got fields %v)", len(got), got)
+	}
+	// First field must be ID (string), second Body (string).
+	if got[0].Kind() != reflect.String || got[1].Kind() != reflect.String {
+		t.Errorf("expected two string fields; got kinds %v, %v", got[0].Kind(), got[1].Kind())
+	}
+}


### PR DESCRIPTION
## unblock-tv8.4: A-4 RBAC typed query builder (pkg/rbac)

Implements the shared RBAC typed query builder under apps/api/shared/rbac/ and the golangci-lint custom analyzer under apps/api/shared/lint/ per docs/specs/01-spec-backend-mvp.md § 10.1 and § 11.3. Foundation infrastructure consumed downstream by B-1 (auth), B-2 (org), B-3 (rbactest), and the cascade subscriber in C-3.

### What was done
- apps/api/shared/rbac: ScopedQuery[T] / For / Where / Run with auto-injected org-scope predicate. SPEC §10.1's locked surface honoured verbatim. Bind(*sqldb.Database) injects the unblock handle from each calling service.
- apps/api/shared/lint: NoDirectIsReadyWriteAnalyzer flags any UPDATE on workitems.items.is_ready / pipeline_stage outside encore.app/deps. Allow-list compares pass.Pkg.Path() — filename matching would break when the cascade subscriber file lands in C-3.
- apps/api/shared/lint/cmd/no_direct_is_ready_write: standalone singlechecker driver.
- apps/api/.golangci.yml: wires the custom linter via the module-plugin system. CI pickup is Olive's A-6 (unblock-tv8.6).
- analysistest fixtures (badpkg + encore.app/deps) lock the positive/negative behaviour.

### Files changed
- apps/api/.golangci.yml
- apps/api/go.mod
- apps/api/go.sum
- apps/api/shared/rbac/rbac.go
- apps/api/shared/rbac/rbac_test.go
- apps/api/shared/lint/no_direct_is_ready_write.go
- apps/api/shared/lint/no_direct_is_ready_write_test.go
- apps/api/shared/lint/cmd/no_direct_is_ready_write/main.go
- apps/api/shared/lint/testdata/src/badpkg/badpkg.go
- apps/api/shared/lint/testdata/src/encore.app/deps/cascade_subscriber.go

### Decisions
- AC-1 'Run fails to compile' implemented as the spec's two-layer guarantee: compile-time via Encore's per-service DB binding + runtime ErrMissingScope on zero-value ScopedQuery. Plain Go cannot express 'method requires field X non-zero' at the type system level; SPEC §10.1 lines 1870-1872 already reframe AC-1 in those exact terms.
- Generic T row scanning uses reflection (declaration-order field mapping). SPEC §10.1 leaves it implementation-defined; auth-key hot path bypasses rbac entirely.
- Custom linter delivered as x/tools/go/analysis Analyzer + singlechecker driver, consumed by golangci-lint via module-plugin system (linters.settings.custom + .custom-gcl.yml).

### Deviations
- Investigation guidance said the rbac package's Run method must call sqldb.Named directly. Encore's parser refuses sqldb.Named at non-service packages (E1814). Implemented rbac.Bind(*sqldb.Database) injection setter; each calling service still calls sqldb.Named in its own package — rbac stays service-agnostic. SPEC §10.1's locked surface is unchanged.