### PR TITLE
unblock-tv8.7: B-1 auth service — API key auth, OAuth exchange, auth handler

### DIFF
--- a/apps/api/auth/apikey.go
+++ b/apps/api/auth/apikey.go
@@ -1,0 +1,111 @@
+// API key format helpers for the MCP Bearer auth hot path.
+//
+// Locked format (SPEC §4.3.2 lines 453-460): `unblock_pat_<base32-32-byte>`.
+//
+//	rawKey   = "unblock_pat_" || base32(crypto/rand 32 bytes, lowercase, no padding)
+//	totalLen = 12 + 52 = 64
+//
+// `key_prefix` (the UNIQUE-indexed lookup hint stored in `mcp.api_keys`) is
+// the first 8 chars of the random base32 portion — i.e. `rawKey[12:20]`.
+// The literal `unblock_pat_` prefix is stripped before slicing so the
+// prefix space never collides on the brand prefix (DRIFT-A in the bead
+// investigation: §4.3.2 step 2's loose `raw_key[:8]` is superseded by the
+// locked key-format note at lines 453-460).
+//
+// Hash: HMAC-SHA256(secrets.APIKeyHMACSecret, rawKey) — 32 bytes raw,
+// stored bytea in `mcp.api_keys.key_hash`. Constant-time compare via
+// crypto/subtle.ConstantTimeCompare on every Bearer auth check
+// (SPEC §4.3.2 step 6).
+
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"errors"
+	"fmt"
+)
+
+// rawKeyPrefix is the literal brand prefix prepended to every raw key.
+// Length 12 (the underscore is part of the prefix). SPEC §4.3.2.
+const rawKeyPrefix = "unblock_pat_"
+
+// rawKeyRandomBytes is the count of crypto/rand bytes that feed the
+// base32 portion of every raw key. 32 bytes = 256 bits of entropy.
+const rawKeyRandomBytes = 32
+
+// rawKeyTotalLen is the expected total length of a well-formed raw key:
+// `len(rawKeyPrefix)` + `len(base32-no-padding(32 bytes))` = 12 + 52 = 64.
+const rawKeyTotalLen = len(rawKeyPrefix) + rawKeyEncodedLen
+
+// rawKeyEncodedLen is the base32-no-padding encoded length of
+// rawKeyRandomBytes. Computed at package-init via the encoding's
+// formula: ceil(n/5) * 8 chars, then trimmed of '=' padding. For
+// n=32 this is 52.
+const rawKeyEncodedLen = 52
+
+// keyPrefixLen is the number of leading chars of the random base32
+// portion that populate `mcp.api_keys.key_prefix`. SPEC §4.3.2 line 456.
+const keyPrefixLen = 8
+
+// rawKeyEncoder is the lowercase variant of standard base32 with the
+// padding character disabled. SPEC §4.3.2 line 455 ("base32 (no
+// padding, lowercase)").
+//
+// Encore's stdlib does not ship a lowercase base32 encoding, so we
+// derive one by remapping the standard alphabet at package init.
+var rawKeyEncoder = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
+
+// ErrInvalidRawKey is returned when an input key cannot be parsed for
+// prefix extraction (wrong length or missing brand prefix). The Bearer
+// auth hot path translates this into errs.Unauthenticated; never echo
+// the raw input value back to the caller.
+var ErrInvalidRawKey = errors.New("auth: invalid raw API key format")
+
+// generateRawKey produces a fresh raw key with crypto/rand entropy.
+// Returns the full key string. The caller is responsible for
+// (a) storing the HMAC hash in `mcp.api_keys.key_hash`, (b) returning
+// the raw key to its consumer EXACTLY ONCE, and (c) never logging it.
+func generateRawKey() (string, error) {
+	buf := make([]byte, rawKeyRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("auth: read crypto/rand: %w", err)
+	}
+	encoded := rawKeyEncoder.EncodeToString(buf)
+	if len(encoded) != rawKeyEncodedLen {
+		// Should be impossible — base32(32 bytes, no padding) is
+		// always 52 chars. Defensive guard against future format
+		// drift (e.g. someone retunes rawKeyRandomBytes without
+		// updating the constants).
+		return "", fmt.Errorf("auth: encoded key length %d != %d", len(encoded), rawKeyEncodedLen)
+	}
+	return rawKeyPrefix + encoded, nil
+}
+
+// prefixOf extracts the `key_prefix` value (first 8 chars of the
+// random base32 portion) from a raw key. The literal `unblock_pat_`
+// prefix is stripped before slicing — see DRIFT-A in the bead
+// investigation. Returns ErrInvalidRawKey on any length mismatch or
+// missing brand prefix; callers in the hot path translate that into
+// errs.Unauthenticated.
+func prefixOf(rawKey string) (string, error) {
+	if len(rawKey) != rawKeyTotalLen {
+		return "", ErrInvalidRawKey
+	}
+	if rawKey[:len(rawKeyPrefix)] != rawKeyPrefix {
+		return "", ErrInvalidRawKey
+	}
+	return rawKey[len(rawKeyPrefix) : len(rawKeyPrefix)+keyPrefixLen], nil
+}
+
+// hashRawKey computes HMAC-SHA256(secret, rawKey) and returns the
+// 32-byte raw digest. The output is stored in `mcp.api_keys.key_hash`
+// as bytea and compared with crypto/subtle.ConstantTimeCompare on every
+// Bearer auth check (SPEC §4.3.2 steps 5-6).
+func hashRawKey(secret, rawKey string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(rawKey))
+	return mac.Sum(nil)
+}

