### PR TITLE
unblock-tv8.32: regex-anchor no_direct_is_ready_write matcher

### DIFF
--- a/apps/api/shared/lint/no_direct_is_ready_write.go
+++ b/apps/api/shared/lint/no_direct_is_ready_write.go
@@ -25,19 +25,33 @@
 //   - The analyzer matches against raw and back-quoted string literals
 //     in any AST position (assignment RHS, function argument, struct
 //     literal). It does NOT execute the SQL or parse it as a
-//     full PostgreSQL grammar — substring matching is sufficient for
-//     the targeted anti-pattern and zero-false-positive within the
-//     unblock backend's expected SQL surface.
-//   - Pattern is case-insensitive on the SQL keywords (UPDATE / SET)
-//     because pgx tolerates either; column names are matched verbatim
-//     (`is_ready`, `pipeline_stage`) since the migration uses
-//     lower-case identifiers.
-//   - String concatenation across two `+` operands is detected: if
-//     either operand contains the trigger keyword, the analyzer
-//     conservatively flags the construction. False positives are
-//     possible but vanishingly rare in real backends; suppress with
-//     `//nolint:no_direct_is_ready_write` if the call site is a
-//     deliberate test fixture.
+//     full PostgreSQL grammar — a single regex anchored on the
+//     UPDATE…SET…<col> shape is sufficient for the targeted
+//     anti-pattern and rejects substring false positives (SELECT
+//     clauses returning is_ready, comment fragments mentioning
+//     "update items.is_ready", INSERT statements listing the column,
+//     adjacent identifiers like update_items_at).
+//   - Pattern is case-insensitive on every component (UPDATE / SET /
+//     items / column name) because pgx tolerates mixed casing and
+//     gofmt/golint-driven SQL hand-formatting in this backend has
+//     historically used both. Column names are still drawn from the
+//     `targetColumns` slice — the regex builds the alternation from
+//     that slice at package init, so adding a future spec'd column
+//     does not require touching the regex literal.
+//   - The (?s) (dotall) flag lets the regex span embedded newlines,
+//     so multi-line UPDATE…SET payloads (the common pgx style) match
+//     in a single pass without manual whitespace folding.
+//   - The regex caps both the UPDATE→items→SET and SET→column gaps
+//     with `[^;]*?`, so a literal carrying multiple statements does
+//     not stitch a forbidden pattern across an unrelated statement
+//     boundary.
+//   - String concatenation across two `+` operands is NOT detected:
+//     this analyzer walks `*ast.BasicLit` nodes only, so a
+//     deliberately split UPDATE statement bypasses it. The cost of
+//     adding BinaryExpr coverage (false positives on string-builder
+//     code that happens to contain "UPDATE" and "is_ready" in
+//     unrelated literals) outweighs the benefit; that pattern is
+//     out-of-scope for this analyzer.
 //
 // The analyzer is consumed by golangci-lint via the module-plugin
 // system; see apps/api/.golangci.yml and the plugin entry point at
