### PR TITLE
tv8.33: harden rbac.Where against SQL injection via static analyzer

### DIFF
--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -5,14 +5,22 @@
 #
 # Custom linter wiring:
 #
-# `no_direct_is_ready_write` is a project-local analyzer at
-# apps/api/shared/lint/. It is consumed via the module-plugin system
-# of golangci-lint v1.57+ (see https://golangci-lint.run/plugins/module-plugins/).
+# Two project-local analyzers live at apps/api/shared/lint/. Both are
+# consumed via the module-plugin system of golangci-lint v1.57+
+# (see https://golangci-lint.run/plugins/module-plugins/):
 #
-# Operators who want the custom linter to participate in CI must:
+#   - no_direct_is_ready_write — rejects UPDATE statements writing
+#     workitems.items.is_ready or pipeline_stage outside the cascade
+#     subscriber package (SPEC §11.3, unblock-tv8.4).
+#   - no_rbac_dynamic_clause — rejects runtime-constructed first
+#     arguments to rbac.ScopedQuery.Where; every clause string must be
+#     a Go string literal or untyped string constant (SPEC §10.1,
+#     unblock-tv8.33).
 #
-#   1. Build a custom golangci-lint binary that includes the
-#      analyzer module:
+# Operators who want the custom linters to participate in CI must:
+#
+#   1. Build a custom golangci-lint binary that includes BOTH analyzer
+#      modules (a single .custom-gcl.yml registers the whole module):
 #
 #        cd apps/api
 #        cat > .custom-gcl.yml <<'EOF'
@@ -29,9 +37,10 @@
 #
 # Local development without a custom binary is still useful: every
 # core linter below runs against the standard golangci-lint binary,
-# and the analyzer is independently runnable via:
+# and each analyzer is independently runnable via:
 #
 #   cd apps/api && go run ./shared/lint/cmd/no_direct_is_ready_write ./...
+#   cd apps/api && go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...
 #
 # The custom linter section below is therefore declared but only
 # consumed when a custom-built binary loads it.
@@ -61,6 +70,14 @@ linters:
           Rejects UPDATE statements writing workitems.items.is_ready or
           pipeline_stage outside encore.app/deps (the cascade subscriber
           package). See SPEC §11.3 lines 2034-2037.
+        original-url: encore.app/shared/lint
+      no_rbac_dynamic_clause:
+        type: module
+        description: |
+          Rejects runtime-constructed first arguments to
+          rbac.ScopedQuery.Where; every clause string MUST be a Go
+          string literal or untyped string constant. Runtime values
+          flow through args... See SPEC §10.1 / unblock-tv8.33.
         original-url: encore.app/shared/lint
   exclusions:
     rules:

--- a/apps/api/shared/lint/cmd/no_rbac_dynamic_clause/main.go
+++ b/apps/api/shared/lint/cmd/no_rbac_dynamic_clause/main.go
@@ -1,0 +1,24 @@
+// Standalone entry point for the no_rbac_dynamic_clause analyzer.
+// Runs as a single-analyzer driver via golang.org/x/tools/go/analysis
+// /singlechecker. Two consumption paths:
+//
+//  1. Direct invocation:  go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...
+//  2. golangci-lint custom plugin: build the analyzer into a custom
+//     golangci-lint binary via the module-plugin system; configure
+//     `linters-settings.custom.no_rbac_dynamic_clause` in
+//     apps/api/.golangci.yml.
+//
+// The singlechecker runtime adds the standard `-V`, `-flags`, and
+// `-fix` switches expected by go/analysis tooling. No additional
+// flags are added here.
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"encore.app/shared/lint"
+)
+
+func main() {
+	singlechecker.Main(lint.NoRbacDynamicClauseAnalyzer)
+}