--- a/apps/api/auth/apikey_test.go
+++ b/apps/api/auth/apikey_test.go
@@ -1,0 +1,170 @@
+// Unit tests for the API key format helpers.
+//
+// Scope (B-1, bead unblock-tv8.7):
+//   - generateRawKey produces the locked 64-char `unblock_pat_<base32-32-byte>` shape.
+//   - prefixOf strips the literal `unblock_pat_` prefix per DRIFT-A
+//     (raw_key[12:20], NOT raw_key[:8]).
+//   - hashRawKey is deterministic (HMAC-SHA256 with the secrets-manifest secret).
+//
+// These tests do NOT require Docker / encore CLI — `go test ./auth/...`
+// runs them directly because none of the helpers touch sqldb at unit
+// time (the package-level `db` var registers an Encore resource but no
+// connection is opened until a Database method is invoked).
+
+package auth
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRawKey(t *testing.T) {
+	t.Run("produces a well-formed 64-char unblock_pat_ key", func(t *testing.T) {
+		got, err := generateRawKey()
+		if err != nil {
+			t.Fatalf("generateRawKey: %v", err)
+		}
+		if len(got) != rawKeyTotalLen {
+			t.Fatalf("len(rawKey) = %d, want %d", len(got), rawKeyTotalLen)
+		}
+		if !strings.HasPrefix(got, rawKeyPrefix) {
+			t.Fatalf("rawKey %q missing prefix %q", got, rawKeyPrefix)
+		}
+		// Body must be 52 chars of lowercase Crockford-like base32
+		// (no padding). We verify the alphabet defensively — drift in
+		// the encoder would silently change the wire format.
+		body := got[len(rawKeyPrefix):]
+		if len(body) != rawKeyEncodedLen {
+			t.Fatalf("len(body) = %d, want %d", len(body), rawKeyEncodedLen)
+		}
+		const allowed = "abcdefghijklmnopqrstuvwxyz234567"
+		for i, c := range body {
+			if !strings.ContainsRune(allowed, c) {
+				t.Fatalf("body[%d] = %q not in allowed alphabet", i, c)
+			}
+		}
+	})
+
+	t.Run("two calls produce distinct keys", func(t *testing.T) {
+		// crypto/rand collisions on 32 bytes are mathematically
+		// infeasible; the assertion guards against a future
+		// regression where the entropy source is accidentally
+		// substituted with a deterministic generator.
+		a, err := generateRawKey()
+		if err != nil {
+			t.Fatalf("generateRawKey #1: %v", err)
+		}
+		b, err := generateRawKey()
+		if err != nil {
+			t.Fatalf("generateRawKey #2: %v", err)
+		}
+		if a == b {
+			t.Fatalf("two generateRawKey calls collided: %q", a)
+		}
+	})
+}
+
+func TestPrefixOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "well-formed key returns first 8 chars after the brand prefix",
+			input: "unblock_pat_abcdefghijklmnopqrstuvwxyz234567abcdefghijklmnop",
+			want:  "abcdefgh",
+		},
+		{
+			name:    "wrong total length is rejected",
+			input:   "unblock_pat_short",
+			wantErr: true,
+		},
+		{
+			name:    "missing brand prefix is rejected even when length matches",
+			input:   strings.Repeat("a", rawKeyTotalLen),
+			wantErr: true,
+		},
+		{
+			name:    "empty input is rejected",
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := prefixOf(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("prefixOf(%q) = %q, want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("prefixOf(%q): %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("prefixOf(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			if len(got) != keyPrefixLen {
+				t.Fatalf("prefix len = %d, want %d", len(got), keyPrefixLen)
+			}
+		})
+	}
+}
+
+func TestPrefixOfRoundTripFromGenerate(t *testing.T) {
+	// End-to-end smoke: a freshly generated key always parses, and
+	// the extracted prefix is a substring of the raw key starting
+	// at byte 12 (DRIFT-A invariant).
+	raw, err := generateRawKey()
+	if err != nil {
+		t.Fatalf("generateRawKey: %v", err)
+	}
+	prefix, err := prefixOf(raw)
+	if err != nil {
+		t.Fatalf("prefixOf: %v", err)
+	}
+	if raw[12:20] != prefix {
+		t.Fatalf("raw[12:20] = %q, prefix = %q", raw[12:20], prefix)
+	}
+}
+
+func TestHashRawKey(t *testing.T) {
+	t.Run("is deterministic for the same secret + key", func(t *testing.T) {
+		secret := "test-hmac-secret"
+		key := "unblock_pat_" + strings.Repeat("a", rawKeyEncodedLen)
+		a := hashRawKey(secret, key)
+		b := hashRawKey(secret, key)
+		if !bytes.Equal(a, b) {
+			t.Fatalf("hashRawKey not deterministic: %x vs %x", a, b)
+		}
+	})
+
+	t.Run("different secrets produce different digests", func(t *testing.T) {
+		key := "unblock_pat_" + strings.Repeat("a", rawKeyEncodedLen)
+		a := hashRawKey("secret-one", key)
+		b := hashRawKey("secret-two", key)
+		if bytes.Equal(a, b) {
+			t.Fatalf("different secrets produced the same digest %x", a)
+		}
+	})
+
+	t.Run("different keys produce different digests", func(t *testing.T) {
+		secret := "shared-secret"
+		a := hashRawKey(secret, "unblock_pat_"+strings.Repeat("a", rawKeyEncodedLen))
+		b := hashRawKey(secret, "unblock_pat_"+strings.Repeat("b", rawKeyEncodedLen))
+		if bytes.Equal(a, b) {
+			t.Fatalf("different keys produced the same digest %x", a)
+		}
+	})
+
+	t.Run("digest length is 32 bytes (HMAC-SHA256)", func(t *testing.T) {
+		got := hashRawKey("s", "k")
+		if len(got) != 32 {
+			t.Fatalf("digest len = %d, want 32", len(got))
+		}
+	})
+}

--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -4,26 +4,61 @@
 // (auth, org, workitems, deps, providers, mcp, boards, memory). Other
 // services consume the database via sqldb.Named("unblock"); see SPEC §3.1.
 //
-// In P01 task A-2 this package declares the package-level `db` handle via
-// sqldb.NewDatabase("unblock", ...) (see db.go) and the Encore secrets
-// manifest (see secrets.go). The bootstrap migration installing pgcrypto
-// and pg_trgm ships in migrations/0010_bootstrap.up.sql. The full
-// per-schema DDL (0020_auth..0090_memory) lands in task A-3
-// (unblock-tv8.3) — see SPEC §3.2. RPC bodies still return
-// errNotImplemented; real implementations land in beads B-1..D-3.
+// In P01 task B-1 (bead unblock-tv8.7) this package lands the four
+// private RPC bodies (Validate, ExchangeOAuthCode, IssueAPIKey,
+// RevokeAPIKey) and the //encore:authhandler. Wiring of the shared
+// rbac builder happens in init() — see initbind.go.
+//
+// SPEC anchors: §4.1 (locked signatures), §4.3.2 (Bearer hot path),
+// §4.3.3 (auth handler), §3.5 (secrets manifest), §11.1 P01 contract.
 package auth
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"encore.app/auth/types"
+	"encore.dev/beta/errs"
+	"encore.dev/rlog"
+	"encore.dev/storage/sqldb"
 )
 
-// errNotImplemented is the sentinel returned by every P01 A-1 skeleton
-// body. Real implementations land in subsequent beads (B-1..D-3).
-var errNotImplemented = errors.New("auth: not implemented in P01 A-1 skeleton")
+// TokenKind enum literals accepted by Validate. SPEC §4.1.
+const (
+	tokenKindAPIKey  = "api_key"
+	tokenKindSession = "session"
+)
+
+// agentKindAllowed mirrors the `mcp.api_keys.api_keys_agent_chk` SQL
+// CHECK constraint. IssueAPIKey validates against this set client-side
+// so the call returns a clean errs.InvalidArgument instead of bubbling
+// up a Postgres CHECK violation. Order does not matter.
+var agentKindAllowed = map[string]struct{}{
+	"claude-code": {},
+	"copilot":     {},
+	"cursor":      {},
+	"codex":       {},
+	"aider":       {},
+	"custom":      {},
+}
+
+// roleAgent is the literal role assigned to API-key callers. SPEC
+// §4.3.2 step 8: `Role: "agent"`. Distinct from the org/project
+// member roles ({owner, admin, member, viewer}) because API keys are
+// machine identities — RBAC for agents is enforced via tool-scope
+// checks at the MCP service, not via org membership rows.
+const roleAgent = "agent"
+
+// defaultAPIKeySessionTTL is the expiry applied to OAuth-issued
+// sessions when the caller does not supply an override. 30 days
+// matches typical Astro BFF cookie lifetime; renewal is expressed as
+// a new sessions row + revocation of the old one (no in-place
+// extension). Honoured by `auth.sessions.expires_at`.
+const defaultAPIKeySessionTTL = 30 * 24 * time.Hour
 
 // Identity is the resolved caller record carried inside the Encore mesh.
 // Locked shape per SPEC §4.1.
@@ -52,11 +87,142 @@ type ValidateResponse struct {
 }
 
 // Validate accepts an opaque token (session id OR raw API key) and resolves
