### PR TITLE
unblock-tv8.35: Harden rbac.For() table argument against SQL injection

### DIFF
--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -12,10 +12,13 @@
 #   - no_direct_is_ready_write — rejects UPDATE statements writing
 #     workitems.items.is_ready or pipeline_stage outside the cascade
 #     subscriber package (SPEC §11.3, unblock-tv8.4).
-#   - no_rbac_dynamic_clause — rejects runtime-constructed first
-#     arguments to rbac.ScopedQuery.Where; every clause string must be
-#     a Go string literal or untyped string constant (SPEC §10.1,
-#     unblock-tv8.33).
+#   - no_rbac_dynamic_clause — rejects runtime-constructed string
+#     arguments to rbac.ScopedQuery.Where (clause, arg index 0) AND
+#     rbac.For (table, arg index 1); both MUST be a Go string literal
+#     or untyped string constant (SPEC §10.1, unblock-tv8.33,
+#     unblock-tv8.35). The file/registration name retains the
+#     historical "clause" suffix; the analyzer's authoritative scope
+#     covers both call shapes.
 #
 # Operators who want the custom linters to participate in CI must:
 #
@@ -74,10 +77,13 @@ linters:
       no_rbac_dynamic_clause:
         type: module
         description: |
-          Rejects runtime-constructed first arguments to
-          rbac.ScopedQuery.Where; every clause string MUST be a Go
-          string literal or untyped string constant. Runtime values
-          flow through args... See SPEC §10.1 / unblock-tv8.33.
+          Rejects runtime-constructed string arguments to
+          rbac.ScopedQuery.Where (clause, arg 0) AND rbac.For (table,
+          arg 1); both MUST be a Go string literal or untyped string
+          constant. Runtime values destined for Where flow through
+          args...; the table identifier of For has no runtime channel
+          (SQL identifiers cannot be bound). See SPEC §10.1 /
+          unblock-tv8.33 / unblock-tv8.35.
         original-url: encore.app/shared/lint
   exclusions:
     rules:

--- a/apps/api/shared/lint/no_rbac_dynamic_clause.go
+++ b/apps/api/shared/lint/no_rbac_dynamic_clause.go
@@ -1,9 +1,21 @@
 // no_rbac_dynamic_clause.go — second project-local analyzer for the
 // unblock backend. Enforces SPEC §10.1's injection-safety invariant on
-// the rbac typed query builder: the first argument to
-// `(*encore.app/shared/rbac.ScopedQuery[T]).Where` MUST be a compile-time
-// string constant. Every runtime value flows through the `args...`
-// variadic; the clause text is never user-controlled.
+// the rbac typed query builder against TWO call shapes:
+//
+//   - `(*encore.app/shared/rbac.ScopedQuery[T]).Where(clause, args...)`
+//     — first argument (clause, index 0) MUST be a compile-time string
+//     constant (unblock-tv8.33).
+//   - `encore.app/shared/rbac.For[T](identity, table)` — second
+//     argument (table, index 1) MUST be a compile-time string constant
+//     (unblock-tv8.35). The table identifier is concatenated verbatim
+//     into the FROM clause AND interpolated into the canonical scope
+//     predicate (`<table>.org_id = $1`); a runtime value rewrites both
+//     sinks and silently bypasses tenant isolation, exactly the same
+//     class of footgun Where guards against.
+//
+// Every runtime value flows through args... (Where) or is forbidden
+// outright (For has no positional bind channel for table — table is a
+// SQL identifier, not a value).
 //
 // Why a static analyzer (and not a runtime check, and not a wrapper
 // type):
@@ -17,13 +29,13 @@
 //     missed escape leaks across orgs. The only correctness-preserving
 //     gate is "no runtime construction permitted at all", which is a
 //     compile-time property the analyzer enforces.
-//   - Wrapper type (a `SafeClause string` type with package-private
-//     constructor): would require a SPEC §10.1 amendment because it
-//     changes the locked Where signature. Investigation
-//     (unblock-tv8.33) explicitly recommended the analyzer path
-//     instead.
+//   - Wrapper type (a `SafeClause string` or `SafeTable string` type
+//     with package-private constructor): would require a SPEC §10.1
+//     amendment because it changes the locked Where/For signature.
+//     Investigation (unblock-tv8.33, unblock-tv8.35) explicitly
+//     recommended the analyzer path instead.
 //
-// Detection rules (the only acceptable forms for the FIRST argument):
+// Detection rules (the only acceptable forms for the guarded argument):
 //
 //   - `*ast.BasicLit` of `token.STRING` kind — covers regular ("…") and
 //     back-quoted (`…`) Go string literals.
@@ -45,14 +57,27 @@
 //     are applied; everything else passes through verbatim and fails
 //     the "is constant" check.
 //