--- a/apps/api/shared/lint/no_rbac_dynamic_clause.go
+++ b/apps/api/shared/lint/no_rbac_dynamic_clause.go
@@ -1,0 +1,239 @@
+// no_rbac_dynamic_clause.go — second project-local analyzer for the
+// unblock backend. Enforces SPEC §10.1's injection-safety invariant on
+// the rbac typed query builder: the first argument to
+// `(*encore.app/shared/rbac.ScopedQuery[T]).Where` MUST be a compile-time
+// string constant. Every runtime value flows through the `args...`
+// variadic; the clause text is never user-controlled.
+//
+// Why a static analyzer (and not a runtime check, and not a wrapper
+// type):
+//
+//   - Runtime check: by the time the SQL string reaches the rbac
+//     builder's build() helper, Go has erased the distinction between
+//     a literal and a runtime-constructed string. The string is
+//     opaque. Runtime validation against arbitrary SQL meta-characters
+//     ('--', ';', '/*', '%') is brittle and, for a
+//     tenant-isolation gate, fundamentally not safe enough — a single
+//     missed escape leaks across orgs. The only correctness-preserving
+//     gate is "no runtime construction permitted at all", which is a
+//     compile-time property the analyzer enforces.
+//   - Wrapper type (a `SafeClause string` type with package-private
+//     constructor): would require a SPEC §10.1 amendment because it
+//     changes the locked Where signature. Investigation
+//     (unblock-tv8.33) explicitly recommended the analyzer path
+//     instead.
+//
+// Detection rules (the only acceptable forms for the FIRST argument):
+//
+//   - `*ast.BasicLit` of `token.STRING` kind — covers regular ("…") and
+//     back-quoted (`…`) Go string literals.
+//   - A typed/untyped *types.Const of string kind — covers references
+//     to a package-level `const` whose initialiser is itself a literal
+//     or a constant expression. The Go compiler folds string constants
+//     at compile time, so the result is byte-fixed before the analyzer
+//     ever runs.
+//
+// Everything else is rejected:
+//
+//   - `*ast.Ident` referencing a `var` (runtime-mutable).
+//   - `*ast.BinaryExpr` with `+` operator (runtime concatenation, even
+//     when both operands look static — Go does not promote `var a, b
+//     string; a + b` to a constant).
+//   - `*ast.CallExpr` (fmt.Sprintf, strings.Join, helper functions).
+//   - `*ast.SelectorExpr` resolving to a non-const (struct field, etc).
+//   - `*ast.ParenExpr` is unwrapped recursively before the rules above
+//     are applied; everything else passes through verbatim and fails
+//     the "is constant" check.
+//
+// Receiver-type resolution: the analyzer uses `pass.TypesInfo.Selections`
+// to extract the receiver's type, then walks through *types.Pointer and
+// *types.Named to land on the underlying generic type. The match
+// requires (a) the receiver type's package import path is exactly
+// `encore.app/shared/rbac` and (b) the method's name is `Where`.
+// Name-only matching is explicitly avoided — a `Where` method on an
+// unrelated query builder elsewhere in the backend would otherwise
+// false-positive.
+package lint
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// rbacPackagePath is the canonical Go import path for the rbac typed
+// query builder package. The analyzer uses pass.TypesInfo to resolve
+// the receiver type back to this path before flagging — name-only
+// matching ('any method called Where') would false-positive on
+// unrelated query builders.
+const rbacPackagePath = "encore.app/shared/rbac"
+
+// rbacWhereMethod is the locked SPEC §10.1 method name on
+// rbac.ScopedQuery[T] whose first argument the analyzer guards.
+const rbacWhereMethod = "Where"
+
+// NoRbacDynamicClauseAnalyzer is the exported analyzer instance. The
+// golangci-lint module-plugin loader picks this up via the cmd/
+// entry point.
+var NoRbacDynamicClauseAnalyzer = &analysis.Analyzer{
+	Name:     "no_rbac_dynamic_clause",
+	Doc:      "rejects runtime-constructed first arguments to rbac.ScopedQuery.Where; clause must be a Go string literal or untyped string constant (SPEC §10.1, unblock-tv8.33)",
+	Run:      runNoRbacDynamicClause,
+	URL:      "https://github.com/websublime/unblock/blob/main/docs/specs/01-spec-backend-mvp.md#101-rbac-pkgrbac-nfr-2",
+	Requires: nil,
+}
+
+// runNoRbacDynamicClause implements analysis.Analyzer.Run. Walks every
+// CallExpr in every file, filters to calls whose selector resolves to
+// (*encore.app/shared/rbac.ScopedQuery[T]).Where via go/types, and
+// verifies the FIRST argument is a compile-time string constant.
+func runNoRbacDynamicClause(pass *analysis.Pass) (interface{}, error) {
+	if pass.Pkg == nil {
+		return nil, nil //nolint:nilnil // analyzer convention
+	}
+	// The rbac package's own tests call Where with literals, but they
+	// also exercise internal helpers. Skip the package itself so the
+	// analyzer never analyses its own subject — false positives would
+	// be confusing and the package's own correctness is governed by
+	// the doc-hardening pass (rbac.go SECURITY block on Where).
+	if pass.Pkg.Path() == rbacPackagePath {
+		return nil, nil //nolint:nilnil
+	}
+
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if sel.Sel == nil || sel.Sel.Name != rbacWhereMethod {
+				return true
+			}
+			if !isRbacScopedQueryReceiver(pass.TypesInfo, sel) {
+				return true
+			}
+			if len(call.Args) == 0 {
+				// Wrong arity — go/types will complain elsewhere; this
+				// analyzer is only concerned with the safety contract.
+				return true
+			}
+			first := call.Args[0]
+			if isCompileTimeStringConstant(pass.TypesInfo, first) {
+				return true
+			}
+			pass.ReportRangef(first, "rbac.Where: first argument must be a Go string literal or untyped string constant; runtime values MUST flow through args... — see SPEC §10.1 / unblock-tv8.33")
+			return true
+		})
+	}
+	return nil, nil //nolint:nilnil
+}
+
+// isRbacScopedQueryReceiver returns true when sel resolves to a method
+// on a *encore.app/shared/rbac.ScopedQuery[T] receiver. The analyzer
+// must reject false positives on unrelated query builders, so we walk
+// through the type-info graph rather than match by name alone.
+func isRbacScopedQueryReceiver(info *types.Info, sel *ast.SelectorExpr) bool {
+	if info == nil {
+		return false
+	}
+	// Selections records selectors that resolve to a method or field
+	// on a typed expression (e.g. `q.Where(...)` where q is typed).
+	// Package-qualified identifiers (e.g. `pkg.Func`) live in
+	// info.Uses instead, but rbac.Where is always a method call so
+	// Selections is the right map.
+	selection, ok := info.Selections[sel]
+	if !ok {
+		return false
+	}
+	recv := selection.Recv()
+	if recv == nil {
+		return false
+	}
+	named := unwrapToNamed(recv)
+	if named == nil {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == rbacPackagePath
+}
+
+// unwrapToNamed strips *types.Pointer wrappers and unwraps generic
+// instantiations down to the underlying *types.Named. Go represents
+// `*ScopedQuery[T]` as Pointer(Named(ScopedQuery)) at the type-info
+// level; method receivers may be either pointer or value, so we
+// accept both.
+func unwrapToNamed(t types.Type) *types.Named {
+	for {
+		switch tt := t.(type) {
+		case *types.Pointer:
+			t = tt.Elem()
+		case *types.Named:
+			return tt
+		case *types.Alias:
+			// Go 1.22+ exposes type aliases as *types.Alias; unwrap to
+			// the aliased type so an `type X = rbac.ScopedQuery[T]`
+			// declaration still resolves correctly.
+			t = types.Unalias(tt)
+		default:
+			return nil
+		}
+	}
+}
+
+// isCompileTimeStringConstant decides whether expr is acceptable as
+// the FIRST argument to rbac.Where. Two acceptable shapes:
+//
+//   - *ast.BasicLit of token.STRING — a literal string written
+//     directly at the call site (regular or back-quoted).
+//   - Any expression whose go/types Constant value is non-nil and of
+//     string kind — covers package-level `const x = "…"` and
+//     compile-time-foldable expressions like `const x = a + b` where a
+//     and b are themselves string constants.
+//
+// Everything else (runtime vars, function returns, BinaryExpr on
+// non-constants, type conversions on non-constants) returns false.
+func isCompileTimeStringConstant(info *types.Info, expr ast.Expr) bool {
+	expr = unparen(expr)
+
+	if lit, ok := expr.(*ast.BasicLit); ok {
+		return lit.Kind == token.STRING
+	}
+	if info == nil {
+		return false
+	}
+	tv, ok := info.Types[expr]
+	if !ok {
+		return false
+	}
+	if tv.Value == nil {
+		// Non-constant expression. go/types only populates Value when
+		// the expression evaluates to a compile-time constant; a var
+		// reference, function call, or BinaryExpr on non-constants
+		// leaves Value nil.
+		return false
+	}
+	return tv.Value.Kind() == constant.String
+}
+
+// unparen strips redundant *ast.ParenExpr wrappers. A user might write
+// `q.Where(("status = $1"), ...)`; the analyzer should treat that the
+// same as the bare literal.
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}