@@ -46,6 +60,7 @@ package lint
 
 import (
 	"go/ast"
+	"regexp"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -71,6 +86,58 @@ var allowedAuxPackages = map[string]struct{}{
 // targetColumns is the set of write targets gated by this analyzer.
 // Adding entries is a SPEC change; do not extend without one.
 var targetColumns = []string{"is_ready", "pipeline_stage"}
+
+// isReadyUpdateRe matches an UPDATE statement on workitems.items (or
+// the unqualified `items` table) whose SET clause writes one of the
+// targetColumns columns. Anatomy:
+//
+//   - (?is) — case-insensitive (?i) for SQL keywords + identifiers,
+//     dotall (?s) so the inner [^;]*? can span embedded newlines for
+//     multi-line UPDATE…SET payloads.
+//   - \bupdate — the UPDATE keyword, word-bounded so identifiers
+//     like `update_items_at` do not match.
+//   - (?:\s|\\.)+ — one-or-more whitespace OR Go escape sequence
+//     (backslash + any char). This lets the analyzer match SQL
+//     authored as a regular Go string literal like
+//     `"UPDATE\tworkitems.items SET ..."` where the payload contains
+//     the literal two-character sequence `\t` rather than a real
+//     TAB; analysistest passes the unprocessed literal text through
+//     `unquoteSQL`, so escape bytes survive verbatim.
+//   - (?:workitems\.)?items\b — either schema-qualified
+//     `workitems.items` or the bare `items` table; the trailing \b
+//     rejects sibling tables like `dependency_items`.
+//   - [^;]*?\bset\b — guarded gap to the SET keyword; the [^;]
+//     character class prevents the regex from stitching across an
+//     unrelated statement that happens to be in the same literal.
+//   - [^;]*?\b(<col1>|<col2>)\b — final guarded gap to one of the
+//     targetColumns column names; the alternation is built from the
+//     targetColumns slice at package init via regexp.QuoteMeta.
+//
+// The regex is compiled once at package load. A per-call compile
+// would be wasted on every literal walked by the analyzer.
+var isReadyUpdateRe = buildIsReadyUpdateRe(targetColumns)
+
+// buildIsReadyUpdateRe assembles the UPDATE…SET…<col> regex from a
+// dynamic column list. Exposed as a function so the package init has
+// a single, testable construction point and so a future SPEC-driven
+// column addition is a one-line change to targetColumns.
+func buildIsReadyUpdateRe(columns []string) *regexp.Regexp {
+	if len(columns) == 0 {
+		// Defensive: an empty column list would compile to a regex
+		// that matches every UPDATE statement. The analyzer's contract
+		// is "match these exact columns or nothing"; refuse to compile
+		// a pattern with no anchors.
+		panic("lint: targetColumns must not be empty — see SPEC §11.3")
+	}
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = regexp.QuoteMeta(col)
+	}
+	pattern := `(?is)\bupdate(?:\s|\\.)+(?:workitems\.)?items\b[^;]*?\bset\b[^;]*?\b(?:` +
+		strings.Join(quoted, "|") +
+		`)\b`
+	return regexp.MustCompile(pattern)
+}
 
 // NoDirectIsReadyWriteAnalyzer is the exported analyzer instance.
 // golangci-lint's module-plugin loader picks this up via the cmd/
@@ -136,28 +203,12 @@ func unquoteSQL(value string) string {
 	return value
 }
 
-// looksLikeIsReadyUpdate is the substring matcher: it returns true
-// when the payload contains an `UPDATE … workitems.items` (or
-// `UPDATE … items`) clause AND a write target hit on
-// `is_ready` or `pipeline_stage`. The match is intentionally loose
-// on whitespace: a single contiguous payload is enough; multi-line
-// SQL is folded into one logical pass.
+// looksLikeIsReadyUpdate is the regex-anchored matcher: it returns
+// true when the payload contains an UPDATE statement on workitems.items
+// (or the bare `items` table) whose SET clause writes one of the
+// targetColumns columns. The regex is built once at package init from
+// the targetColumns slice; this function is a thin wrapper so the
+// run() loop reads naturally and the package surface stays stable.
 func looksLikeIsReadyUpdate(payload string) bool {
-	lower := strings.ToLower(payload)
-	if !strings.Contains(lower, "update ") {
-		return false
-	}
-	hasItemsTable := strings.Contains(lower, "workitems.items") ||
-		strings.Contains(lower, " items ") ||
-		strings.HasSuffix(lower, " items") ||
-		strings.Contains(lower, "\titems")
-	if !hasItemsTable {
-		return false
-	}
-	for _, col := range targetColumns {
-		if strings.Contains(lower, col) {
-			return true
-		}
-	}
-	return false
+	return isReadyUpdateRe.MatchString(payload)
 }

--- a/apps/api/shared/lint/no_direct_is_ready_write.go
+++ b/apps/api/shared/lint/no_direct_is_ready_write.go
@@ -52,6 +52,18 @@
 //     code that happens to contain "UPDATE" and "is_ready" in
 //     unrelated literals) outweighs the benefit; that pattern is
 //     out-of-scope for this analyzer.
+//   - SQL comments (`--` line comments, `/* … */` block comments) are
+//     NOT parsed: the analyzer scans raw BasicLit text without a SQL
+//     lexer, so a string literal containing a syntactically complete
+//     fake UPDATE inside a comment (e.g. `-- UPDATE workitems.items
+//     SET is_ready = true`) will still false-positive. This is a
+//     known-and-accepted residual: comment-aware parsing would
+//     require a real SQL grammar, the false-positive cost of the
+//     current heuristic is bounded (literals carrying full fake DML
+//     in comments are vanishingly rare in production code), and the
+//     escape hatch is to relocate the example out of an executable
+//     literal (e.g. into a Go-source `//` comment, which the analyzer
+//     does not scan).
 //
 // The analyzer is consumed by golangci-lint via the module-plugin
 // system; see apps/api/.golangci.yml and the plugin entry point at
@@ -103,9 +115,17 @@ var targetColumns = []string{"is_ready", "pipeline_stage"}
 //     the literal two-character sequence `\t` rather than a real
 //     TAB; analysistest passes the unprocessed literal text through
 //     `unquoteSQL`, so escape bytes survive verbatim.
-//   - (?:workitems\.)?items\b — either schema-qualified
-//     `workitems.items` or the bare `items` table; the trailing \b
-//     rejects sibling tables like `dependency_items`.
+//   - (?:workitems\.items|items)\b — explicit alternation of the
+//     two accepted table forms: schema-qualified `workitems.items`
+//     or the bare `items` table. Written as an explicit alternation
+//     rather than the equivalent factored form `(?:workitems\.)?items`
+//     so the segment self-documents the closed set of accepted
+//     prefixes — only `workitems.` is allowed; an unrelated schema
+//     like `auth.items` cannot land on the bare branch because the
+//     preceding `(?:\s|\\.)+` separator does not span letters, so
+//     after a non-`workitems` schema-qualifier the regex has no path
+//     forward. The trailing \b rejects sibling tables like
+//     `dependency_items`.
 //   - [^;]*?\bset\b — guarded gap to the SET keyword; the [^;]
 //     character class prevents the regex from stitching across an
 //     unrelated statement that happens to be in the same literal.
@@ -133,7 +153,7 @@ func buildIsReadyUpdateRe(columns []string) *regexp.Regexp {
 	for i, col := range columns {
 		quoted[i] = regexp.QuoteMeta(col)
 	}
-	pattern := `(?is)\bupdate(?:\s|\\.)+(?:workitems\.)?items\b[^;]*?\bset\b[^;]*?\b(?:` +
+	pattern := `(?is)\bupdate(?:\s|\\.)+(?:workitems\.items|items)\b[^;]*?\bset\b[^;]*?\b(?:` +
 		strings.Join(quoted, "|") +
 		`)\b`
 	return regexp.MustCompile(pattern)

--- a/apps/api/shared/lint/testdata/src/badpkg/badpkg.go
+++ b/apps/api/shared/lint/testdata/src/badpkg/badpkg.go
@@ -1,21 +1,76 @@
 // Fixture for analysistest: a package that MUST be flagged for any
-// UPDATE on workitems.items.is_ready or pipeline_stage. The `want`
-// comments declare the expected diagnostic positions.
+// UPDATE on workitems.items.is_ready or pipeline_stage. Inline
+// annotations on each positive literal declare the expected
+// diagnostic positions.
+//
+// Layout: positive cases (must fire) carry an annotation on the
+// literal's source line; negative cases (must NOT fire) carry an
+// inline comment explaining what false-positive class they pin down
+// for the regex matcher.
 package badpkg
 
 const (
-	// A direct UPDATE on is_ready outside the allowed package.
+	// Positive: a direct UPDATE on is_ready outside the allowed package.
 	flagged1 = `UPDATE workitems.items SET is_ready = true WHERE id = $1` // want `direct UPDATE on workitems.items.is_ready or pipeline_stage outside encore.app/deps`
 
-	// Multi-line UPDATE expressed as a regular string literal so the
-	// diagnostic position lands on a single source line that the
-	// `want` annotation can match.
+	// Positive: multi-line UPDATE expressed as a regular string literal
+	// so the diagnostic position lands on a single source line that the
+	// `want` annotation can match. Pins the (?s) dotall flag — without
+	// it the .* between UPDATE and SET would not span the embedded
+	// newline.
 	flagged2 = "UPDATE workitems.items\n   SET pipeline_stage = 'Done'\n WHERE id = $1" // want `direct UPDATE on workitems.items.is_ready or pipeline_stage outside encore.app/deps`
 
-	// A clean update on a different column must NOT fire.
-	clean = `UPDATE workitems.items SET status = 'Done' WHERE id = $1`
+	// Positive: regular Go string with \n escape between UPDATE and
+	// the items table. Pins the (?:\s|\\.) gap accepting Go-source
+	// escape bytes (the literal two-character sequence \n) in addition
+	// to real whitespace.
+	flagged3 = "UPDATE\nworkitems.items SET is_ready = true WHERE id = $1" // want `direct UPDATE on workitems.items.is_ready or pipeline_stage outside encore.app/deps`
+
+	// Positive: bare `items` table (no schema qualifier). The regex
+	// accepts both `workitems.items` and the unqualified form because
+	// some queries operate inside a SET search_path = workitems
+	// connection scope.
+	flagged4 = `UPDATE items SET is_ready = true WHERE id = $1` // want `direct UPDATE on workitems.items.is_ready or pipeline_stage outside encore.app/deps`
+
+	// Negative: a clean UPDATE on a different column must NOT fire.
+	cleanColumn = `UPDATE workitems.items SET status = 'Done' WHERE id = $1`
+
+	// Negative: a SELECT clause that incidentally returns is_ready
+	// must NOT fire. Pins the requirement that the regex anchors on
+	// UPDATE, not just any SQL containing "is_ready".
+	cleanSelect = `SELECT id, is_ready, pipeline_stage FROM workitems.items WHERE org_id = $1`
+
+	// Negative: a comment string that mentions an UPDATE on
+	// items.is_ready in prose must NOT fire. Pins the requirement that
+	// the regex demands a real SET keyword between UPDATE and the
+	// column — a documentation fragment that names the column without
+	// a SET clause is harmless.
+	cleanComment = `-- historical note: previous code did update items is_ready directly; now routed via cascade`
+
+	// Negative: an INSERT that lists is_ready in the column list must
+	// NOT fire. Pins the requirement that the regex anchors on the
+	// UPDATE keyword, not on the column name appearing anywhere.
+	cleanInsert = `INSERT INTO workitems.items (id, org_id, is_ready, pipeline_stage) VALUES ($1, $2, false, 'Investigation')`
+
+	// Negative: an identifier that contains "update" as a substring
+	// (here as a column name) must NOT fire. Pins the \bupdate\s+
+	// word boundary on the UPDATE keyword.
+	cleanIdentifier = `SELECT update_items_at, is_ready FROM workitems.items WHERE id = $1`
+
+	// Negative: a DELETE statement on workitems.items must NOT fire,
+	// even when an adjacent literal in the same const block mentions
+	// is_ready. Pins the requirement that the regex requires UPDATE,
+	// not any DML keyword.
+	cleanDelete = `DELETE FROM workitems.items WHERE id = $1 AND is_ready = false`
+
+	// Negative: a SELECT on a table whose name ends in "items" but is
+	// NOT items itself (e.g. workitems.dependency_items) must NOT
+	// fire. Pins the \bitems\b word boundary on the table name.
+	cleanSiblingTable = `UPDATE workitems.dependency_items SET created_at = now() WHERE parent_id = $1`
 )
 
 // Reference the consts so go vet does not complain about unused
 // package-level identifiers in the analysistest run.
-var _ = flagged1 + flagged2 + clean
+var _ = flagged1 + flagged2 + flagged3 + flagged4 +
+	cleanColumn + cleanSelect + cleanComment + cleanInsert +
+	cleanIdentifier + cleanDelete + cleanSiblingTable


### PR DESCRIPTION
## unblock-tv8.32: Tighten looksLikeIsReadyUpdate to regex-anchored UPDATE…SET…<col> pattern

Tightens the `no_direct_is_ready_write` static analyzer (SPEC §11.3 enforcement gate) so it fires only on real UPDATE…SET…<col> SQL, not on any string that happens to contain the substrings `update`, `items`, and `is_ready`/`pipeline_stage`.

### What was done
Replaced the loose substring scan in `looksLikeIsReadyUpdate` with a regex-anchored matcher built once at package init from the `targetColumns` slice. Extended the `badpkg` analysistest fixture with 4 positive cases and 7 negative cases pinning every false-positive class the old matcher could trip (SELECT returning is_ready, documentation comment string, INSERT column list, identifier `update_items_at`, DELETE statement, sibling table `dependency_items`, clean UPDATE on a non-target column).

### Files changed
- `apps/api/shared/lint/no_direct_is_ready_write.go` — regex matcher + updated package docstring
- `apps/api/shared/lint/testdata/src/badpkg/badpkg.go` — fixture extended with positive + negative cases

### Decisions
- Regex separator `(?:\s|\\.)+` between UPDATE and items table to also accept Go-source escape bytes (literal `\` + `n`/`t`/`r`) since `analysistest` passes `unquoteSQL` output through verbatim without processing Go string-literal escapes.
- `panic` on empty `targetColumns` inside `buildIsReadyUpdateRe` to refuse compiling a regex that would otherwise match every UPDATE statement.

### Deviations
The investigation recommended `\bupdate\s+...` for the gap after UPDATE; the implementation generalises that to `(?:\s|\\.)+` so SQL authored as `"UPDATE\nworkitems.items SET ..."` (where `\n` is two source bytes that survive `lit.Value`) still matches. Fixture case `flagged3` pins this.

### Quality gates
- `go test ./shared/lint/...` — 4 tests pass (2 for this analyzer + 2 regression for `no_rbac_dynamic_clause`)
- `go vet ./shared/lint/...` — clean
- `go fmt ./...` — clean
- `go run ./shared/lint/cmd/no_direct_is_ready_write ./...` against full `apps/api/` tree — zero findings

### Aux-allow-list note
The investigation flagged that `allowedAuxPackages` MAY become unnecessary after the regex tightens. Per investigation guidance, that experiment is a follow-up; removing entries here would risk CI breakage and the aux list is cheap insurance. Left unchanged.