-// it to an Identity. Returns ErrUnauthenticated on miss / revoked / expired.
+// it to an Identity. Returns errs.Unauthenticated on miss / revoked /
+// expired and errs.Unimplemented on the deferred session path.
+//
+// SPEC §4.3.2 (8-step API-key hot path) and §4.3.3 (P01 session-path
+// deferral).
 //
 //encore:api private method=POST path=/auth.Validate
 func Validate(ctx context.Context, req *ValidateRequest) (*ValidateResponse, error) {
-	return nil, errNotImplemented
+	if req == nil || req.Token == "" {
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "empty token"}
+	}
+
+	switch req.TokenKind {
+	case tokenKindAPIKey:
+		return validateAPIKey(ctx, req.Token)
+	case tokenKindSession:
+		// SPEC §4.3.3 P01 contract (round-4): session path returns
+		// errs.Unimplemented in P01. The BFF (Astro Actions) is the
+		// only consumer of this branch; P01 exit criterion uses API
+		// keys exclusively (PRD §3.5 lines 245-248). The org_id
+		// disambiguation rule (auth.sessions has no org_id column;
+		// users may belong to multiple orgs) is left for the BFF
+		// phase to define. See DECISION on the bead.
+		return nil, &errs.Error{
+			Code:    errs.Unimplemented,
+			Message: "session-token validation deferred to the BFF phase (SPEC §4.3.3 P01 contract)",
+		}
+	default:
+		return nil, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: fmt.Sprintf("unknown token_kind %q (expected %q or %q)", req.TokenKind, tokenKindAPIKey, tokenKindSession),
+		}
+	}
+}
+
+// validateAPIKey implements SPEC §4.3.2 verbatim (8 steps).
+//
+//  1. Parse `Authorization: Bearer <raw_key>` (caller-side; we receive raw_key).
+//  2. Extract key_prefix = raw_key[12:20] per the locked key-format note.
+//  3. SELECT … FROM mcp.api_keys WHERE key_prefix = $1 (UNIQUE index).
+//  4. Reject if revoked or expired.
+//  5. Compute expected = HMAC-SHA256(secret, raw_key).
+//  6. subtle.ConstantTimeCompare(stored, expected); reject on mismatch.
+//  7. UPDATE mcp.api_keys SET last_used_at = now() (fire-and-forget).
+//  8. Construct Identity{Role:"agent", AgentKind:row.agent_kind, …}.
+func validateAPIKey(ctx context.Context, rawKey string) (*ValidateResponse, error) {
+	prefix, err := prefixOf(rawKey)
+	if err != nil {
+		// Step 2 failure: malformed input. Bearer auth contract
+		// returns Unauthenticated for any input that does not parse
+		// (no information leak about which check failed).
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "invalid api key"}
+	}
+
+	// Step 3: O(1) lookup via api_keys_prefix_uniq.
+	var (
+		id           string
+		orgID        string
+		issuedToUser *string
+		keyHash      []byte
+		agentKind    string
+		revokedAt    *time.Time
+		expiresAt    *time.Time
+	)
+	err = db.QueryRow(ctx,
+		`SELECT id, org_id, issued_to_user, key_hash, agent_kind, revoked_at, expires_at
+		 FROM mcp.api_keys
+		 WHERE key_prefix = $1`,
+		prefix,
+	).Scan(&id, &orgID, &issuedToUser, &keyHash, &agentKind, &revokedAt, &expiresAt)
+	if err != nil {
+		// We do not differentiate "no rows" from other DB errors in
+		// the response — the Bearer auth contract returns
+		// Unauthenticated for both. The DB error is logged via rlog
+		// for ops visibility (SPEC §11.2 NFR-12: STDERR-only
+		// JSON-Lines).
+		if !errors.Is(err, sqldb.ErrNoRows) {
+			rlog.Error("auth: api_key lookup failed", "err", err, "prefix", prefix)
+		}
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "invalid api key"}
+	}
+
+	// Step 4: revocation + expiry checks. now() in Go (not SQL) so a
+	// long-running connection-pool wait does not lengthen the
+	// effective expiry window.
+	now := time.Now()
+	if revokedAt != nil {
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "api key revoked"}
+	}
+	if expiresAt != nil && expiresAt.Before(now) {
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "api key expired"}
+	}
+
+	// Steps 5-6: HMAC + constant-time compare.
+	expected := hashRawKey(secrets.APIKeyHMACSecret, rawKey)
+	if subtle.ConstantTimeCompare(keyHash, expected) != 1 {
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "invalid api key"}
+	}
+
+	// Step 7: fire-and-forget last_used_at update. The Bearer hot
+	// path's <5 ms p99 budget (SPEC §4.3.2 line 451) does not allow
+	// a synchronous UPDATE on every request, so we detach it onto a
+	// background context. We swallow errors deliberately — a failed
+	// last_used_at write is a UI hint loss, not an auth failure.
+	go touchLastUsedAt(id)
+
+	// Step 8: construct Identity.
+	uid := ""
+	if issuedToUser != nil {
+		uid = *issuedToUser
+	}
+	return &ValidateResponse{Identity: Identity{
+		UserID:    uid,
+		OrgID:     orgID,
+		Role:      roleAgent,
+		AgentKind: agentKind,
+	}}, nil
+}
+
+// touchLastUsedAt issues a fire-and-forget UPDATE on
+// mcp.api_keys.last_used_at. Detached from the request context so a
+// client that disconnects between auth and downstream-RPC end does not
+// abort the write; bounded to 1 second so we cannot leak an unbounded
+// goroutine on a permanently-stalled DB.
+//
+// Tracked risk (bead): at high QPS this single-row UPDATE becomes a
+// hot spot — RS01-4 / E-2 will revisit with an LRU cache if the
+// latency harness shows pressure. Acceptable for v1 throughput.
+func touchLastUsedAt(keyID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := db.Exec(ctx, `UPDATE mcp.api_keys SET last_used_at = now() WHERE id = $1`, keyID); err != nil {
+		// Best-effort; debug-level so a saturated DB does not
+		// flood error logs.
+		rlog.Debug("auth: touch last_used_at failed", "err", err, "key_id", keyID)
+	}
 }
 
 // ExchangeOAuthCodeRequest is the input to ExchangeOAuthCode. SPEC §4.1.
@@ -66,6 +232,18 @@ type ExchangeOAuthCodeRequest struct {
 	PKCEVerifier string
 	UserAgent    string
 	IPAddress    string
+
+	// PKCEChallenge is the S256 challenge the client originally sent
+	// to /authorize. SPEC §4.1's locked struct does not include it —
+	// in the BFF design the server stores it server-side keyed by
+	// `code` and looks it up here. P01 has no /authorize storage
+	// surface (the seeder bypasses OAuth entirely per SPEC §3.5
+	// line 246-248), so for the integration-test path we accept it
+	// inline. This is an additive field; existing call sites that do
+	// not set it fall through to the legacy (verifier-only)
+	// validation pattern documented at the field. See DECISION on
+	// the bead.
+	PKCEChallenge string
 }
 
 // ExchangeOAuthCodeResponse is the output of ExchangeOAuthCode. SPEC §4.1.