--- a/apps/api/shared/lint/no_rbac_dynamic_clause_test.go
+++ b/apps/api/shared/lint/no_rbac_dynamic_clause_test.go
@@ -1,0 +1,46 @@
+// Tests for NoRbacDynamicClauseAnalyzer using analysistest.
+//
+// Three fixtures live under testdata/src/:
+//
+//   - encore.app/shared/rbac: a stub rbac package matching the locked
+//     SPEC §10.1 surface. Imported by both bad/good fixtures so the
+//     analyzer's receiver-type resolution sees the canonical package
+//     path (`encore.app/shared/rbac`) and matches consistently.
+//   - rbacclausebad: every call to rbac.Where with a runtime first
+//     argument; each carries a `// want` annotation matching the
+//     analyzer's diagnostic.
+//   - rbacclausegood: literals, named constants, composed constants,
+//     parenthesised literals, and a same-named method on an unrelated
+//     receiver type. No diagnostics expected.
+//
+// The receiver-resolution test in the good fixture (`unrelatedBuilder`
+// with its own Where method) is the explicit guard against
+// name-only matching: SPEC §10.1's investigation flagged this as a
+// MEDIUM risk, and the green-fixture failure mode would be a clear
+// signal that the go/types resolution path regressed.
+package lint
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestNoRbacDynamicClause_FlagsRuntimeClauses runs the analyzer
+// against the rbacclausebad fixture and asserts every `// want`
+// annotation is satisfied — vars, BinaryExpr concatenation,
+// fmt.Sprintf, function returns, and struct selectors all flag.
+func TestNoRbacDynamicClause_FlagsRuntimeClauses(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, NoRbacDynamicClauseAnalyzer, "rbacclausebad")
+}
+
+// TestNoRbacDynamicClause_AllowsCompileTimeConstants runs the analyzer
+// against the rbacclausegood fixture and asserts NO diagnostic fires.
+// Covers: BasicLit (regular and back-quoted), named const, composed
+// const, parenthesised literal, and an unrelated `Where` method on a
+// non-rbac receiver type.
+func TestNoRbacDynamicClause_AllowsCompileTimeConstants(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, NoRbacDynamicClauseAnalyzer, "rbacclausegood")
+}