-// Receiver-type resolution: the analyzer uses `pass.TypesInfo.Selections`
-// to extract the receiver's type, then walks through *types.Pointer and
-// *types.Named to land on the underlying generic type. The match
-// requires (a) the receiver type's package import path is exactly
-// `encore.app/shared/rbac` and (b) the method's name is `Where`.
-// Name-only matching is explicitly avoided — a `Where` method on an
-// unrelated query builder elsewhere in the backend would otherwise
-// false-positive.
+// Resolution paths (two distinct go/types maps):
+//
+//   - Where (method-call): `pass.TypesInfo.Selections` records selectors
+//     that resolve to a method or field on a typed receiver. The
+//     analyzer walks Selection.Recv() through *types.Pointer / *types.Named
+//     to confirm the receiver's package path is `encore.app/shared/rbac`
+//     and method name is `Where`. Name-only matching is explicitly
+//     avoided — a `Where` method on an unrelated query builder elsewhere
+//     in the backend would otherwise false-positive.
+//   - For (package-level generic func): `Selections` does NOT capture
+//     package-qualified identifier resolution; `pass.TypesInfo.Uses`
+//     (equivalently `ObjectOf`) is the correct map. The analyzer
+//     resolves the SelectorExpr's selector ident to a *types.Func and
+//     asserts its package path is `encore.app/shared/rbac` and name is
+//     `For`. Critical AST nuance: `rbac.For[row](id, table)` parses as
+//     CallExpr{Fun: IndexExpr{X: SelectorExpr{rbac.For}, Index: row},
+//     Args: [id, table]} (single type arg) or IndexListExpr (multiple
+//     type args, Go 1.18+). The walker MUST unwrap *ast.IndexExpr and
+//     *ast.IndexListExpr before reaching the SelectorExpr; a naive
+//     match on call.Fun.(*ast.SelectorExpr) silently misses every For
+//     call site because the IndexExpr wraps it.
 package lint
 
 import (
@@ -75,30 +100,49 @@ const rbacPackagePath = "encore.app/shared/rbac"
 // rbac.ScopedQuery[T] whose first argument the analyzer guards.
 const rbacWhereMethod = "Where"
 
+// rbacForFunc is the locked SPEC §10.1 package-level constructor name on
+// rbac whose SECOND argument (table) the analyzer guards. For is
+// generic, so the AST shape at the call site is
+// CallExpr{Fun: IndexExpr|IndexListExpr{X: SelectorExpr{rbac.For}}}.
+const rbacForFunc = "For"
+
 // NoRbacDynamicClauseAnalyzer is the exported analyzer instance. The
 // golangci-lint module-plugin loader picks this up via the cmd/
-// entry point.
+// entry point. Despite the file/registration name retaining the
+// historical "clause" suffix (kept stable to avoid churning the
+// golangci-lint custom-binary registration), the analyzer guards both
+// `rbac.ScopedQuery.Where` (clause, arg index 0) and `rbac.For` (table,
+// arg index 1). The Doc string is the authoritative scope.
 var NoRbacDynamicClauseAnalyzer = &analysis.Analyzer{
 	Name:     "no_rbac_dynamic_clause",
-	Doc:      "rejects runtime-constructed first arguments to rbac.ScopedQuery.Where; clause must be a Go string literal or untyped string constant (SPEC §10.1, unblock-tv8.33)",
+	Doc:      "rejects runtime-constructed string arguments to rbac.ScopedQuery.Where (clause, arg 0) and rbac.For (table, arg 1); both MUST be a Go string literal or untyped string constant (SPEC §10.1, unblock-tv8.33, unblock-tv8.35)",
 	Run:      runNoRbacDynamicClause,
 	URL:      "https://github.com/websublime/unblock/blob/main/docs/specs/01-spec-backend-mvp.md#101-rbac-pkgrbac-nfr-2",
 	Requires: nil,
 }
 
 // runNoRbacDynamicClause implements analysis.Analyzer.Run. Walks every
-// CallExpr in every file, filters to calls whose selector resolves to
-// (*encore.app/shared/rbac.ScopedQuery[T]).Where via go/types, and
-// verifies the FIRST argument is a compile-time string constant.
+// CallExpr in every file and applies two parallel detection paths:
+//
+//   - Method calls whose selector resolves to
+//     (*encore.app/shared/rbac.ScopedQuery[T]).Where via
+//     pass.TypesInfo.Selections — guards arg index 0 (clause).
+//   - Package-level generic calls whose selector resolves (after
+//     unwrapping *ast.IndexExpr / *ast.IndexListExpr for the type-arg
+//     wrapper) to encore.app/shared/rbac.For via pass.TypesInfo.Uses —
+//     guards arg index 1 (table).
+//
+// Both paths share isCompileTimeStringConstant as the gate.
 func runNoRbacDynamicClause(pass *analysis.Pass) (interface{}, error) {
 	if pass.Pkg == nil {
 		return nil, nil //nolint:nilnil // analyzer convention
 	}
-	// The rbac package's own tests call Where with literals, but they
-	// also exercise internal helpers. Skip the package itself so the
-	// analyzer never analyses its own subject — false positives would
-	// be confusing and the package's own correctness is governed by
-	// the doc-hardening pass (rbac.go SECURITY block on Where).
+	// The rbac package's own tests call Where/For with literals, but
+	// they also exercise internal helpers. Skip the package itself so
+	// the analyzer never analyses its own subject — false positives
+	// would be confusing and the package's own correctness is governed
+	// by the doc-hardening pass (rbac.go SECURITY blocks on Where and
+	// For).
 	if pass.Pkg.Path() == rbacPackagePath {
 		return nil, nil //nolint:nilnil
 	}
@@ -109,30 +153,111 @@ func runNoRbacDynamicClause(pass *analysis.Pass) (interface{}, error) {
 			if !ok {
 				return true
 			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
+
+			// Detection path A: method call on
+			// (*rbac.ScopedQuery[T]).Where. The Fun is a bare
+			// SelectorExpr (no IndexExpr wrapper — Where is not
+			// generic).
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+				if sel.Sel != nil && sel.Sel.Name == rbacWhereMethod &&
+					isRbacScopedQueryReceiver(pass.TypesInfo, sel) {
+					if len(call.Args) == 0 {
+						// Wrong arity — go/types complains
+						// elsewhere; this analyzer is only concerned
+						// with the safety contract.
+						return true
+					}
+					first := call.Args[0]
+					if !isCompileTimeStringConstant(pass.TypesInfo, first) {
+						pass.ReportRangef(first, "rbac.Where: first argument must be a Go string literal or untyped string constant; runtime values MUST flow through args... — see SPEC §10.1 / unblock-tv8.33")
+					}
+					return true
+				}
 			}
-			if sel.Sel == nil || sel.Sel.Name != rbacWhereMethod {
-				return true
+
+			// Detection path B: package-level generic call to rbac.For.
+			// AST shape: CallExpr{Fun: IndexExpr|IndexListExpr{X:
+			// SelectorExpr{rbac.For}}, Args: [identity, table]}. The
+			// SelectorExpr is wrapped in the type-argument node and
+			// must be unwrapped first.
+			if sel := unwrapForSelector(call.Fun); sel != nil {
+				if sel.Sel != nil && sel.Sel.Name == rbacForFunc &&
+					isRbacForFunc(pass.TypesInfo, sel) {
+					// For has signature For[T](identity, table) — table
+					// is the SECOND positional arg. Require len > 1.
+					if len(call.Args) < 2 {
+						return true
+					}
+					second := call.Args[1]
+					if !isCompileTimeStringConstant(pass.TypesInfo, second) {
+						pass.ReportRangef(second, "rbac.For: second argument (table) must be a Go string literal or untyped string constant; runtime values would breach tenant isolation by rewriting the FROM clause and scope predicate — see SPEC §10.1 / unblock-tv8.35")
+					}
+					return true
+				}
 			}
-			if !isRbacScopedQueryReceiver(pass.TypesInfo, sel) {
-				return true
-			}
-			if len(call.Args) == 0 {
-				// Wrong arity — go/types will complain elsewhere; this
-				// analyzer is only concerned with the safety contract.
-				return true
-			}
-			first := call.Args[0]
-			if isCompileTimeStringConstant(pass.TypesInfo, first) {
-				return true
-			}
-			pass.ReportRangef(first, "rbac.Where: first argument must be a Go string literal or untyped string constant; runtime values MUST flow through args... — see SPEC §10.1 / unblock-tv8.33")
+
 			return true
 		})
 	}
 	return nil, nil //nolint:nilnil
+}
+
+// unwrapForSelector returns the underlying *ast.SelectorExpr for a
+// (potentially generic) call's Fun expression, or nil when the shape
+// does not match.
+//
+// Three accepted shapes:
+//
+//   - *ast.SelectorExpr — non-generic call (kept for symmetry; rbac.For
+//     is generic so this branch never hits in production but is cheap
+//     and keeps the helper composable).
+//   - *ast.IndexExpr{X: *ast.SelectorExpr} — single type-argument
+//     instantiation, e.g. `rbac.For[Item](id, "items")`.
+//   - *ast.IndexListExpr{X: *ast.SelectorExpr} — multi type-argument
+//     instantiation (Go 1.18+), kept for forward compatibility.
+//
+// Anything else returns nil so the caller short-circuits the For
+// detection branch cleanly.
+func unwrapForSelector(fun ast.Expr) *ast.SelectorExpr {
+	switch f := fun.(type) {
+	case *ast.SelectorExpr:
+		return f
+	case *ast.IndexExpr:
+		if sel, ok := f.X.(*ast.SelectorExpr); ok {
+			return sel
+		}
+	case *ast.IndexListExpr:
+		if sel, ok := f.X.(*ast.SelectorExpr); ok {
+			return sel
+		}
+	}
+	return nil
+}
+
+// isRbacForFunc returns true when sel resolves to the package-level
+// generic function encore.app/shared/rbac.For. Resolution uses
+// pass.TypesInfo.Uses (equivalently ObjectOf) on the selector ident:
+// Selections is the wrong map for package-qualified identifiers — it
+// records typed-receiver selectors, while a package-level func's
+// SelectorExpr resolves through Uses. Mismatch silently fails:
+// Selections.Lookup on a package-qualified ident returns no entry, so
+// using Selections here would make the rule a no-op for For.
+func isRbacForFunc(info *types.Info, sel *ast.SelectorExpr) bool {
+	if info == nil || sel == nil || sel.Sel == nil {
+		return false
+	}
+	obj := info.ObjectOf(sel.Sel)
+	if obj == nil {
+		return false
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return false
+	}
+	if fn.Pkg() == nil {
+		return false
+	}
+	return fn.Pkg().Path() == rbacPackagePath && fn.Name() == rbacForFunc
 }
 
 // isRbacScopedQueryReceiver returns true when sel resolves to a method