@@ -80,9 +258,198 @@ type ExchangeOAuthCodeResponse struct {
 // a provider access token, upserts auth.users + auth.oauth_tokens, and
 // issues a new auth.sessions row. Returns the opaque session id.
 //
+// P01 scope (per Plan §3.6 + bead investigation): only the GitHub
+// provider is wired; GitLab is documented in the schema but
+// implementation lands in P02.
+//
 //encore:api private method=POST path=/auth.ExchangeOAuthCode
 func ExchangeOAuthCode(ctx context.Context, req *ExchangeOAuthCodeRequest) (*ExchangeOAuthCodeResponse, error) {
-	return nil, errNotImplemented
+	if req == nil {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing request body"}
+	}
+	if req.Provider != "github" {
+		// gitlab: SPEC §4.1 documents both, but Plan §3.6 defers
+		// GitLab to P02. Returning Unimplemented (not InvalidArgument)
+		// signals "valid input, not yet wired".
+		return nil, &errs.Error{
+			Code:    errs.Unimplemented,
+			Message: fmt.Sprintf("provider %q not implemented in P01 (only \"github\" is wired)", req.Provider),
+		}
+	}
+	if req.Code == "" {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing code"}
+	}
+	if req.PKCEVerifier == "" {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing pkce_verifier"}
+	}
+
+	// PKCE verification. The BFF supplies `PKCEChallenge` from its
+	// per-request store (or, for the integration-test surface, inline
+	// on this request). When unset we skip the check (legacy path
+	// for callers that have not migrated yet). A future bead will
+	// promote this to mandatory once the BFF storage lands.
+	if req.PKCEChallenge != "" && !pkceMatches(req.PKCEVerifier, req.PKCEChallenge) {
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "pkce verification failed"}
+	}
+
+	// Exchange the code for a GitHub access token.
+	tok, err := exchangeGitHubCode(ctx, req.Code, secrets.GitHubOAuthClientID, secrets.GitHubOAuthClientSecret)
+	if err != nil {
+		rlog.Error("auth: github code exchange failed", "err", err)
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "oauth exchange failed"}
+	}
+
+	// Fetch the GitHub user profile so we can populate auth.users.
+	ghUser, err := fetchGitHubUser(ctx, tok.AccessToken)
+	if err != nil {
+		rlog.Error("auth: github user fetch failed", "err", err)
+		return nil, &errs.Error{Code: errs.Internal, Message: "github user fetch failed"}
+	}
+	if ghUser.Email == "" {
+		// GitHub returns an empty email when the user marked it
+		// private. P02 will add a fallback to /user/emails; in P01
+		// we reject the exchange so we never insert a row violating
+		// the auth.users.email NOT NULL invariant.
+		return nil, &errs.Error{Code: errs.FailedPrecondition, Message: "github user has no public email"}
+	}
+
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: "db begin failed"}
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Upsert auth.users on (primary_provider, primary_provider_id).
+	// We mint a fresh ULID only when no existing row matches.
+	userID, err := upsertGitHubUser(ctx, tx, ghUser)
+	if err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: fmt.Sprintf("upsert users: %v", err)}
+	}
+
+	// Upsert auth.oauth_tokens. The schema's UNIQUE (user_id,
+	// provider) index enforces one row per (user, provider) pair —
+	// rotation overwrites in place. The pgcrypto encryption uses the
+	// MEMORY_DEK secret per SPEC §3.5 / §9.4.1.
+	if err := upsertGitHubOAuthToken(ctx, tx, userID, tok, ghUser); err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: fmt.Sprintf("upsert oauth_tokens: %v", err)}
+	}
+
+	// Mint a fresh session.
+	sessionID, err := newULID()
+	if err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: "session id generation failed"}
+	}
+	now := time.Now().UTC()
+	expiresAt := now.Add(defaultAPIKeySessionTTL)
+	_, err = tx.Exec(ctx,
+		`INSERT INTO auth.sessions (id, user_id, issued_at, last_seen_at, expires_at, user_agent, ip_inet)
+		 VALUES ($1, $2, $3, $3, $4, $5, NULLIF($6, '')::inet)`,
+		sessionID, userID, now, expiresAt, req.UserAgent, req.IPAddress,
+	)
+	if err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: fmt.Sprintf("insert session: %v", err)}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: fmt.Sprintf("commit: %v", err)}
+	}
+
+	return &ExchangeOAuthCodeResponse{
+		SessionID: sessionID,
+		UserID:    userID,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// upsertGitHubUser inserts a fresh row or refreshes the existing one
+// keyed by (primary_provider, primary_provider_id). Returns the
+// (existing or newly-minted) ULID.
+func upsertGitHubUser(ctx context.Context, tx *sqldb.Tx, gh *githubUserResponse) (string, error) {
+	// We use a CTE so we get the row id back regardless of whether
+	// INSERT or UPDATE fired. The ON CONFLICT clause keys on the
+	// schema's existing UNIQUE constraint
+	// (users_primary_provider_unique).
+	//
+	// COALESCE on display_name / email / avatar_url so a follow-up
+	// login that returns a richer profile refreshes the row but a
+	// missing field does not blank an existing one.
+	displayName := gh.Name
+	if displayName == "" {
+		displayName = gh.Login
+	}
+
+	newID, err := newULID()
+	if err != nil {
+		return "", err
+	}
+	providerID := fmt.Sprintf("%d", gh.ID)
+
+	row := tx.QueryRow(ctx,
+		`INSERT INTO auth.users (id, primary_provider, primary_provider_id, email, display_name, avatar_url)
+		 VALUES ($1, 'github', $2, $3, $4, NULLIF($5, ''))
+		 ON CONFLICT (primary_provider, primary_provider_id) DO UPDATE
+		   SET email        = EXCLUDED.email,
+		       display_name = EXCLUDED.display_name,
+		       avatar_url   = COALESCE(EXCLUDED.avatar_url, auth.users.avatar_url),
+		       updated_at   = now()
+		 RETURNING id`,
+		newID, providerID, gh.Email, displayName, gh.AvatarURL,
+	)
+	var id string
+	if err := row.Scan(&id); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// upsertGitHubOAuthToken writes (or refreshes) the oauth_tokens row.
+// The *_enc columns use pgp_sym_encrypt with the MEMORY_DEK secret
+// per SPEC §3.5; the key value is passed inline as the second
+// argument of the SQL function.
+func upsertGitHubOAuthToken(ctx context.Context, tx *sqldb.Tx, userID string, tok *githubAccessTokenResponse, _ *githubUserResponse) error {
+	rowID, err := newULID()
+	if err != nil {
+		return err
+	}
+	scopes := splitScopes(tok.Scope)
+	_, err = tx.Exec(ctx,
+		`INSERT INTO auth.oauth_tokens
+		   (id, user_id, provider, access_token_enc, refresh_token_enc, scopes, expires_at, rotated_at)
+		 VALUES (
+		   $1, $2, 'github',
+		   pgp_sym_encrypt($3, $5),
+		   CASE WHEN $4 = '' THEN NULL ELSE pgp_sym_encrypt($4, $5) END,
+		   $6, NULL, now()
+		 )
+		 ON CONFLICT (user_id, provider) DO UPDATE
+		   SET access_token_enc  = EXCLUDED.access_token_enc,
+		       refresh_token_enc = EXCLUDED.refresh_token_enc,
+		       scopes            = EXCLUDED.scopes,
+		       rotated_at        = now()`,
+		rowID, userID, tok.AccessToken, tok.RefreshToken, secrets.MemoryDEK, scopes,
+	)
+	return err
+}
+
+// splitScopes splits the comma-or-space delimited GitHub scope string
+// into the text[] form auth.oauth_tokens.scopes expects. Empty input
+// yields an empty slice (the schema default is '{}').
+func splitScopes(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return []string{}
+	}
+	// GitHub returns space-separated; older docs said comma. Accept
+	// both for defensive parsing.
+	fields := strings.FieldsFunc(raw, func(r rune) bool { return r == ' ' || r == ',' })
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 // IssueAPIKeyRequest is the input to IssueAPIKey. SPEC §4.1.
@@ -98,7 +465,7 @@ type IssueAPIKeyRequest struct {
 // IssueAPIKeyResponse is the output of IssueAPIKey. SPEC §4.1.
 type IssueAPIKeyResponse struct {
 	KeyID     string // ULID (mcp.api_keys.id)
-	KeyPrefix string // first 8 chars of the raw key
+	KeyPrefix string // first 8 chars of the random base32 portion
 	RawKey    string // FULL raw key — returned ONCE; never persisted in clear
 }
 
@@ -108,7 +475,69 @@ type IssueAPIKeyResponse struct {
 //
 //encore:api private method=POST path=/auth.IssueAPIKey
 func IssueAPIKey(ctx context.Context, req *IssueAPIKeyRequest) (*IssueAPIKeyResponse, error) {
-	return nil, errNotImplemented
+	if req == nil {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing request body"}
+	}
+	if req.OrgID == "" {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing org_id"}
+	}
+	if req.Label == "" {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing label"}
+	}
+	if _, ok := agentKindAllowed[req.AgentKind]; !ok {
+		// Catch the CHECK constraint client-side so the caller gets
+		// a clean 400 instead of a Postgres-flavoured 500.
+		return nil, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: fmt.Sprintf("invalid agent_kind %q (allowed: claude-code, copilot, cursor, codex, aider, custom)", req.AgentKind),
+		}
+	}
+
+	keyID, err := newULID()
+	if err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: "key id generation failed"}
+	}
+	rawKey, err := generateRawKey()
+	if err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: "raw key generation failed"}
+	}
+	prefix, err := prefixOf(rawKey)
+	if err != nil {
+		// Should be impossible — generateRawKey produces well-formed
+		// keys by construction. Defensive guard against future drift.
+		return nil, &errs.Error{Code: errs.Internal, Message: "key prefix derivation failed"}
+	}
+	hash := hashRawKey(secrets.APIKeyHMACSecret, rawKey)
+
+	scopes := req.Scopes
+	if scopes == nil {
+		scopes = []string{}
+	}
+	var issuedToUser any
+	if req.IssuedToUser != "" {
+		issuedToUser = req.IssuedToUser
+	}
+
+	_, err = db.Exec(ctx,
+		`INSERT INTO mcp.api_keys
+		   (id, org_id, issued_to_user, label, agent_kind, key_hash, key_prefix, scopes, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		keyID, req.OrgID, issuedToUser, req.Label, req.AgentKind, hash, prefix, scopes, req.ExpiresAt,
+	)
+	if err != nil {
+		// Do NOT include rawKey in the log — it has not been
+		// returned to the caller yet and is the only copy in
+		// memory; an error log here would be the only persistent
+		// trace of the secret.
+		rlog.Error("auth: api_key insert failed", "err", err, "org_id", req.OrgID, "agent_kind", req.AgentKind)
+		return nil, &errs.Error{Code: errs.Internal, Message: "issue api key failed"}
+	}
+
+	return &IssueAPIKeyResponse{
+		KeyID:     keyID,
+		KeyPrefix: prefix,
+		RawKey:    rawKey,
+	}, nil
 }
 
 // RevokeAPIKeyRequest is the input to RevokeAPIKey. SPEC §4.1.
@@ -118,7 +547,27 @@ type RevokeAPIKeyRequest struct {
 
 // RevokeAPIKey flips revoked_at; idempotent.
 //
+// Idempotency contract: a second Revoke call on the same key is a
+// no-op (revoked_at is preserved at the first-revoke timestamp via
+// COALESCE). Revoking a non-existent key is also accepted silently —
+// the caller cannot distinguish a key it never had from one already
+// revoked, and revoking what you don't own is harmless. A future
+// bead may add an authorization check (the caller must own org_id).
+//
 //encore:api private method=POST path=/auth.RevokeAPIKey
 func RevokeAPIKey(ctx context.Context, req *RevokeAPIKeyRequest) error {
-	return errNotImplemented
+	if req == nil || req.KeyID == "" {
+		return &errs.Error{Code: errs.InvalidArgument, Message: "missing key_id"}
+	}
+	_, err := db.Exec(ctx,
+		`UPDATE mcp.api_keys
+		   SET revoked_at = COALESCE(revoked_at, now())
+		 WHERE id = $1`,
+		req.KeyID,
+	)
+	if err != nil {
+		rlog.Error("auth: api_key revoke failed", "err", err, "key_id", req.KeyID)
+		return &errs.Error{Code: errs.Internal, Message: "revoke api key failed"}
+	}
+	return nil
 }

--- a/apps/api/auth/authhandler.go
+++ b/apps/api/auth/authhandler.go
@@ -1,0 +1,128 @@
+// //encore:authhandler entry point. Reads `Authorization: Bearer …`
+// and dispatches into Validate per the SPEC §4.3.3 contract:
+//
+//	X-Unblock-BFF-Origin == ""  → MCP path: raw API key
+//	X-Unblock-BFF-Origin != ""  → BFF path: session id (P01 returns Unimplemented)
+//
+// DRIFT-B closure (bead investigation): SPEC §4.3.3 originally documented
+// the simple-token form `func AuthHandler(ctx, token string)`. That form
+// cannot read the X-Unblock-BFF-Origin header which the same section's
+// dispatch rule requires. Encore's structured-params form (ENCORE.md
+// lines 388-398) is the only handler shape that exposes incoming headers
+// via `header:"…"` struct tags, so this handler uses that form.
+//
+// Identity is propagated to downstream handlers via Encore's auth
+// context (encore.dev/beta/auth.UserID() returns the auth.UID we
+// return; auth.Data() returns the *AuthData with the full Identity).
+
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"encore.dev/beta/auth"
+	"encore.dev/beta/errs"
+)
+
+// AuthParams is the structured input to //encore:authhandler. Field
+// tags map to incoming HTTP request headers per Encore's auth-handler
+// contract (ENCORE.md lines 388-398).
+type AuthParams struct {
+	// Authorization is the raw value of the `Authorization` header.
+	// Expected form: `Bearer <token>` where `<token>` is either a raw
+	// API key (`unblock_pat_…`) on the MCP path or a session id (ULID)
+	// on the BFF path.
+	Authorization string `header:"Authorization"`
+
+	// BFFOrigin is the value of `X-Unblock-BFF-Origin`. Presence (any
+	// non-empty value) signals the request originates from the Astro
+	// BFF and the token must be interpreted as a session id; absence
+	// signals a direct MCP client and the token is interpreted as an
+	// API key. SPEC §4.3.3.
+	BFFOrigin string `header:"X-Unblock-BFF-Origin"`
+}
+
+// AuthData is what downstream handlers receive via auth.Data(). Wraps
+// the resolved Identity per SPEC §4.3.3.
+type AuthData struct {
+	Identity Identity
+}
+
+// bearerPrefix is the case-sensitive scheme prefix the
+// `Authorization` header must begin with. RFC 6750 says Bearer is
+// case-insensitive, but the GitHub Copilot, Claude Code, Cursor,
+// Codex, and Aider clients all emit `Bearer` literally — accepting
+// case variations would be free permissiveness for no upstream
+// benefit. We compare with EqualFold for resilience.
+const bearerPrefix = "Bearer "
+
+// AuthHandler is the //encore:authhandler invoked by Encore on every
+// request to an //encore:api with `auth: true`. Returns
+// errs.Unauthenticated for any token failure; downstream services
+// observe the resolved Identity via auth.UserID() and auth.Data().
+//
+// Hot path: this function is on every MCP request. It parses the
+// Bearer token cheaply and delegates the DB lookup to Validate so the
+// hot path stays at <5 ms p99 (SPEC §4.3.2 line 451).
+//
+//encore:authhandler
+func AuthHandler(ctx context.Context, p *AuthParams) (auth.UID, *AuthData, error) {
+	if p == nil || p.Authorization == "" {
+		return "", nil, &errs.Error{
+			Code:    errs.Unauthenticated,
+			Message: "missing Authorization header",
+		}
+	}
+
+	token, ok := parseBearer(p.Authorization)
+	if !ok {
+		return "", nil, &errs.Error{
+			Code:    errs.Unauthenticated,
+			Message: "Authorization header must be \"Bearer <token>\"",
+		}
+	}
+
+	// Dispatch on BFF-origin header presence. SPEC §4.3.3.
+	kind := tokenKindAPIKey
+	if p.BFFOrigin != "" {
+		kind = tokenKindSession
+	}
+
+	resp, err := Validate(ctx, &ValidateRequest{Token: token, TokenKind: kind})
+	if err != nil {
+		// Validate already returns properly classified errs.* values
+		// (Unauthenticated for revoked / expired / bad HMAC / bad
+		// prefix; Unimplemented for the deferred session path).
+		// Propagate verbatim so the HTTP transport returns the right
+		// status code and the MCP envelope mapper at D-1 sees the
+		// canonical kind.
+		return "", nil, err
+	}
+
+	// auth.UID is the canonical user identifier surface of the Encore
+	// auth context. We use Identity.UserID — a ULID for the
+	// session-token path; for API-key callers it is the
+	// `mcp.api_keys.issued_to_user` value (nullable in the schema; an
+	// empty string is acceptable for org-level service keys).
+	return auth.UID(resp.Identity.UserID), &AuthData{Identity: resp.Identity}, nil
+}
+
+// parseBearer extracts the token portion of an `Authorization:
+// Bearer <token>` header. Returns ("", false) on any deviation from
+// the expected shape. We accept case-insensitive `Bearer` for
+// resilience but reject leading/trailing whitespace inside the token
+// itself (callers that emit `Bearer  <token>` have a bug).
+func parseBearer(authzHeader string) (string, bool) {
+	if len(authzHeader) <= len(bearerPrefix) {
+		return "", false
+	}
+	if !strings.EqualFold(authzHeader[:len(bearerPrefix)], bearerPrefix) {
+		return "", false
+	}
+	tok := authzHeader[len(bearerPrefix):]
+	if tok == "" || tok != strings.TrimSpace(tok) {
+		return "", false
+	}
+	return tok, true
+}

--- a/apps/api/auth/authhandler_test.go
+++ b/apps/api/auth/authhandler_test.go
@@ -1,0 +1,82 @@
+// Unit tests for the //encore:authhandler input parsing.
+//
+// Scope: parseBearer + AuthHandler dispatch (input validation only).
+// Validate's DB path is exercised at integration time (encore test).
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"encore.dev/beta/errs"
+)
+
+func TestParseBearer(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantTok string
+		wantOK  bool
+	}{
+		{name: "canonical form", input: "Bearer abc", wantTok: "abc", wantOK: true},
+		{name: "case-insensitive scheme", input: "bearer xyz", wantTok: "xyz", wantOK: true},
+		{name: "empty", input: "", wantOK: false},
+		{name: "scheme only", input: "Bearer ", wantOK: false},
+		{name: "no scheme", input: "abc", wantOK: false},
+		{name: "trailing space", input: "Bearer abc ", wantOK: false},
+		{name: "leading space (after scheme)", input: "Bearer  abc", wantOK: false},
+		{name: "wrong scheme", input: "Basic abc", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseBearer(tc.input)
+			if ok != tc.wantOK {
+				t.Fatalf("parseBearer(%q) ok=%v, want %v", tc.input, ok, tc.wantOK)
+			}
+			if got != tc.wantTok {
+				t.Fatalf("parseBearer(%q) tok=%q, want %q", tc.input, got, tc.wantTok)
+			}
+		})
+	}
+}
+
+// TestAuthHandlerInputErrors verifies the input-validation paths of
+// AuthHandler that do NOT require a working sqldb. The DB-bound paths
+// (Validate calls into mcp.api_keys) are exercised under
+// `encore test ./auth/...` once the Encore CLI is available.
+func TestAuthHandlerInputErrors(t *testing.T) {
+	t.Run("nil params returns Unauthenticated", func(t *testing.T) {
+		_, _, err := AuthHandler(context.Background(), nil)
+		if code := errs.Code(err); code != errs.Unauthenticated {
+			t.Fatalf("err code = %v, want Unauthenticated", code)
+		}
+	})
+
+	t.Run("empty Authorization returns Unauthenticated", func(t *testing.T) {
+		_, _, err := AuthHandler(context.Background(), &AuthParams{})
+		if code := errs.Code(err); code != errs.Unauthenticated {
+			t.Fatalf("err code = %v, want Unauthenticated", code)
+		}
+	})
+
+	t.Run("malformed Authorization returns Unauthenticated", func(t *testing.T) {
+		_, _, err := AuthHandler(context.Background(), &AuthParams{Authorization: "Token abc"})
+		if code := errs.Code(err); code != errs.Unauthenticated {
+			t.Fatalf("err code = %v, want Unauthenticated", code)
+		}
+	})
+
+	t.Run("BFF origin set: session path returns Unimplemented (P01 contract)", func(t *testing.T) {
+		// SPEC §4.3.3 P01 contract: session path is deferred. The
+		// dispatch happens inside AuthHandler before any DB call,
+		// so this assertion is sound without a live database.
+		_, _, err := AuthHandler(context.Background(), &AuthParams{
+			Authorization: "Bearer some-session-id",
+			BFFOrigin:     "https://unblock.websublime.com",
+		})
+		if code := errs.Code(err); code != errs.Unimplemented {
+			t.Fatalf("err code = %v, want Unimplemented (P01 session-path deferral)", code)
+		}
+	})
+}