--- a/apps/api/shared/lint/testdata/src/encore.app/shared/rbac/rbac.go
+++ b/apps/api/shared/lint/testdata/src/encore.app/shared/rbac/rbac.go
@@ -1,0 +1,49 @@
+// Fake encore.app/shared/rbac package for analysistest fixtures.
+//
+// analysistest builds a self-contained module rooted at testdata/src/,
+// so the real rbac package (which imports encore.dev/storage/sqldb and
+// encore.app/auth) cannot be referenced — pulling those in would
+// require importing the entire Encore runtime into the lint testdata
+// tree. Instead, this fake mirrors the locked SPEC §10.1 surface
+// (For/Where/Run signatures plus the ScopedQuery[T] type) so the
+// analyzer's go/types-based receiver resolution sees the same package
+// path (`encore.app/shared/rbac`) and matches the same way it does
+// against the real package.
+//
+// Bodies are stubs — the analyzer never executes the code, only walks
+// its types. The methods return the receiver so fluent chains in the
+// fixture compile without runtime semantics.
+package rbac
+
+import "context"
+
+// ScopedQuery is the public type the analyzer's receiver-resolution
+// logic must recognise. The internal layout doesn't matter to the
+// analyzer; only the package path of the named type does.
+type ScopedQuery[T any] struct {
+	_ T
+}
+
+// Identity is a stand-in for auth.Identity; the analyzer doesn't
+// inspect it.
+type Identity struct {
+	OrgID string
+}
+
+// For mirrors rbac.For so fixtures can build a *ScopedQuery[T] for
+// chaining into Where calls.
+func For[T any](_ Identity, _ string) *ScopedQuery[T] {
+	return &ScopedQuery[T]{}
+}
+
+// Where mirrors the locked SPEC §10.1 signature. The analyzer flags
+// non-literal first arguments at call sites of THIS method.
+func (q *ScopedQuery[T]) Where(_ string, _ ...any) *ScopedQuery[T] {
+	return q
+}
+
+// Run mirrors the locked SPEC §10.1 signature so chained call sites
+// compile.
+func (q *ScopedQuery[T]) Run(_ context.Context) ([]T, error) {
+	return nil, nil
+}