--- a/apps/api/shared/lint/no_rbac_dynamic_clause_test.go
+++ b/apps/api/shared/lint/no_rbac_dynamic_clause_test.go
@@ -4,20 +4,26 @@
 //
 //   - encore.app/shared/rbac: a stub rbac package matching the locked
 //     SPEC §10.1 surface. Imported by both bad/good fixtures so the
-//     analyzer's receiver-type resolution sees the canonical package
-//     path (`encore.app/shared/rbac`) and matches consistently.
-//   - rbacclausebad: every call to rbac.Where with a runtime first
-//     argument; each carries a `// want` annotation matching the
-//     analyzer's diagnostic.
+//     analyzer's receiver-type resolution (Where) and Uses-based
+//     package-path resolution (For) see the canonical package path
+//     (`encore.app/shared/rbac`) and match consistently.
+//   - rbacclausebad: every call to rbac.Where with a runtime FIRST
+//     argument AND every call to rbac.For with a runtime SECOND
+//     argument (table); each carries a `// want` annotation matching
+//     the analyzer's diagnostic for the relevant call shape.
 //   - rbacclausegood: literals, named constants, composed constants,
-//     parenthesised literals, and a same-named method on an unrelated
-//     receiver type. No diagnostics expected.
+//     parenthesised literals (for both Where clause and For table),
+//     plus a same-named `Where` method on an unrelated receiver type
+//     and a same-named `For` function in an unrelated package. No
+//     diagnostics expected.
 //