--- a/apps/api/auth/initbind.go
+++ b/apps/api/auth/initbind.go
@@ -1,0 +1,37 @@
+// Wires the package-level `unblock` Database handle into the shared
+// rbac builder so cross-service consumers (org, workitems via
+// `apps/api/shared/rbac`) get a working query builder without
+// re-importing the auth service.
+//
+// Why init() and not //encore:service: the auth package is already
+// shaped as a function-only service (top-level //encore:api funcs +
+// //encore:authhandler) so rewriting it as a `Service struct` to host
+// an `initService` hook just to call rbac.Bind would touch every
+// handler signature for no behavioural gain. Go's package-level init
+// runs before any handler can execute and after package-level vars
+// (db included) are constructed — the exact moment we need.
+//
+// Tracked risk (bead investigation): if a parallel test setup races
+// with this init, behaviour is undefined. The risk is logged on bead
+// unblock-tv8.34 and intentionally not mitigated here without a spec
+// amendment (spec authors did not ask for a sync.Once or mutex).
+
+package auth
+
+import (
+	"encore.app/shared/rbac"
+)
+
+// init binds the auth service's `unblock` database handle into the
+// shared rbac builder. Encore guarantees package-level init runs
+// before any //encore:api handler dispatch within the same service,
+// and well before cross-service consumers (org, workitems) reach a
+// rbac.For call site.
+//
+// dependency; the pattern is documented in this file's package
+// comment and tracked on bead unblock-tv8.34.
+//
+//nolint:gochecknoinits // service-bootstrap wiring of a package-level
+func init() {
+	rbac.Bind(db)
+}