--- a/apps/api/shared/lint/testdata/src/rbacclausebad/rbacclausebad.go
+++ b/apps/api/shared/lint/testdata/src/rbacclausebad/rbacclausebad.go
@@ -1,0 +1,59 @@
+// Fixture for analysistest: a package whose calls to
+// rbac.ScopedQuery.Where pass non-literal first arguments. Every
+// flagged call carries a "want" annotation matching the analyzer's
+// diagnostic message.
+package rbacclausebad
+
+import (
+	"context"
+	"fmt"
+
+	"encore.app/shared/rbac"
+)
+
+type row struct {
+	ID string
+}
+
+// Var as the first argument — runtime value, must flag.
+func badVar(ctx context.Context, id rbac.Identity, userClause string) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(userClause). // want `rbac\.Where: first argument must be a Go string literal or untyped string constant`
+		Run(ctx)
+}
+
+// String concatenation at runtime — must flag. Even when both sides
+// look static, Go does not promote `var a, b string; a + b` to a
+// constant.
+func badConcat(ctx context.Context, id rbac.Identity, suffix string) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where("status = " + suffix). // want `rbac\.Where: first argument must be a Go string literal or untyped string constant`
+		Run(ctx)
+}
+
+// fmt.Sprintf return — runtime value, must flag.
+func badSprintf(ctx context.Context, id rbac.Identity, col string) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(fmt.Sprintf("%s = $1", col), "Ready"). // want `rbac\.Where: first argument must be a Go string literal or untyped string constant`
+		Run(ctx)
+}
+
+// Function-return as first argument — runtime value, must flag.
+func buildClause() string { return "status = $1" }
+
+func badFuncReturn(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(buildClause(), "Ready"). // want `rbac\.Where: first argument must be a Go string literal or untyped string constant`
+		Run(ctx)
+}
+
+// Struct-field selector — runtime value, must flag.
+type filter struct {
+	Clause string
+}
+
+func badSelector(ctx context.Context, id rbac.Identity, f filter) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(f.Clause). // want `rbac\.Where: first argument must be a Go string literal or untyped string constant`
+		Run(ctx)
+}

--- a/apps/api/shared/lint/testdata/src/rbacclausegood/rbacclausegood.go
+++ b/apps/api/shared/lint/testdata/src/rbacclausegood/rbacclausegood.go
@@ -1,0 +1,73 @@
+// Fixture for analysistest: a package whose calls to
+// rbac.ScopedQuery.Where pass acceptable first arguments. The
+// analyzer must NOT fire on any call here (no "want" annotations,
+// which analysistest interprets as "expect zero diagnostics").
+package rbacclausegood
+
+import (
+	"context"
+
+	"encore.app/shared/rbac"
+)
+
+type row struct {
+	ID string
+}
+
+// Plain double-quoted string literal — the canonical form.
+func goodLiteral(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where("status = $1", "Ready").
+		Run(ctx)
+}
+
+// Back-quoted (raw) string literal — equivalent for our purposes.
+func goodRawLiteral(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(`status = $1 AND priority = $2`, "Ready", "P0").
+		Run(ctx)
+}
+
+// Package-level untyped string constant — go/types resolves this to a
+// constant value at compile time.
+const filterClause = "status = $1 AND is_archived = false"
+
+func goodNamedConst(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(filterClause, "Ready").
+		Run(ctx)
+}
+
+// Constant expression composed of two string constants — Go folds
+// these at compile time, so the result is byte-fixed before the
+// analyzer ever runs.
+const baseClause = "status = $1"
+const tailClause = " AND is_archived = false"
+const composedClause = baseClause + tailClause
+
+func goodComposedConst(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(composedClause, "Ready").
+		Run(ctx)
+}
+
+// Parenthesised literal — `unparen` strips the wrapper, the bare
+// literal still passes the BasicLit check.
+func goodParenthesisedLiteral(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where(("status = $1"), "Ready").
+		Run(ctx)
+}
+
+// A `Where` method on a different type with the same name MUST NOT
+// false-positive — the analyzer's receiver-resolution gate filters by
+// package path, not method name alone.
+type unrelatedBuilder struct{}
+
+func (u *unrelatedBuilder) Where(_ string, _ ...any) *unrelatedBuilder { return u }
+
+func goodUnrelatedWhere(b *unrelatedBuilder, userClause string) {
+	// userClause is runtime — would be flagged if the analyzer
+	// matched by name. Receiver-type resolution must filter this out.
+	b.Where(userClause)
+}

