### PR TITLE
unblock-tv8.30: extract auth.Identity to auth/types leaf package

### DIFF
--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"encore.app/auth/types"
 )
 
 // errNotImplemented is the sentinel returned by every P01 A-1 skeleton
@@ -25,12 +27,18 @@ var errNotImplemented = errors.New("auth: not implemented in P01 A-1 skeleton")
 
 // Identity is the resolved caller record carried inside the Encore mesh.
 // Locked shape per SPEC §4.1.
-type Identity struct {
-	UserID    string // ULID
-	OrgID     string // ULID — primary org binding for this auth event
-	Role      string // "owner" | "admin" | "member" | "viewer"
-	AgentKind string // empty for human sessions; AgentKind value for API-key callers
-}
+//
+// Re-exported as a type alias from the leaf `auth/types` sub-package
+// (bead unblock-tv8.30). The alias preserves SPEC §10.1's literal
+// spelling `auth.Identity` at every consumer call site (org, rbac,
+// future B-1..D-3 / E-*) while letting Encore-free test paths import
+// the pure-value definition directly via `encore.app/auth/types`.
+//
+// Do NOT redeclare Identity as a non-alias type here — that breaks
+// the structural identity guarantee that lets `auth.Identity{...}`
+// literals interoperate with `types.Identity{...}` in code that
+// crosses both spellings.
+type Identity = types.Identity
 
 // ValidateRequest is the input to Validate. SPEC §4.1.
 type ValidateRequest struct {

--- a/apps/api/auth/types/types.go
+++ b/apps/api/auth/types/types.go
@@ -1,0 +1,66 @@
+// Package types holds the pure value types of the auth service that are
+// safe to import from non-Encore Go test runners (plain `go test`, godoc,
+// static analysis). It is a leaf sub-package: it imports nothing from
+// encore.dev, declares no APIs, and registers no infrastructure.
+//
+// Why it exists (bead unblock-tv8.30): the parent `auth` package declares
+// the canonical `unblock` Postgres handle via
+// `var db = sqldb.NewDatabase("unblock", ...)` at package scope. Encore's
+// runtime panics if NewDatabase executes outside the encore CLI's
+// cluster bring-up — and cluster bring-up itself requires Docker. Any
+// transitive import of `encore.app/auth` from a non-Encore test path
+// (e.g. `go test ./shared/rbac/...`) triggers `auth.init()` and panics
+// with "encore apps must be run using the encore command". That made
+// every consumer of `auth.Identity` (org, rbac, future B-1..D-3, E-*)
+// require Docker just to compile a unit test that never touches the DB.
+//
+// The fix: extract the pure value types (currently just Identity) into
+// this leaf sub-package. The parent `auth` package re-exports them via
+// `type Identity = types.Identity` so SPEC §10.1's literal spelling
+// `auth.Identity` is preserved at every call site. Consumers that only
+// need the type — like the rbac builder under `apps/api/shared/rbac/` —
+// import `encore.app/auth/types` directly and avoid the auth-package
+// init-time hazards entirely (NewDatabase, secrets binding,
+// //encore:api endpoints).
+//
+// Constraints (DO NOT VIOLATE):
+//
+//   - This package MUST NOT import any encore.dev/* package, directly or
+//     transitively. The whole point of the package is to be Encore-free.
+//   - This package MUST NOT declare //encore:api endpoints, //encore:service
+//     annotations, or any infrastructure resource (sqldb.NewDatabase,
+//     pubsub.NewTopic, cache.NewCluster, secrets, ...). It is a pure
+//     value-type package.
+//   - SPEC §3.1 invariant: the auth service remains the sole
+//     migration-owner; sqldb.NewDatabase("unblock", ...) is still called
+//     exactly once across the workspace, in `apps/api/auth/db.go`.
+//   - SPEC §10.1 invariant: consumer call sites continue to spell the
+//     type as `auth.Identity` (literal). They MUST NOT be re-spelled to
+//     `types.Identity` or `authtypes.Identity`. The parent `auth`
+//     package re-exports via type alias.
+package types
+
+// Identity is the resolved caller record carried inside the Encore mesh.
+// Locked shape per SPEC §4.1.
+//
+// Field semantics:
+//
+//   - UserID:    ULID — the auth.users row this Identity was minted for.
+//   - OrgID:     ULID — the primary org binding for this auth event;
+//     used by the rbac scope predicate (`<table>.org_id = $1`).
+//   - Role:      one of "owner" | "admin" | "member" | "viewer" — see
+//     SPEC §4.2 RBAC matrix. Unspecified values are rejected at
+//     org.Authorize.
+//   - AgentKind: empty for human sessions; an AgentKind enum value
+//     (SPEC §4.3) for API-key callers (Bearer-key auth path).
+//
+// This type is a pure value record: no methods, no pointers to runtime
+// state, no Encore infrastructure dependencies. Safe to construct from
+// any package, including plain `go test` consumers under
+// `apps/api/shared/*`.
+type Identity struct {
+	UserID    string // ULID
+	OrgID     string // ULID — primary org binding for this auth event
+	Role      string // "owner" | "admin" | "member" | "viewer"
+	AgentKind string // empty for human sessions; AgentKind value for API-key callers
+}

--- a/apps/api/shared/rbac/rbac.go
+++ b/apps/api/shared/rbac/rbac.go
@@ -12,6 +12,18 @@
 //	func (q *ScopedQuery[T]) Where(clause string, args ...any) *ScopedQuery[T]
 //	func (q *ScopedQuery[T]) Run(ctx context.Context) ([]T, error)
 //
+// Identity-type plumbing (bead unblock-tv8.30): SPEC §10.1's surface
+// is documented with the literal `auth.Identity`. The implementation
+// here imports the type from its leaf-package source at
+// `encore.app/auth/types`, because importing `encore.app/auth`
+// directly would drag in the auth service's package-level
+// sqldb.NewDatabase("unblock", ...) declaration and panic any plain
+// `go test` run with "encore apps must be run using the encore
+// command". The two spellings are interchangeable: the parent `auth`
+// package declares `type Identity = types.Identity`, so a value
+// constructed in a service as `auth.Identity{...}` is the same Go
+// type as the `types.Identity` parameter accepted here.
+//
 // Usage:
 //
 //	import "encore.app/shared/rbac"
@@ -108,7 +120,7 @@ import (
 	"reflect"
 	"strings"
 
-	"encore.app/auth"
+	"encore.app/auth/types"
 	"encore.dev/storage/sqldb"
 )
 
@@ -170,7 +182,13 @@ type ScopedQuery[T any] struct {
 	// future audit hooks (e.g. logging the row-count returned per
 	// Identity for cross-tenant leak detection); not currently emitted
 	// to the SQL plan beyond the scope predicate.
-	identity auth.Identity
+	//
+	// Typed as types.Identity (the leaf-package source) rather than
+	// auth.Identity to keep this package import-clean of the auth
+	// service's init-time sqldb.NewDatabase call. The two spellings
+	// are the same Go type via the alias declared in
+	// apps/api/auth/auth.go.
+	identity types.Identity
 
 	// table is the fully-qualified target table, e.g. "workitems.items".
 	// Empty is rejected at Run time (see ErrEmptyTable).
@@ -220,7 +238,7 @@ type userClause struct {
 // is responsible for using a valid identifier; SQL-injection-safety on
 // the table parameter rests on the linter at apps/api/shared/lint/ and
 // on code review (SPEC §10.1 acceptance criterion #3).
-func For[T any](identity auth.Identity, table string) *ScopedQuery[T] {
+func For[T any](identity types.Identity, table string) *ScopedQuery[T] {
 	q := &ScopedQuery[T]{
 		identity: identity,
 		table:    table,

--- a/apps/api/shared/rbac/rbac_test.go
+++ b/apps/api/shared/rbac/rbac_test.go
@@ -12,12 +12,18 @@ import (
 	"strings"
 	"testing"
 
-	"encore.app/auth"
+	"encore.app/auth/types"
 )
 
 // fakeIdentity returns a deterministic identity for builder tests.
-func fakeIdentity(orgID string) auth.Identity {
-	return auth.Identity{
+//
+// Imported as `types.Identity` rather than `auth.Identity`: the latter
+// path triggers `auth.init()` (sqldb.NewDatabase) which panics outside
+// the encore CLI's cluster bring-up. The leaf `auth/types` package is
+// Encore-free by construction (bead unblock-tv8.30). The two spellings
+// alias to the same Go type — see auth.go's `type Identity = types.Identity`.
+func fakeIdentity(orgID string) types.Identity {
+	return types.Identity{
 		UserID:    "usr_test",
 		OrgID:     orgID,
 		Role:      "member",
@@ -206,28 +212,39 @@ func TestWhere_InjectionDocumentation_HostileClauseEmitsVerbatim(t *testing.T) {
 
 // TestWhere_InjectionDocumentation_NoRuntimeSanitiser is a paired
 // regression: it asserts that classic injection meta-characters (';',
-// '--', '/*') survive verbatim through build(). Pinning this
-// behaviour is the regression net if a future contributor adds a
+// '--', '/*', stray quote) survive verbatim through build(). Pinning
+// this behaviour is the regression net if a future contributor adds a
 // runtime sanitiser and silently changes the contract documented on
 // Where. Runtime sanitisation is the wrong gate for this surface; the
 // analyzer is the only acceptable defence.
+//
+// Test asserts on the meta-character bytes only — the `$N` placeholder
+// indices are renumbered by build() to keep positional args contiguous
+// (the scope predicate consumes $1, so user `$1` becomes `$2`). That
+// renumbering is orthogonal placeholder bookkeeping covered by
+// TestWhere_AppendsAndJoinsAndRenumbers; this test is concerned only
+// with non-numeric meta-character survival.
 func TestWhere_InjectionDocumentation_NoRuntimeSanitiser(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		clause string
-		want   string
+		// wantSubstr is a fragment of the hostile clause AFTER the
+		// renumbered placeholder — chosen so the assertion is robust
+		// to placeholder renumbering but still pins the meta-character
+		// survival.
+		wantSubstr string
 	}{
-		{name: "semicolon", clause: "status = $1; DROP TABLE x", want: "status = $1; DROP TABLE x"},
-		{name: "line_comment", clause: "status = $1 -- malicious", want: "status = $1 -- malicious"},
-		{name: "block_comment", clause: "status = $1 /* malicious */", want: "status = $1 /* malicious */"},
-		{name: "stray_quote", clause: "status = $1 OR title = 'oops", want: "status = $1 OR title = 'oops"},
+		{name: "semicolon", clause: "status = $1; DROP TABLE x", wantSubstr: "; DROP TABLE x"},
+		{name: "line_comment", clause: "status = $1 -- malicious", wantSubstr: " -- malicious"},
+		{name: "block_comment", clause: "status = $1 /* malicious */", wantSubstr: " /* malicious */"},
+		{name: "stray_quote", clause: "status = $1 OR title = 'oops", wantSubstr: " OR title = 'oops"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			q := For[struct{ ID string }](fakeIdentity("org_alpha"), "workitems.items").
 				Where(tc.clause, "Ready")
 			sql, _ := q.build()
-			if !strings.Contains(sql, tc.want) {
-				t.Fatalf("hostile pattern %q not found in assembled SQL — runtime sanitiser detected, see SPEC §10.1: got %q", tc.want, sql)
+			if !strings.Contains(sql, tc.wantSubstr) {
+				t.Fatalf("hostile pattern %q not found in assembled SQL — runtime sanitiser detected, see SPEC §10.1: got %q", tc.wantSubstr, sql)
 			}
 		})
 	}


### PR DESCRIPTION
## unblock-tv8.30: Move sqldb.NewDatabase out of auth package init to enable Docker-free unit tests on apps/api/shared/*

Breaks the import-time `sqldb.NewDatabase` panic chain that forced every plain `go test ./apps/api/shared/...` run to require Docker, by extracting `auth.Identity` into a new leaf sub-package `encore.app/auth/types` and re-exporting it from the parent `auth` package via a type alias.

### What was done

- Added `apps/api/auth/types/types.go` containing the `Identity` value type (locked shape per SPEC §4.1) and a thorough package doc explaining the Encore-free constraint and SPEC §3.1 invariant.
- `apps/api/auth/auth.go`: replaced the inline `Identity` declaration with `type Identity = types.Identity` so SPEC §10.1's literal `auth.Identity` spelling continues to work at every Encore-service consumer call site (org.go and future B-1..D-3 / E-*).
- `apps/api/shared/rbac/rbac.go`: switched the import from `encore.app/auth` to `encore.app/auth/types`; typed `ScopedQuery.identity` and `For[T]`'s parameter as `types.Identity`. Package doc updated to explain the spelling reconciliation. The two spellings alias to the same Go type — `auth.Identity{...}` literals from service consumers pass into `rbac.For[T]` without any conversion.
- `apps/api/shared/rbac/rbac_test.go`: switched `fakeIdentity` to `types.Identity`. Fixed two pre-existing assertion bugs in `TestWhere_InjectionDocumentation_NoRuntimeSanitiser` that were masked while the import-time panic prevented any test from running (the placeholder renumberer rewrites user `$1` to `$2` because the scope predicate consumes `$1`; assertions now pin the meta-character bytes after the placeholder rather than the full clause including the placeholder index).

### Approach choice and SPEC §3.1 citation

**Option (a)** per the orchestrator DIRECTIVE on the bead — extract `auth.Identity` to a typesonly sub-package rather than function-wrap `NewDatabase` (option b). The chosen physical layout is **`apps/api/auth/types/`** (the primary path the bead description listed first), not the `shared/authtypes/` fallback. Encore's parser accepts the layout — verified empirically with `encore check`, which builds the application graph, analyses service topology, and compiles the source tree successfully.

**SPEC §3.1 invariant preserved**: `auth` remains the sole migration-owner; `sqldb.NewDatabase("unblock", ...)` is still called exactly once across the workspace, in `apps/api/auth/db.go`. The new `auth/types` sub-package imports zero `encore.dev/*` packages and declares no infrastructure resources or APIs. Cross-package access from rbac, mcp, etc. continues to use either the cross-service `sqldb.Named("unblock")` pattern (Encore-services) or the `rbac.Bind(*sqldb.Database)` injection setter from the unblock-tv8.4 DEVIATION (shared/rbac).

### Decisions

1. Layout `auth/types/` over `shared/authtypes/` — confirmed empirically via `encore check`.
2. `rbac.go` and `rbac_test.go` spell the type as `types.Identity` internally (the DIRECTIVE listed `rbac.go` among consumer call sites that should keep `auth.Identity` literal, but importing `encore.app/auth` from rbac re-triggers exactly the panic this bead removes — the constraint and the goal are mutually exclusive at this one site). The SPEC §10.1 *surface* (literal `auth.Identity` as the function-signature spelling visible to Encore-service consumers like `org.go`) is preserved via the type alias; rbac is the implementation, observationally equivalent through Go alias structural identity.

### Deviations

1. Fixed two pre-existing assertion bugs in `TestWhere_InjectionDocumentation_NoRuntimeSanitiser` — see the DEVIATION comment on the bead. Spec/contract intent unchanged; only the assertion shape changed.

### Verification

- `go test ./apps/api/shared/rbac/...` PASSES under plain `go test` — primary acceptance criterion. Was a panic before this patch.
- `go test -race ./apps/api/shared/...` passes.
- `go test ./apps/api/shared/lint/...` passes — analysistest fake at `testdata/src/encore.app/shared/rbac/rbac.go` continues to work unchanged (it has its own stand-in Identity, never imports the real auth package).
- `go fmt ./...`, `go vet ./...`, `go build ./...` all clean.
- `encore check` builds the application graph and compiles the source tree — Encore parser accepts the `auth/types` layout. Only the local cluster bring-up step fails because Docker is not installed, which is precisely the scenario this bead enables tests to bypass; CI runs `encore check` and `encore test ./...` with Docker.

### Test plan

- [x] `cd apps/api && go test ./shared/rbac/...` (no Docker) passes
- [x] `cd apps/api && go test -race ./shared/...` passes
- [x] `cd apps/api && go fmt ./...` clean
- [x] `cd apps/api && go vet ./...` clean
- [x] `cd apps/api && go build ./...` clean
- [x] `cd apps/api && encore check` builds graph and compiles (Docker-step failure expected locally)
- [ ] CI: `golangci-lint run --max-warnings 0` (gate runs on CI; binary not available locally)
- [ ] CI: `encore test ./...` Docker-backed full run