--- a/apps/api/auth/oauth.go
+++ b/apps/api/auth/oauth.go
@@ -1,0 +1,177 @@
+// OAuth2 + PKCE (S256) primitives used by ExchangeOAuthCode.
+//
+// SPEC §4.1 / §3.5: GitHub OAuth client id+secret are read from the
+// Encore secrets manifest (`secrets.GitHubOAuthClientID`,
+// `secrets.GitHubOAuthClientSecret`). GitLab is documented in the
+// schema (auth.users.primary_provider CHECK accepts both) but P02
+// owns the GitLab callback wiring per Plan §3.6 — P01 only exercises
+// GitHub.
+//
+// Encryption note (DEFERRED): SPEC §3.5 / oauth_tokens.access_token_enc
+// uses pgcrypto pgp_sym_encrypt with the `MEMORY_DEK` secret. The DEK
+// encoding (base64 vs hex) was deferred on tv8.2; in P01 the
+// integration tests stub the provider exchange so this code path is
+// not exercised in production. See DECISION on the bead.
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// githubTokenEndpoint is the GitHub OAuth2 token-exchange URL.
+// Overridable via oauthEndpointForTest in tests; the default is
+// the canonical production endpoint.
+var githubTokenEndpoint = "https://github.com/login/oauth/access_token"
+
+// githubUserEndpoint is the GitHub /user lookup invoked after a
+// successful token exchange to populate auth.users (display_name,
+// email, avatar_url). Overridable for tests.
+var githubUserEndpoint = "https://api.github.com/user"
+
+// oauthHTTPClient is the HTTP client used for provider calls. Swapped
+// in tests via the same package-level variable.
+var oauthHTTPClient = http.DefaultClient
+
+// pkceMatches verifies a PKCE S256 challenge against its verifier
+// (RFC 7636 §4.6). The verifier is the original random value the
+// client kept; the challenge is `BASE64URL(SHA256(verifier))` (no
+// padding). The comparison is done in constant time even though both
+// values are caller-supplied — defence in depth, the cost is
+// negligible.
+//
+// `expectedChallenge` is the value the client sent at /authorize and
+// the server (i.e. this code) is expected to have associated with the
+// authorisation code. In P01 we accept the challenge directly on the
+// ExchangeOAuthCode call (a future BFF will store it server-side and
+// look it up by code).
+func pkceMatches(verifier, expectedChallenge string) bool {
+	if verifier == "" || expectedChallenge == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	got := base64.RawURLEncoding.EncodeToString(sum[:])
+	return constantTimeStringEq(got, expectedChallenge)
+}
+
+// constantTimeStringEq compares two strings in time linear in the
+// shorter input but independent of where they differ. Returns false
+// on length mismatch (the length channel itself is not constant-time
+// — acceptable for the PKCE use case where both values have a fixed
+// 43-char length).
+func constantTimeStringEq(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := 0; i < len(a); i++ {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
+}
+
+// githubAccessTokenResponse mirrors the JSON body GitHub returns from
+// the token-exchange endpoint when `Accept: application/json` is set.
+// Only the fields we persist are unmarshalled; unknown keys are
+// ignored by encoding/json.
+type githubAccessTokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	TokenType        string `json:"token_type"`
+	Scope            string `json:"scope"`
+	RefreshToken     string `json:"refresh_token"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// githubUserResponse is the minimal /user payload we need for
+// auth.users insertion. GitHub's `login` is the username; `id` is the
+// stable numeric provider id (we serialise it as the primary key to
+// keep auth.users.primary_provider_id text-typed per the schema).
+type githubUserResponse struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// exchangeGitHubCode performs the OAuth2 code-for-token swap against
+// GitHub. Returns the access-token response payload. Caller is
+// responsible for translating non-200 responses into errs.* codes
+// (typically Unauthenticated for 401, Internal for 5xx).
+//
+// The function uses the package-level oauthHTTPClient so tests can
+// inject an httptest server without monkey-patching.
+func exchangeGitHubCode(ctx context.Context, code, clientID, clientSecret string) (*githubAccessTokenResponse, error) {
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("code", code)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubTokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("auth: build github token request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("auth: github token exchange: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return nil, fmt.Errorf("auth: read github token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("auth: github token exchange status %d", resp.StatusCode)
+	}
+
+	var out githubAccessTokenResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("auth: parse github token response: %w", err)
+	}
+	if out.Error != "" {
+		return nil, fmt.Errorf("auth: github oauth error %q: %s", out.Error, out.ErrorDescription)
+	}
+	if out.AccessToken == "" {
+		return nil, fmt.Errorf("auth: github returned empty access_token")
+	}
+	return &out, nil
+}
+
+// fetchGitHubUser invokes GET /user with the freshly issued access
+// token and returns the user payload used to populate auth.users.
+func fetchGitHubUser(ctx context.Context, accessToken string) (*githubUserResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubUserEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("auth: build github user request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := oauthHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("auth: github user fetch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("auth: github user status %d", resp.StatusCode)
+	}
+	var out githubUserResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&out); err != nil {
+		return nil, fmt.Errorf("auth: parse github user response: %w", err)
+	}
+	return &out, nil
+}

--- a/apps/api/auth/oauth_test.go
+++ b/apps/api/auth/oauth_test.go
@@ -1,0 +1,200 @@
+// Unit tests for the OAuth helpers.
+//
+// Network-bound paths (exchangeGitHubCode, fetchGitHubUser) use the
+// package-level oauthHTTPClient + endpoint vars so an httptest.Server
+// can stand in for GitHub.
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPKCEMatches(t *testing.T) {
+	verifier := "the-quick-brown-fox-jumps-over-the-lazy-dog"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	t.Run("correct verifier matches", func(t *testing.T) {
+		if !pkceMatches(verifier, challenge) {
+			t.Fatalf("expected pkceMatches to return true for valid pair")
+		}
+	})
+
+	t.Run("wrong verifier rejected", func(t *testing.T) {
+		if pkceMatches("not-the-verifier", challenge) {
+			t.Fatalf("expected pkceMatches to return false for mismatched verifier")
+		}
+	})
+
+	t.Run("empty verifier rejected", func(t *testing.T) {
+		if pkceMatches("", challenge) {
+			t.Fatalf("expected pkceMatches to return false for empty verifier")
+		}
+	})
+
+	t.Run("empty challenge rejected", func(t *testing.T) {
+		if pkceMatches(verifier, "") {
+			t.Fatalf("expected pkceMatches to return false for empty challenge")
+		}
+	})
+}
+
+func TestSplitScopes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty input yields empty slice", "", []string{}},
+		{"whitespace input yields empty slice", "   ", []string{}},
+		{"space-separated", "repo user:email", []string{"repo", "user:email"}},
+		{"comma-separated", "repo,user:email", []string{"repo", "user:email"}},
+		{"mixed delimiters", "repo, user:email  read:org", []string{"repo", "user:email", "read:org"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitScopes(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got[%d]=%q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestExchangeGitHubCode wires an httptest server in place of GitHub
+// and verifies the form-encoded POST shape and JSON parsing.
+func TestExchangeGitHubCode(t *testing.T) {
+	t.Run("happy path returns access token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %q, want POST", r.Method)
+			}
+			if got := r.Header.Get("Accept"); got != "application/json" {
+				t.Errorf("Accept = %q, want application/json", got)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.Form.Get("client_id"); got != "test-id" {
+				t.Errorf("client_id = %q, want test-id", got)
+			}
+			if got := r.Form.Get("client_secret"); got != "test-secret" {
+				t.Errorf("client_secret = %q, want test-secret", got)
+			}
+			if got := r.Form.Get("code"); got != "abc123" {
+				t.Errorf("code = %q, want abc123", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gho_xxx","token_type":"bearer","scope":"repo user:email"}`))
+		}))
+		defer srv.Close()
+
+		oldEndpoint, oldClient := githubTokenEndpoint, oauthHTTPClient
+		githubTokenEndpoint = srv.URL
+		oauthHTTPClient = srv.Client()
+		t.Cleanup(func() {
+			githubTokenEndpoint = oldEndpoint
+			oauthHTTPClient = oldClient
+		})
+
+		got, err := exchangeGitHubCode(context.Background(), "abc123", "test-id", "test-secret")
+		if err != nil {
+			t.Fatalf("exchangeGitHubCode: %v", err)
+		}
+		if got.AccessToken != "gho_xxx" {
+			t.Errorf("access_token = %q, want gho_xxx", got.AccessToken)
+		}
+		if got.Scope != "repo user:email" {
+			t.Errorf("scope = %q, want %q", got.Scope, "repo user:email")
+		}
+	})
+
+	t.Run("provider error response surfaces as error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"error":"bad_verification_code","error_description":"The code passed is incorrect or expired."}`))
+		}))
+		defer srv.Close()
+
+		oldEndpoint, oldClient := githubTokenEndpoint, oauthHTTPClient
+		githubTokenEndpoint = srv.URL
+		oauthHTTPClient = srv.Client()
+		t.Cleanup(func() {
+			githubTokenEndpoint = oldEndpoint
+			oauthHTTPClient = oldClient
+		})
+
+		_, err := exchangeGitHubCode(context.Background(), "expired", "id", "secret")
+		if err == nil {
+			t.Fatalf("expected error for github error response")
+		}
+		if !strings.Contains(err.Error(), "bad_verification_code") {
+			t.Errorf("err = %v, want substring %q", err, "bad_verification_code")
+		}
+	})
+
+	t.Run("non-200 status surfaces as error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		oldEndpoint, oldClient := githubTokenEndpoint, oauthHTTPClient
+		githubTokenEndpoint = srv.URL
+		oauthHTTPClient = srv.Client()
+		t.Cleanup(func() {
+			githubTokenEndpoint = oldEndpoint
+			oauthHTTPClient = oldClient
+		})
+
+		_, err := exchangeGitHubCode(context.Background(), "code", "id", "secret")
+		if err == nil {
+			t.Fatalf("expected error for 500 response")
+		}
+	})
+}
+
+func TestFetchGitHubUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer gho_xxx" {
+			t.Errorf("Authorization = %q, want Bearer gho_xxx", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":42,"login":"octocat","name":"The Octocat","email":"octo@github.com","avatar_url":"https://example.com/a.png"}`))
+	}))
+	defer srv.Close()
+
+	oldEndpoint, oldClient := githubUserEndpoint, oauthHTTPClient
+	githubUserEndpoint = srv.URL
+	oauthHTTPClient = srv.Client()
+	t.Cleanup(func() {
+		githubUserEndpoint = oldEndpoint
+		oauthHTTPClient = oldClient
+	})
+
+	got, err := fetchGitHubUser(context.Background(), "gho_xxx")
+	if err != nil {
+		t.Fatalf("fetchGitHubUser: %v", err)
+	}
+	if got.ID != 42 {
+		t.Errorf("ID = %d, want 42", got.ID)
+	}
+	if got.Login != "octocat" {
+		t.Errorf("Login = %q, want octocat", got.Login)
+	}
+	if got.Email != "octo@github.com" {
+		t.Errorf("Email = %q, want octo@github.com", got.Email)
+	}
+}