--- a/apps/api/shared/rbac/rbac.go
+++ b/apps/api/shared/rbac/rbac.go
@@ -43,6 +43,37 @@
 //     and means a service that does not declare access to the unblock
 //     database fails at `encore check` time, not at runtime.
 //
+// Injection-safety invariant (SPEC §10.1, unblock-tv8.33):
+//
+//   - The first argument to Where MUST be a Go string literal or an
+//     untyped string constant — i.e. a value that is fixed at compile
+//     time. Every runtime value (request body, URL parameter, header,
+//     row from the database, anything user-controlled) MUST flow through
+//     the args... variadic, never through string concatenation into the
+//     clause text.
+//   - The clause string is concatenated verbatim into the assembled SQL
+//     statement (see build). There is no runtime validation, escaping,
+//     or sanitisation — the SQL string is opaque to Go. A clause
+//     fragment that contains user-controlled data fragments the WHERE
+//     predicate and silently bypasses the org_id scope guard installed
+//     by For. For a tenant-isolation gate this is fatal.
+//   - The project-local static analyzer
+//     `apps/api/shared/lint/no_rbac_dynamic_clause.go` is the
+//     enforcement gate: it rejects any call to ScopedQuery.Where whose
+//     first argument is not a compile-time string constant. The
+//     analyzer is wired into `apps/api/.golangci.yml` and is also
+//     runnable directly via
+//     `go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...`.
+//   - Runtime detection is fundamentally impossible: by the time the
+//     SQL string reaches build, Go has erased the difference between a
+//     literal and a runtime-constructed string. The analyzer is the
+//     only gate. Reviewers asking "why no runtime check" should consult
+//     this paragraph.
+//   - The same caller-trust model applies to the `table` argument of
+//     For — see its doc-comment and unblock-tv8.33's risk note on the
+//     table parameter (out of scope for that bead but called out here
+//     for completeness).
+//
 // Compile-time property (SPEC §10.1, AC-1).
 //
 // AC-1 reads "ScopedQuery[T].Run fails to compile when no scope filter is