-// The receiver-resolution test in the good fixture (`unrelatedBuilder`
-// with its own Where method) is the explicit guard against
-// name-only matching: SPEC §10.1's investigation flagged this as a
-// MEDIUM risk, and the green-fixture failure mode would be a clear
-// signal that the go/types resolution path regressed.
+// The resolution-path tests in the good fixture (`unrelatedBuilder`
+// with its own Where method, and the local `For` generic in the
+// rbacclausegood package) are the explicit guards against name-only
+// matching: SPEC §10.1's investigation flagged this as a MEDIUM risk
+// for both call shapes. A green-fixture failure mode would be a clear
+// signal that either the go/types Selections path (Where) or the
+// Uses/IndexExpr-unwrap path (For) regressed.
 package lint
 
 import (
@@ -28,8 +34,13 @@ import (
 
 // TestNoRbacDynamicClause_FlagsRuntimeClauses runs the analyzer
 // against the rbacclausebad fixture and asserts every `// want`
-// annotation is satisfied — vars, BinaryExpr concatenation,
-// fmt.Sprintf, function returns, and struct selectors all flag.
+// annotation is satisfied. Covers BOTH guarded call shapes:
+//
+//   - rbac.ScopedQuery.Where (clause arg, index 0): vars, BinaryExpr
+//     concatenation, fmt.Sprintf, function returns, struct selectors.
+//   - rbac.For (table arg, index 1): same five runtime shapes on the
+//     SECOND positional arg. The analyzer must unwrap the *ast.IndexExpr
+//     wrapping the type-argument [row] before reaching the SelectorExpr.
 func TestNoRbacDynamicClause_FlagsRuntimeClauses(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, NoRbacDynamicClauseAnalyzer, "rbacclausebad")
@@ -37,9 +48,10 @@ func TestNoRbacDynamicClause_FlagsRuntimeClauses(t *testing.T) {
 
 // TestNoRbacDynamicClause_AllowsCompileTimeConstants runs the analyzer
 // against the rbacclausegood fixture and asserts NO diagnostic fires.
-// Covers: BasicLit (regular and back-quoted), named const, composed
-// const, parenthesised literal, and an unrelated `Where` method on a
-// non-rbac receiver type.
+// Covers BOTH guarded call shapes for: BasicLit (regular and
+// back-quoted), named const, composed const, parenthesised literal,
+// plus an unrelated `Where` method on a non-rbac receiver type and an
+// unrelated `For` generic function in a non-rbac package.
 func TestNoRbacDynamicClause_AllowsCompileTimeConstants(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, NoRbacDynamicClauseAnalyzer, "rbacclausegood")

--- a/apps/api/shared/lint/testdata/src/rbacclausebad/rbacclausebad.go
+++ b/apps/api/shared/lint/testdata/src/rbacclausebad/rbacclausebad.go
@@ -1,7 +1,7 @@
 // Fixture for analysistest: a package whose calls to
-// rbac.ScopedQuery.Where pass non-literal first arguments. Every
-// flagged call carries a "want" annotation matching the analyzer's
-// diagnostic message.
+// rbac.ScopedQuery.Where (clause, arg 0) and rbac.For (table, arg 1)
+// pass non-literal arguments. Every flagged call carries a "want"
+// annotation matching the analyzer's diagnostic message.
 package rbacclausebad
 
 import (
@@ -14,6 +14,8 @@ import (
 type row struct {
 	ID string
 }
+
+// -- rbac.ScopedQuery.Where (clause arg, index 0) -----------------------
 
 // Var as the first argument — runtime value, must flag.
 func badVar(ctx context.Context, id rbac.Identity, userClause string) ([]row, error) {
@@ -56,4 +58,52 @@ func badSelector(ctx context.Context, id rbac.Identity, f filter) ([]row, error)
 	return rbac.For[row](id, "workitems.items").
 		Where(f.Clause). // want `rbac\.Where: first argument must be a Go string literal or untyped string constant`
 		Run(ctx)
+}
+
+// -- rbac.For (table arg, index 1) -------------------------------------
+//
+// All five shapes mirror the Where bad cases above, but on the SECOND
+// positional argument of For. The analyzer must unwrap *ast.IndexExpr
+// (the [row] type-argument) to reach the SelectorExpr, then resolve via
+// pass.TypesInfo.Uses (NOT Selections — Selections is method-only).
+
+// Var as the table argument — runtime value, must flag.
+func badForVarTable(ctx context.Context, id rbac.Identity, userTable string) ([]row, error) {
+	return rbac.For[row](id, userTable). // want `rbac\.For: second argument \(table\) must be a Go string literal or untyped string constant`
+						Where("status = $1", "Ready").
+						Run(ctx)
+}
+
+// Runtime concatenation of the table identifier — must flag.
+func badForConcatTable(ctx context.Context, id rbac.Identity, schema string) ([]row, error) {
+	return rbac.For[row](id, schema+".items"). // want `rbac\.For: second argument \(table\) must be a Go string literal or untyped string constant`
+							Where("status = $1", "Ready").
+							Run(ctx)
+}
+
+// fmt.Sprintf return — runtime value, must flag.
+func badForSprintfTable(ctx context.Context, id rbac.Identity, schema string) ([]row, error) {
+	return rbac.For[row](id, fmt.Sprintf("%s.items", schema)). // want `rbac\.For: second argument \(table\) must be a Go string literal or untyped string constant`
+									Where("status = $1", "Ready").
+									Run(ctx)
+}
+
+// Function-return as table — runtime value, must flag.
+func buildTable() string { return "workitems.items" }
+
+func badForFuncReturnTable(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, buildTable()). // want `rbac\.For: second argument \(table\) must be a Go string literal or untyped string constant`
+						Where("status = $1", "Ready").
+						Run(ctx)
+}
+
+// Struct-field selector as table — runtime value, must flag.
+type tableSpec struct {
+	Name string
+}
+
+func badForSelectorTable(ctx context.Context, id rbac.Identity, t tableSpec) ([]row, error) {
+	return rbac.For[row](id, t.Name). // want `rbac\.For: second argument \(table\) must be a Go string literal or untyped string constant`
+						Where("status = $1", "Ready").
+						Run(ctx)
 }

--- a/apps/api/shared/lint/testdata/src/rbacclausegood/rbacclausegood.go
+++ b/apps/api/shared/lint/testdata/src/rbacclausegood/rbacclausegood.go
@@ -1,7 +1,8 @@
 // Fixture for analysistest: a package whose calls to
-// rbac.ScopedQuery.Where pass acceptable first arguments. The
-// analyzer must NOT fire on any call here (no "want" annotations,
-// which analysistest interprets as "expect zero diagnostics").
+// rbac.ScopedQuery.Where (clause arg) and rbac.For (table arg) pass
+// acceptable arguments. The analyzer must NOT fire on any call here
+// (no "want" annotations, which analysistest interprets as "expect
+// zero diagnostics").
 package rbacclausegood
 
 import (
@@ -13,6 +14,8 @@ import (
 type row struct {
 	ID string
 }
+
+// -- rbac.ScopedQuery.Where (clause arg, index 0) -----------------------
 
 // Plain double-quoted string literal — the canonical form.
 func goodLiteral(ctx context.Context, id rbac.Identity) ([]row, error) {
@@ -70,4 +73,71 @@ func goodUnrelatedWhere(b *unrelatedBuilder, userClause string) {
 	// userClause is runtime — would be flagged if the analyzer
 	// matched by name. Receiver-type resolution must filter this out.
 	b.Where(userClause)
+}
+
+// -- rbac.For (table arg, index 1) -------------------------------------
+//
+// Five shapes mirror the Where good cases. Each must NOT flag the
+// table argument. The analyzer's resolution path for For uses
+// pass.TypesInfo.Uses on the (unwrapped) selector ident; package-path
+// gate is `encore.app/shared/rbac`.
+
+// Plain double-quoted string literal as table — canonical form.
+func goodForLiteralTable(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, "workitems.items").
+		Where("status = $1", "Ready").
+		Run(ctx)
+}
+
+// Back-quoted (raw) string literal as table.
+func goodForRawLiteralTable(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, `deps.dependencies`).
+		Where("from_id = $1", "itm_x").
+		Run(ctx)
+}
+
+// Package-level untyped string constant as table.
+const itemsTable = "workitems.items"
+
+func goodForNamedConstTable(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, itemsTable).
+		Where("status = $1", "Ready").
+		Run(ctx)
+}
+
+// Constant expression composed of two string constants as table.
+const schemaPart = "workitems"
+const tablePart = ".items"
+const composedTable = schemaPart + tablePart
+
+func goodForComposedConstTable(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, composedTable).
+		Where("status = $1", "Ready").
+		Run(ctx)
+}
+
+// Parenthesised literal as table — unparen strips the wrapper.
+func goodForParenthesisedLiteralTable(ctx context.Context, id rbac.Identity) ([]row, error) {
+	return rbac.For[row](id, ("workitems.items")).
+		Where("status = $1", "Ready").
+		Run(ctx)
+}
+
+// A package-level generic `For` function on an UNRELATED package MUST
+// NOT false-positive — the analyzer's package-path gate is the
+// load-bearing check, name-only matching would otherwise flag any
+// `For` symbol elsewhere in the codebase.
+//
+// The fixture's local For below shares the same name and shape
+// (generic, second-arg string) as rbac.For but lives in this package
+// — pass.TypesInfo.Uses resolves it to a *types.Func whose Pkg() path
+// is `rbacclausegood`, NOT `encore.app/shared/rbac`. The resolution
+// gate filters it out.
+func For[T any](_ rbac.Identity, _ string) *T { return nil }
+
+func goodUnrelatedFor(id rbac.Identity, userTable string) {
+	// userTable is runtime — would be flagged if the analyzer matched
+	// by name on the For symbol. Package-path resolution must filter
+	// this out.
+	_ = For[row](id, userTable)
 }

--- a/apps/api/shared/rbac/rbac.go
+++ b/apps/api/shared/rbac/rbac.go
@@ -55,36 +55,37 @@
 //     and means a service that does not declare access to the unblock
 //     database fails at `encore check` time, not at runtime.
 //
-// Injection-safety invariant (SPEC §10.1, unblock-tv8.33):
+// Injection-safety invariant (SPEC §10.1, unblock-tv8.33, unblock-tv8.35):
 //
-//   - The first argument to Where MUST be a Go string literal or an
-//     untyped string constant — i.e. a value that is fixed at compile
-//     time. Every runtime value (request body, URL parameter, header,
-//     row from the database, anything user-controlled) MUST flow through
-//     the args... variadic, never through string concatenation into the
-//     clause text.
-//   - The clause string is concatenated verbatim into the assembled SQL
-//     statement (see build). There is no runtime validation, escaping,
-//     or sanitisation — the SQL string is opaque to Go. A clause
-//     fragment that contains user-controlled data fragments the WHERE
-//     predicate and silently bypasses the org_id scope guard installed
-//     by For. For a tenant-isolation gate this is fatal.
+//   - The first argument to Where (clause) AND the second argument to
+//     For (table) MUST each be a Go string literal or an untyped string
+//     constant — i.e. a value that is fixed at compile time. Every
+//     runtime value (request body, URL parameter, header, row from the
+//     database, anything user-controlled) is forbidden in either
+//     position; values destined for Where flow through the args...
+//     variadic, and the table identifier of For has no runtime channel
+//     at all (it is a SQL identifier, not a value).
+//   - Both strings are concatenated verbatim into the assembled SQL
+//     statement (see build): the clause into the WHERE chain, and the
+//     table into the FROM clause AND into the canonical scope predicate
+//     `<table>.org_id = $1`. There is no runtime validation, escaping,
+//     or sanitisation — the SQL string is opaque to Go. A runtime value
+//     in either position fragments the WHERE predicate and silently
+//     bypasses the org_id scope guard installed by For. For a
+//     tenant-isolation gate this is fatal.
 //   - The project-local static analyzer
 //     `apps/api/shared/lint/no_rbac_dynamic_clause.go` is the
-//     enforcement gate: it rejects any call to ScopedQuery.Where whose
-//     first argument is not a compile-time string constant. The
-//     analyzer is wired into `apps/api/.golangci.yml` and is also
-//     runnable directly via
-//     `go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...`.
+//     enforcement gate for BOTH call shapes: it rejects any call to
+//     ScopedQuery.Where whose first argument is not a compile-time
+//     string constant, and any call to rbac.For whose second argument
+//     (table) is not a compile-time string constant. The analyzer is
+//     wired into `apps/api/.golangci.yml` and is also runnable directly
+//     via `go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...`.
 //   - Runtime detection is fundamentally impossible: by the time the
 //     SQL string reaches build, Go has erased the difference between a
 //     literal and a runtime-constructed string. The analyzer is the
 //     only gate. Reviewers asking "why no runtime check" should consult
 //     this paragraph.
-//   - The same caller-trust model applies to the `table` argument of
-//     For — see its doc-comment and unblock-tv8.33's risk note on the
-//     table parameter (out of scope for that bead but called out here
-//     for completeness).
 //
 // Compile-time property (SPEC §10.1, AC-1).
 //
@@ -234,10 +235,37 @@ type userClause struct {
 // library's database/sql.DB.Prepare. This keeps the fluent surface
 // chainable without panic-paths.
 //
-// table must be a fully-qualified `<schema>.<table>` identifier. Caller
-// is responsible for using a valid identifier; SQL-injection-safety on
-// the table parameter rests on the linter at apps/api/shared/lint/ and
-// on code review (SPEC §10.1 acceptance criterion #3).
+// table must be a fully-qualified `<schema>.<table>` identifier.
+//
+// SECURITY (SPEC §10.1, unblock-tv8.35).
+//
+// The table argument MUST be a Go string literal or an untyped string
+// constant fixed at compile time. SQL identifiers have NO bind-parameter
+// channel in PostgreSQL — table cannot be passed via args... like a
+// value. A runtime-constructed table string is concatenated verbatim
+// into BOTH the FROM clause (build at line ~370) and the canonical
+// scope predicate `fmt.Sprintf("%s.org_id = $1", table)` (For body
+// below). A user-controlled table value rewrites both sinks and
+// silently bypasses tenant isolation — exactly the same class of
+// footgun unblock-tv8.33 closed for Where.
+//
+//	// CORRECT — string literals and named constants:
+//	rbac.For[Item](id, "workitems.items").Where(...).Run(ctx)
+//
+//	const itemsTable = "workitems.items"
+//	rbac.For[Item](id, itemsTable).Where(...).Run(ctx)
+//
+//	// WRONG — runtime construction breaches scope:
+//	rbac.For[Item](id, req.Table)                       // injection
+//	rbac.For[Item](id, schema + ".items")               // injection
+//	rbac.For[Item](id, fmt.Sprintf("%s.items", schema)) // injection
+//
+// The analyzer at `apps/api/shared/lint/no_rbac_dynamic_clause.go`
+// rejects every non-literal second argument to For at lint time,
+// alongside the same gate on Where's first argument. Runtime validation
+// is impossible — the SQL string is opaque to Go by the time it reaches
+// build. Bypassing the analyzer (e.g. //nolint suppression) on this
+// function is forbidden and a code-review failure.
 func For[T any](identity types.Identity, table string) *ScopedQuery[T] {
 	q := &ScopedQuery[T]{
 		identity: identity,

--- a/apps/api/shared/rbac/rbac_test.go
+++ b/apps/api/shared/rbac/rbac_test.go
@@ -250,6 +250,97 @@ func TestWhere_InjectionDocumentation_NoRuntimeSanitiser(t *testing.T) {
 	}
 }
 
+// TestFor_TableInjectionDocumentation pins the runtime behaviour of
+// For in the presence of a hostile, dynamically-constructed table
+// identifier. These tests EXIST TO DOCUMENT THE INVARIANT, not to
+// exercise a defence: the rbac builder has no runtime gate against SQL
+// injection on the table argument, by design — see the SECURITY block
+// on For (SPEC §10.1, unblock-tv8.35).
+//
+// The production-grade gate is the static analyzer at
+// `apps/api/shared/lint/no_rbac_dynamic_clause.go`, which rejects any
+// non-literal SECOND argument to rbac.For at lint time (alongside the
+// same gate on Where's first argument). These tests confirm that:
+//
+//  1. If the analyzer is bypassed (e.g. //nolint suppression, which is
+//     forbidden but possible), a hostile table value is concatenated
+//     verbatim into BOTH the assembled FROM clause and the canonical
+//     scope predicate `<table>.org_id = $1` — i.e. the leak is real,
+//     and a single hostile string can rewrite both sinks at once.
+//  2. The scope predicate is still emitted in shape, but its target
+//     identifier is now caller-controlled and an attacker can use SQL
+//     meta-characters (semicolon, line-comment, OR-true) to neutralise
+//     the org_id filter, bypass tenant isolation, or terminate the
+//     statement and append arbitrary SQL.
+//
+// If either assertion ever flips (e.g. a future runtime sanitiser is
+// added on the table argument), the test must be re-evaluated —
+// runtime sanitisation of arbitrary SQL identifiers is brittle and has
+// historically been the wrong gate for tenant isolation. The analyzer
+// remains the contractual gate.
+func TestFor_TableInjectionDocumentation_HostileTableEmitsVerbatim(t *testing.T) {
+	// A hostile table value that closes the scope predicate with a
+	// line-comment marker, terminates the statement with a semicolon,
+	// and appends arbitrary DDL. The analyzer would reject this at
+	// lint time because the value is a `var hostile := ...` — but the
+	// runtime builder has no such gate. We construct the value via a
+	// literal here only so the test itself compiles cleanly; the
+	// assertion is that build() emits the bytes verbatim regardless of
+	// source.
+	const hostileTable = "workitems.items; DROP TABLE x --"
+
+	q := For[struct{ ID string }](fakeIdentity("org_alpha"), hostileTable)
+	sql, _ := q.build()
+
+	// The hostile bytes survive into the assembled FROM clause
+	// verbatim.
+	if !strings.Contains(sql, "FROM "+hostileTable+" WHERE") {
+		t.Fatalf("hostile table did NOT appear verbatim in FROM clause — runtime sanitiser detected on table arg, contract changed: %q", sql)
+	}
+	// The scope predicate is also rewritten with the hostile bytes,
+	// because For interpolates `<table>.org_id = $1` via fmt.Sprintf.
+	// The line-comment marker (` -- `) inside hostileTable now sits
+	// inside the predicate and (with PostgreSQL's line-comment
+	// semantics in the assembled statement) neutralises everything
+	// downstream — the org_id filter is gone in the SQL parse tree.
+	if !strings.Contains(sql, hostileTable+".org_id = $1") {
+		t.Errorf("scope predicate not interpolated with hostile table verbatim: %q", sql)
+	}
+}
+
+// TestFor_TableInjectionDocumentation_NoRuntimeSanitiser is a paired
+// regression: it asserts that classic injection meta-characters (';',
+// '--', '/*', stray quote, OR-true) survive verbatim through For ->
+// build() on the table argument. Pinning this behaviour is the
+// regression net if a future contributor adds a runtime sanitiser and
+// silently changes the contract documented on For. Runtime
+// sanitisation is the wrong gate for this surface; the analyzer is the
+// only acceptable defence.
+func TestFor_TableInjectionDocumentation_NoRuntimeSanitiser(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		table string
+		// wantSubstr is a fragment of the hostile table chosen so the
+		// assertion pins meta-character survival in BOTH the FROM
+		// clause and the interpolated scope predicate.
+		wantSubstr string
+	}{
+		{name: "semicolon", table: "workitems.items; DROP TABLE x", wantSubstr: "; DROP TABLE x"},
+		{name: "line_comment", table: "workitems.items -- malicious", wantSubstr: " -- malicious"},
+		{name: "block_comment", table: "workitems.items /* malicious */", wantSubstr: " /* malicious */"},
+		{name: "stray_quote", table: "workitems.items OR title = 'oops", wantSubstr: " OR title = 'oops"},
+		{name: "or_true", table: "workitems.items WHERE 1=1 OR ", wantSubstr: " WHERE 1=1 OR "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			q := For[struct{ ID string }](fakeIdentity("org_alpha"), tc.table)
+			sql, _ := q.build()
+			if !strings.Contains(sql, tc.wantSubstr) {
+				t.Fatalf("hostile pattern %q not found in assembled SQL — runtime sanitiser detected on table arg, see SPEC §10.1: got %q", tc.wantSubstr, sql)
+			}
+		})
+	}
+}
+
 // TestExportedFields_StructLayout confirms the reflection helper
 // returns exported fields in declaration order and skips unexported
 // ones. Exercises the same code path scanAll uses against generic T.

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -2035,14 +2035,17 @@ seeded fixture and asserts:
   rule under `apps/api/shared/lint/no_direct_is_ready_write.go` rejects
   any UPDATE statement targeting `workitems.items.is_ready` or
   `pipeline_stage` outside `apps/api/deps/cascade_subscriber.go`.)
-- [ ] `rbac.ScopedQuery.Where` is never called with a runtime-constructed
-  clause string — every first argument MUST be a Go string literal or
-  untyped string constant; runtime values flow through `args...`
-  exclusively. (Static analysis: `golangci-lint` custom linter rule
-  under `apps/api/shared/lint/no_rbac_dynamic_clause.go` rejects any
-  non-literal first argument across the unblock backend. Locked SPEC
-  §10.1 surface is unchanged; the analyzer is a meta-guard.
-  unblock-tv8.33.)
+- [ ] `rbac.For` and `rbac.ScopedQuery.Where` are never called with
+  runtime-constructed string arguments — every table identifier (For
+  arg 2) AND every clause string (Where arg 1) MUST be a Go string
+  literal or untyped string constant. Runtime values destined for
+  Where flow through `args...` exclusively; the table identifier of
+  For has no runtime channel (SQL identifiers cannot be bound).
+  (Static analysis: `golangci-lint` custom linter rule under
+  `apps/api/shared/lint/no_rbac_dynamic_clause.go` rejects any
+  non-literal call site across the unblock backend for BOTH call
+  shapes. Locked SPEC §10.1 surface is unchanged; the analyzer is a
+  meta-guard. unblock-tv8.33, unblock-tv8.35.)
 - [ ] `deps.cascade_events` insert is idempotent on re-delivery (property
   test: re-deliver every `CascadeRequested` event twice; assert post-state
   is byte-identical and exactly one row exists per `(event_id,


### PR DESCRIPTION
## unblock-tv8.35: Harden rbac.For() table argument against SQL injection (symmetrise with Where guard)

Extends the no_rbac_dynamic_clause analyzer (installed by tv8.33 for `rbac.ScopedQuery.Where`) to also guard the second argument of `rbac.For` (table). Same class of footgun: a runtime-controlled table identifier rewrites both the FROM clause and the canonical scope predicate `<table>.org_id = $1`, silently bypassing tenant isolation.

### What was done
- Single-analyzer dual-detection: kept `no_rbac_dynamic_clause` as the registration tag; widened scope to cover both `Where` (clause, arg 0, method-call via Selections) and `For` (table, arg 1, package-level generic via Uses with IndexExpr/IndexListExpr unwrap).
- `For()` doc-comment: mirrored Where's SECURITY block with CORRECT/WRONG examples.
- Package-doc Injection-safety invariant: turned the tv8.33 forward-reference into a concrete "enforced for both" claim.
- SPEC §11.3 bullet extended to cover For + Where in one entry; cites unblock-tv8.35.
- analysistest fixtures: 5 new bad shapes + 5 new good shapes for For; new unrelated-package-level-For false-positive guard.
- `rbac_test.go`: `TestFor_TableInjectionDocumentation` pair pins verbatim-emit behaviour into both sinks.

### Files changed
- apps/api/shared/lint/no_rbac_dynamic_clause.go
- apps/api/shared/lint/no_rbac_dynamic_clause_test.go
- apps/api/shared/lint/testdata/src/rbacclausebad/rbacclausebad.go
- apps/api/shared/lint/testdata/src/rbacclausegood/rbacclausegood.go
- apps/api/shared/rbac/rbac.go
- apps/api/shared/rbac/rbac_test.go
- apps/api/.golangci.yml
- docs/specs/01-spec-backend-mvp.md

### Decisions
- DECISION: Chose path (A) — single-analyzer extension — over (B) sibling analyzer no_rbac_dynamic_table.go. Reasons: investigation explicitly recommended (A); single golangci-lint registration; reuses isCompileTimeStringConstant verbatim; avoids touching tv8.31's v2 config-schema work in flight. Kept analyzer name `no_rbac_dynamic_clause` (registration tag is stable; Doc string is authoritative scope).

### Deviations
None — implemented as spec. Investigation Approach (A) followed end-to-end. Locked SPEC §10.1 surface (For/Where/Run) byte-unchanged.

### Tests
- `go test ./shared/lint/... ./shared/rbac/...` PASS (race detector PASS).
- `go run ./shared/lint/cmd/no_rbac_dynamic_clause ./...` reports zero findings against apps/api (confirms no real `rbac.For` call sites yet — matches the pre-tv8.7/tv8.8 timing constraint in the bead).
- Bad fixture: 5 For + 5 Where `want` annotations all satisfied.
- Good fixture: 10 For + 5 Where + 1 unrelated-method + 1 unrelated-package For — zero diagnostics emitted (receiver/package-path resolution gates verified).