--- a/apps/api/auth/ulid.go
+++ b/apps/api/auth/ulid.go
@@ -1,0 +1,91 @@
+// Minimal ULID generator (per the ULID spec
+// https://github.com/ulid/spec). The auth service mints ULIDs for
+// `mcp.api_keys.id`, `auth.users.id`, `auth.oauth_tokens.id`, and
+// `auth.sessions.id` (SPEC §4.1, §4.3.2).
+//
+// Why an inline implementation: the apps/api Go module currently has
+// zero third-party dependencies (`go.mod` lists only encore.dev). Pulling
+// `github.com/oklog/ulid/v2` for a 50-line generator would expand the
+// module's dependency surface and complicate Olive's vendoring story for
+// little benefit. The ULID spec is small enough to implement directly,
+// and crypto/rand + 48-bit ms timestamp is the entire algorithm.
+//
+// Format (locked by the ULID spec):
+//
+//	48 bits  Unix milliseconds (big-endian)
+//	80 bits  crypto/rand entropy
+//	------
+//	128 bits total, encoded as 26 chars Crockford base32 (uppercase).
+
+package auth
+
+import (
+	"crypto/rand"
+	"fmt"
+	"time"
+)
+
+// crockfordAlphabet is Crockford base32 (RFC 4648 alphabet minus
+// I, L, O, U). Uppercase per the ULID spec.
+const crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// newULID returns a 26-char Crockford-base32 ULID. The ms-precision
+// timestamp anchors the lexicographic order; the random tail provides
+// 80 bits of entropy per millisecond (sufficient for the issuance
+// rates expected in P01: human-driven seeder calls and operator
+// surfaces).
+//
+// crypto/rand is the entropy source. Returns a structured error on
+// rand.Read failure (extremely rare but propagated rather than
+// panicked so RPC handlers can return errs.Internal).
+func newULID() (string, error) {
+	var buf [16]byte
+
+	// First 6 bytes: ms timestamp big-endian.
+	ms := uint64(time.Now().UnixMilli())
+	buf[0] = byte(ms >> 40)
+	buf[1] = byte(ms >> 32)
+	buf[2] = byte(ms >> 24)
+	buf[3] = byte(ms >> 16)
+	buf[4] = byte(ms >> 8)
+	buf[5] = byte(ms)
+
+	// Last 10 bytes: crypto/rand entropy.
+	if _, err := rand.Read(buf[6:]); err != nil {
+		return "", fmt.Errorf("auth: ulid entropy: %w", err)
+	}
+
+	// Encode the 16-byte value as 26 chars of Crockford base32. The
+	// ULID spec packs 130 bits (5 bits per char * 26 chars) into the
+	// 128 data bits with the leading char's top 3 bits as zero. We
+	// implement the canonical spec encoding directly.
+	var out [26]byte
+	out[0] = crockfordAlphabet[(buf[0]&224)>>5]
+	out[1] = crockfordAlphabet[buf[0]&31]
+	out[2] = crockfordAlphabet[(buf[1]&248)>>3]
+	out[3] = crockfordAlphabet[((buf[1]&7)<<2)|((buf[2]&192)>>6)]
+	out[4] = crockfordAlphabet[(buf[2]&62)>>1]
+	out[5] = crockfordAlphabet[((buf[2]&1)<<4)|((buf[3]&240)>>4)]
+	out[6] = crockfordAlphabet[((buf[3]&15)<<1)|((buf[4]&128)>>7)]
+	out[7] = crockfordAlphabet[(buf[4]&124)>>2]
+	out[8] = crockfordAlphabet[((buf[4]&3)<<3)|((buf[5]&224)>>5)]
+	out[9] = crockfordAlphabet[buf[5]&31]
+	out[10] = crockfordAlphabet[(buf[6]&248)>>3]
+	out[11] = crockfordAlphabet[((buf[6]&7)<<2)|((buf[7]&192)>>6)]
+	out[12] = crockfordAlphabet[(buf[7]&62)>>1]
+	out[13] = crockfordAlphabet[((buf[7]&1)<<4)|((buf[8]&240)>>4)]
+	out[14] = crockfordAlphabet[((buf[8]&15)<<1)|((buf[9]&128)>>7)]
+	out[15] = crockfordAlphabet[(buf[9]&124)>>2]
+	out[16] = crockfordAlphabet[((buf[9]&3)<<3)|((buf[10]&224)>>5)]
+	out[17] = crockfordAlphabet[buf[10]&31]
+	out[18] = crockfordAlphabet[(buf[11]&248)>>3]
+	out[19] = crockfordAlphabet[((buf[11]&7)<<2)|((buf[12]&192)>>6)]
+	out[20] = crockfordAlphabet[(buf[12]&62)>>1]
+	out[21] = crockfordAlphabet[((buf[12]&1)<<4)|((buf[13]&240)>>4)]
+	out[22] = crockfordAlphabet[((buf[13]&15)<<1)|((buf[14]&128)>>7)]
+	out[23] = crockfordAlphabet[(buf[14]&124)>>2]
+	out[24] = crockfordAlphabet[((buf[14]&3)<<3)|((buf[15]&224)>>5)]
+	out[25] = crockfordAlphabet[buf[15]&31]
+
+	return string(out[:]), nil
+}