@@ -212,6 +243,30 @@ func For[T any](identity auth.Identity, table string) *ScopedQuery[T] {
 //
 // An empty clause is recorded as an error and surfaces at Run time;
 // the receiver is still returned so fluent chains do not crash.
+//
+// SECURITY (SPEC §10.1, unblock-tv8.33).
+//
+// The clause argument MUST be a Go string literal or an untyped string
+// constant fixed at compile time. Every runtime value MUST flow through
+// args... — never through string concatenation, fmt.Sprintf, or any
+// other operation that produces the clause text at runtime.
+//
+//	// CORRECT — constants and placeholders:
+//	q.Where("status = $1 AND priority = $2", status, prio)
+//
+//	const filter = "is_archived = false"
+//	q.Where(filter)
+//
+//	// WRONG — runtime construction breaches scope:
+//	q.Where("status = '" + userInput + "'")              // injection
+//	q.Where(fmt.Sprintf("status = '%s'", userInput))     // injection
+//	clause := buildClause(req); q.Where(clause)          // injection
+//
+// The analyzer at `apps/api/shared/lint/no_rbac_dynamic_clause.go`
+// rejects every non-literal first argument at lint time. Runtime
+// validation is impossible — the SQL string is opaque to Go by the
+// time it reaches build. Bypassing the analyzer (e.g. //nolint
+// suppression) on this method is forbidden and a code-review failure.
 func (q *ScopedQuery[T]) Where(clause string, args ...any) *ScopedQuery[T] {
 	if q == nil {
 		// nil receiver should not happen via the supported path (For

--- a/apps/api/shared/rbac/rbac_test.go
+++ b/apps/api/shared/rbac/rbac_test.go
@@ -154,6 +154,85 @@ func TestRenumberPlaceholders_DollarNotFollowedByDigits(t *testing.T) {
 	}
 }
 
+// TestWhere_InjectionDocumentation pins the runtime behaviour of
+// Where in the presence of a hostile, dynamically-constructed clause
+// string. These tests EXIST TO DOCUMENT THE INVARIANT, not to exercise
+// a defence: the rbac builder has no runtime gate against SQL
+// injection, by design — see the SECURITY block on Where (SPEC §10.1,
+// unblock-tv8.33).
+//
+// The production-grade gate is the static analyzer at
+// `apps/api/shared/lint/no_rbac_dynamic_clause.go`, which rejects any
+// non-literal first argument at lint time. These tests confirm that:
+//
+//  1. If the analyzer is bypassed (e.g. //nolint suppression, which is
+//     forbidden but possible), a hostile clause is concatenated
+//     verbatim into the assembled SQL — i.e. the leak is real.
+//  2. The scope predicate (org_id = $1) is still emitted, but it sits
+//     before the hostile clause and an attacker can use SQL
+//     meta-characters to neutralise it (close the predicate with a
+//     comment, OR-true, etc).
+//
+// If either assertion ever flips (e.g. a future runtime sanitiser is
+// added), the test must be re-evaluated — runtime sanitisation of
+// arbitrary SQL is brittle and has historically been the wrong gate
+// for tenant isolation. The analyzer remains the contractual gate.
+func TestWhere_InjectionDocumentation_HostileClauseEmitsVerbatim(t *testing.T) {
+	// A clause that pretends to filter on status but trails SQL that
+	// neutralises the org_id predicate by injecting OR 1=1 and a
+	// line-comment marker.
+	//
+	// The analyzer would reject this at lint time because the value
+	// is a `var hostile := ...` — but the runtime builder has no
+	// such gate. We construct the clause via a literal here only so
+	// the test itself compiles cleanly; the assertion is that
+	// build() emits the bytes verbatim regardless of source.
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), "workitems.items").
+		Where("status = $1 OR 1=1 -- ", "Ready")
+	sql, _ := q.build()
+
+	// The hostile bytes survive into the assembled SQL.
+	if !strings.Contains(sql, "OR 1=1 -- ") {
+		t.Fatalf("hostile clause did NOT appear verbatim in assembled SQL — runtime sanitiser detected, contract changed: %q", sql)
+	}
+	// The scope predicate is still emitted at $1, but the AND-join
+	// places it BEFORE the hostile clause. Combined with `OR 1=1`
+	// the org_id filter is neutralised at the SQL semantic level —
+	// hence the analyzer-only gate.
+	if !strings.Contains(sql, "workitems.items.org_id = $1") {
+		t.Errorf("scope predicate missing from assembled SQL: %q", sql)
+	}
+}
+
+// TestWhere_InjectionDocumentation_NoRuntimeSanitiser is a paired
+// regression: it asserts that classic injection meta-characters (';',
+// '--', '/*') survive verbatim through build(). Pinning this
+// behaviour is the regression net if a future contributor adds a
+// runtime sanitiser and silently changes the contract documented on
+// Where. Runtime sanitisation is the wrong gate for this surface; the
+// analyzer is the only acceptable defence.
+func TestWhere_InjectionDocumentation_NoRuntimeSanitiser(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		clause string
+		want   string
+	}{
+		{name: "semicolon", clause: "status = $1; DROP TABLE x", want: "status = $1; DROP TABLE x"},
+		{name: "line_comment", clause: "status = $1 -- malicious", want: "status = $1 -- malicious"},
+		{name: "block_comment", clause: "status = $1 /* malicious */", want: "status = $1 /* malicious */"},
+		{name: "stray_quote", clause: "status = $1 OR title = 'oops", want: "status = $1 OR title = 'oops"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := For[struct{ ID string }](fakeIdentity("org_alpha"), "workitems.items").
+				Where(tc.clause, "Ready")
+			sql, _ := q.build()
+			if !strings.Contains(sql, tc.want) {
+				t.Fatalf("hostile pattern %q not found in assembled SQL — runtime sanitiser detected, see SPEC §10.1: got %q", tc.want, sql)
+			}
+		})
+	}
+}
+
 // TestExportedFields_StructLayout confirms the reflection helper
 // returns exported fields in declaration order and skips unexported
 // ones. Exercises the same code path scanAll uses against generic T.

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -2035,6 +2035,14 @@ seeded fixture and asserts:
   rule under `apps/api/shared/lint/no_direct_is_ready_write.go` rejects
   any UPDATE statement targeting `workitems.items.is_ready` or
   `pipeline_stage` outside `apps/api/deps/cascade_subscriber.go`.)
+- [ ] `rbac.ScopedQuery.Where` is never called with a runtime-constructed
+  clause string — every first argument MUST be a Go string literal or
+  untyped string constant; runtime values flow through `args...`
+  exclusively. (Static analysis: `golangci-lint` custom linter rule
+  under `apps/api/shared/lint/no_rbac_dynamic_clause.go` rejects any
+  non-literal first argument across the unblock backend. Locked SPEC
+  §10.1 surface is unchanged; the analyzer is a meta-guard.
+  unblock-tv8.33.)
 - [ ] `deps.cascade_events` insert is idempotent on re-delivery (property
   test: re-deliver every `CascadeRequested` event twice; assert post-state
   is byte-identical and exactly one row exists per `(event_id,


### PR DESCRIPTION
## unblock-tv8.33: Harden rbac.Where() against SQL injection via caller-supplied clause

Hardens `rbac.ScopedQuery.Where` against SQL-injection via caller-supplied clause strings. The locked SPEC §10.1 surface is preserved — the gate is a project-local static analyzer that rejects every non-literal first argument to `Where` at lint time.

### What was done
- New analyzer `no_rbac_dynamic_clause` at `apps/api/shared/lint/` using `go/types` receiver resolution (matches `rbac.ScopedQuery[T]` by package path, not method name); accepts only `ast.BasicLit` STRING and compile-time string constants for the first argument.
- Singlechecker entry point at `apps/api/shared/lint/cmd/no_rbac_dynamic_clause/`.
- Analysistest fixtures: `rbacclausebad` (5 flagged shapes — var, BinaryExpr concat, fmt.Sprintf, function-return, struct selector), `rbacclausegood` (literals, named const, composed const, parenthesised literal, plus an unrelated-type `Where` to guard receiver-resolution from name-only false-positives), and a stub `encore.app/shared/rbac` mirroring the locked SPEC §10.1 surface.
- `apps/api/.golangci.yml` — second `custom.no_rbac_dynamic_clause` block alongside `no_direct_is_ready_write`; both share the single `.custom-gcl.yml` module entry.
- `apps/api/shared/rbac/rbac.go` — package-doc Injection-safety invariant + SECURITY block on `Where`; runtime detection is impossible by design, the analyzer is the only contractual gate.
- `apps/api/shared/rbac/rbac_test.go` — `TestWhere_InjectionDocumentation` cases pinning the verbatim-emit behaviour as a regression net.
- `docs/specs/01-spec-backend-mvp.md §11.3` — new architectural-invariant bullet citing the analyzer + bead.

### Files changed
- `apps/api/shared/lint/no_rbac_dynamic_clause.go` (new)
- `apps/api/shared/lint/cmd/no_rbac_dynamic_clause/main.go` (new)
- `apps/api/shared/lint/no_rbac_dynamic_clause_test.go` (new)
- `apps/api/shared/lint/testdata/src/encore.app/shared/rbac/rbac.go` (new)
- `apps/api/shared/lint/testdata/src/rbacclausebad/rbacclausebad.go` (new)
- `apps/api/shared/lint/testdata/src/rbacclausegood/rbacclausegood.go` (new)
- `apps/api/.golangci.yml` (modified)
- `apps/api/shared/rbac/rbac.go` (modified)
- `apps/api/shared/rbac/rbac_test.go` (modified)
- `docs/specs/01-spec-backend-mvp.md` (modified)

### Decisions
- **DECISION**: Took option 2a (static analyzer + doc hardening) instead of 2b (SafeClause wrapper type). Rationale: SPEC §10.1 lines 1857-1873 lock the `Where(clause string, args ...any)` signature; option 2b would require a spec amendment. The analyzer preserves the locked surface and matches the investigation's recommended path.

### Deviations
- None — implemented as Sherlock's investigation prescribed.

### Tests
- `go fmt`, `go vet`, `go build` all clean across `apps/api/`.
- `go test ./shared/lint/` — 4/4 pass (2 existing + 2 new).
- Direct invocation `go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...` — zero diagnostics across `apps/api/` (no real call sites yet — B-1/B-2 will be the first consumers gated by this analyzer).
- Receiver-type resolution explicitly verified by the unrelated-`Where` fixture in `rbacclausegood`, which would false-positive under name-only matching.