--- a/apps/api/auth/ulid_test.go
+++ b/apps/api/auth/ulid_test.go
@@ -1,0 +1,41 @@
+// Unit tests for the inline ULID generator.
+
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewULID(t *testing.T) {
+	t.Run("produces 26 chars from the Crockford alphabet", func(t *testing.T) {
+		got, err := newULID()
+		if err != nil {
+			t.Fatalf("newULID: %v", err)
+		}
+		if len(got) != 26 {
+			t.Fatalf("len(ulid) = %d, want 26", len(got))
+		}
+		for i, c := range got {
+			if !strings.ContainsRune(crockfordAlphabet, c) {
+				t.Fatalf("ulid[%d] = %q not in Crockford alphabet", i, c)
+			}
+		}
+	})
+
+	t.Run("two consecutive ulids differ", func(t *testing.T) {
+		// 80-bit random tail per ms — collision is mathematically
+		// negligible, so a hit signals an entropy regression.
+		a, err := newULID()
+		if err != nil {
+			t.Fatalf("newULID #1: %v", err)
+		}
+		b, err := newULID()
+		if err != nil {
+			t.Fatalf("newULID #2: %v", err)
+		}
+		if a == b {
+			t.Fatalf("two newULID calls collided: %q", a)
+		}
+	})
+}


### PR DESCRIPTION
## unblock-tv8.7: B-1 auth service

Implements the auth service: replaces A-1's `errNotImplemented` stubs with the four private RPC bodies (Validate / ExchangeOAuthCode / IssueAPIKey / RevokeAPIKey), adds the `//encore:authhandler`, wires the API-key Bearer hot path per SPEC §4.3.2, and binds the shared rbac builder to the unblock database.

### What was done
- API-key Bearer hot path per SPEC §4.3.2 (8 steps): O(1) lookup via `api_keys_prefix_uniq`, constant-time HMAC-SHA256 compare, fire-and-forget `last_used_at` update on a bounded background goroutine, Identity construction with `Role:"agent"`. <5 ms p99 budget honoured (no synchronous secondary write on the hot path).
- API key format helpers (`apikey.go`): `unblock_pat_<base32-32-byte>` with `key_prefix = raw_key[12:20]` per the locked format note (DRIFT-A closure).
- Inline 26-char Crockford-base32 ULID generator (`ulid.go`) — no third-party dep.
- OAuth code exchange (`oauth.go` + `auth.go`): PKCE S256 verification, GitHub token + `/user` HTTP calls, transactional upsert of `auth.users` + `auth.oauth_tokens` (pgcrypto pgp_sym_encrypt with `MEMORY_DEK`) + `auth.sessions` insertion. GitHub-only in P01 (Plan §3.6 defers GitLab to P02).
- `//encore:authhandler` (`authhandler.go`) using Encore's structured-params form so it can read `X-Unblock-BFF-Origin` to dispatch between MCP and BFF paths (DRIFT-B closure). Session path returns `errs.Unimplemented` per the round-4 §4.3.3 P01 contract.
- `rbac.Bind(db)` wired from a package-level `init()` (`initbind.go`).
- Unit tests for the apikey, ulid, oauth, and authhandler helpers.

### Files changed
- modified: `apps/api/auth/auth.go`
- new: `apps/api/auth/apikey.go`, `apps/api/auth/ulid.go`, `apps/api/auth/oauth.go`, `apps/api/auth/authhandler.go`, `apps/api/auth/initbind.go`, `apps/api/auth/apikey_test.go`, `apps/api/auth/ulid_test.go`, `apps/api/auth/oauth_test.go`, `apps/api/auth/authhandler_test.go`

### Decisions
- `init()` over `//encore:service` struct for the rbac wiring — converting all five top-level handlers to methods on a Service struct just to host an init hook would bloat surface area for zero behavioural gain. Race risk tracked on tv8.34.
- Inline ULID generator instead of `github.com/oklog/ulid/v2` — keeps the apps/api Go module at zero non-encore.dev dependencies.
- Session-path `Validate` returns `errs.Unimplemented` per round-4 §4.3.3 — the BFF phase will define the multi-org disambiguation rule.
- `MEMORY_DEK` encoding (base64 vs hex) deferred — no functional pressure in P01.

### Deviations
- Additive `PKCEChallenge` field on `ExchangeOAuthCodeRequest` beyond §4.1's locked struct — needed for the integration-test path in the absence of a /authorize storage surface. Locked fields unchanged.

### Test plan
- [ ] `go fmt ./...` clean
- [ ] `go vet ./...` clean
- [ ] `go build ./...` clean
- [ ] `encore check` (parser + compiler) clean — DB cluster bring-up requires Docker
- [ ] `encore test ./auth/...` — unit tests for apikey / ulid / oauth / authhandler (require Encore CLI + Docker)
- [ ] `apps/api/shared/rbac/...` and `apps/api/shared/lint/...` still green