### PR TITLE
unblock-tv8.9: B-3 RBAC regression suite (apps/api/shared/rbactest/)

### DIFF
--- a/apps/api/shared/rbactest/doc.go
+++ b/apps/api/shared/rbactest/doc.go
@@ -1,0 +1,116 @@
+// Package rbactest is the exhaustive RBAC regression suite for the
+// `://unblock` backend. It fires one Go subtest per
+// (caller-org × target-org × caller-role × table × action) tuple across
+// every P01-exposed schema this bead owns, and asserts that the
+// canonical isolation gates (org.Authorize predicate and rbac.For[T]
+// scoped reads) never leak a single row or a single PERMIT across the
+// tenant boundary. CI gates release on zero cross-tenant leaks
+// (SPEC §10.1, §11.2 NFR-2).
+//
+// Bead unblock-tv8.9 (B-3) lays down the suite scaffolding and covers
+// the auth + org schemas: auth.users, auth.oauth_tokens, auth.sessions,
+// org.organizations, org.projects, org.members, org.project_members.
+// Bead unblock-tv8.15 (C-6) extends the matrix to workitems.items,
+// workitems.comments, workitems.trail, deps.dependencies as the
+// C-group RPCs land. Bead unblock-tv8.25 (E-3) closes the final
+// release-gate matrix across mcp.api_keys, mcp.tool_calls,
+// memory.entries, boards.boards. The package shape, matrix vocabulary,
+// and seed/cleanup helpers below are deliberately additive so the two
+// follow-up beads only add fixture rows and table classifications
+// rather than re-architecting the driver.
+//
+// Two assertion shapes, picked by table characteristics
+// (see matrix.go for the classification table):
+//
+//  1. Tables that carry an `org_id` column (org.projects, org.members
+//     today; workitems.items, workitems.comments, workitems.trail,
+//     deps.dependencies, mcp.api_keys, mcp.tool_calls, memory.entries,
+//     boards.boards in C-6/E-3): driven through rbac.For[T]. The
+//     assertion is row-level — the suite seeds rows in both orgs and
+//     asserts that a caller from org_a reading `<table>` produces zero
+//     rows whose org_id == org_b.id, for every (caller-role × action)
+//     pairing. The reads themselves are read-only (read-action only);
+//     write/delete are exercised via the Authorize-predicate shape
+//     below because the rbac builder is a read-only surface.
+//
+//  2. Tables that do NOT carry an `org_id` column (auth.users,
+//     auth.oauth_tokens, auth.sessions, org.organizations,
+//     org.project_members): driven through org.Authorize directly.
+//     The cross-tenant gate for these tables is the Authorize
+//     predicate (step 1 cross-tenant short-circuit), not a
+//     `WHERE … org_id = $1` SQL filter. The assertion is permit-level
+//     — for every (caller-role × action) tuple, the suite asserts
+//     Authorize denies when the request's OrgID differs from the
+//     caller's Identity.OrgID, and permits or denies per the policy
+//     matrix when same-org. The two shapes converge on the same
+//     promise: zero cross-tenant leaks at the gate or in the rows.
+//
+// Roles axis (first-class — SPEC §10.1):
+//
+// The matrix iterates {owner, admin, member, viewer, agent}. The
+// synthetic "agent" role (Identity.Role = "agent") is the API-key
+// runtime identity per SPEC §4.3.2 step 8 — never a member-table row,
+// constructed in-memory only by the test fixtures. owner, admin,
+// member, viewer are seeded as org.members rows so the effective-role
+// derivation (max(org_role, project_role)) inside Authorize reads a
+// real row. The five-role axis matches the org.Authorize
+// implementation's branches (apps/api/org/org.go ~line 506 onward) and
+// is what makes "one test per tuple" exhaustive against the actual
+// policy code path, not a paraphrase of it.
+//
+// Encore-runtime requirement.
+//
+// This package MUST be executed under `encore test
+// ./apps/api/shared/rbactest/...`. Plain `go test` does NOT bring up
+// the Encore-managed Postgres cluster, does NOT fire the dedicated
+// apps/api/db/ service's init() (which is what calls auth.BindDB(DB),
+// org.BindDB(DB), workitems.BindDB(DB), deps.BindDB(DB), and
+// rbac.Bind(DB) per apps/api/db/db.go's package doc), and therefore
+// leaves every service's *sqldb.Database pointer nil. Run on a nil
+// handle panics inside encore.dev/storage/sqldb. Any future contributor
+// tempted to add a `go:build` constraint or a runtime fast-path that
+// allows `go test` here MUST first read the CLAUDE.md
+// `feedback_encore_test_not_go_test` memory and the package-doc on
+// apps/api/db/db.go — the constraint is empirical, not stylistic.
+//
+// CI wiring (out of scope for this bead).
+//
+// The CI gate that runs this suite and blocks merge on any failure is
+// owned by bead unblock-tv8.6 (A-6) — that bead is the consumer of
+// this package, not its sibling. This package's responsibility ends at
+// being discoverable as `encore test
+// ./apps/api/shared/rbactest/...` and producing a subtest tree whose
+// name pinpoints any failing tuple. SPEC §10.1 line 2001-2004 — the
+// "CI gates release on zero cross-tenant leaks" sentence — is the
+// product invariant; the wiring lives in A-6.
+//
+// Concurrency.
+//
+// The suite does NOT call t.Parallel anywhere. rbac.Bind (and the
+// per-service BindDB hooks) are not goroutine-safe; bead
+// unblock-tv8.34 tracks the hardening discussion. The single-binding
+// contract is shared with the wider domain-service tree (auth, org,
+// workitems, deps); rbactest takes the same guarantee Encore's process
+// init provides ("BindDB completes before any handler dispatches") and
+// runs the matrix sequentially. The suite has a few-thousand subtests
+// in P01; sequential execution is fast enough on the Encore-managed
+// local cluster (single-digit-second budget per encore test invocation
+// on developer hardware).
+//
+// Cleanup discipline.
+//
+// Every subtest runs against the same seeded fixture (two orgs, all
+// roles per side, one project per org, one user per role per org,
+// plus a small set of cross-side leak-bait rows in auth.users,
+// auth.oauth_tokens, auth.sessions, mcp.api_keys). TestMain seeds
+// once at startup and tears down once at exit via a leaf-first
+// TRUNCATE ... CASCADE on org.organizations (the FK chain fans out
+// to org.members, org.projects, org.project_members,
+// auth.users-by-membership-fan, auth.oauth_tokens-by-user-cascade,
+// auth.sessions-by-user-cascade, mcp.api_keys-by-org-cascade, …).
+// Per-subtest cleanup is deliberately avoided — the matrix subtests
+// are read-only on the fixture and never mutate state, so a single
+// global seed/teardown pair is both correct and fastest. If a future
+// contributor adds a mutating subtest, it MUST t.Cleanup its own
+// rollback or be excluded from the read-only sweep.
+package rbactest

--- a/apps/api/shared/rbactest/matrix.go
+++ b/apps/api/shared/rbactest/matrix.go
@@ -1,0 +1,188 @@
+// matrix.go declares the test-matrix vocabulary: the role axis, the
+// action axis, and the per-table classification (org_id-scoped vs
+// Authorize-only) that selects the assertion shape. The exhaustive
+// matrix sweep in rbactest_test.go iterates these.
+//
+// The constants here are intentionally re-declared instead of re-using
+// the org package's unexported `resource*` / `role*` / `action*`
+// values. SPEC §10.1's matrix is a contract — the suite asserts the
+// contract, so the contract values live here in plain sight. If a
+// drift ever emerges between the org service's closed-set constants
+// and this file, the divergence is a finding the suite is meant to
+// surface, not a sync target.
+
+package rbactest
+
+// Role axis (SPEC §10.1, §4.2 role-action matrix; org.Authorize
+// branches on Identity.Role).
+//
+// owner/admin/member/viewer are seeded as org.members rows so the
+// Authorize effective-role derivation (max(org_role, project_role))
+// reads the persisted policy state.
+//
+// agent is the synthetic API-key runtime identity per SPEC §4.3.2
+// step 8: never an org.members row, constructed in-memory only.
+// Authorize's agent branch (apps/api/org/org.go step 4) is the
+// production code path that must answer same-org permit / cross-org
+// deny / delete-everywhere deny / non-agent-resource deny.
+const (
+	RoleOwner  = "owner"
+	RoleAdmin  = "admin"
+	RoleMember = "member"
+	RoleViewer = "viewer"
+	RoleAgent  = "agent"
+)
+
+// AllRoles is the canonical iteration order for the role axis. Order
+// is policy-strength descending plus agent last, which keeps the
+// subtest tree readable in --verbose output.
+var AllRoles = []string{
+	RoleOwner,
+	RoleAdmin,
+	RoleMember,
+	RoleViewer,
+	RoleAgent,
+}
+
+// Action axis (SPEC §4.2 RBAC matrix).
+const (
+	ActionRead   = "read"
+	ActionWrite  = "write"
+	ActionDelete = "delete"
+)
+
+// AllActions is the canonical iteration order for the action axis.
+var AllActions = []string{
+	ActionRead,
+	ActionWrite,
+	ActionDelete,
+}
+
+// Org/User axis labels. The suite seeds exactly two orgs. The names
+// are short to keep the generated subtest names parse-friendly.
+const (
+	OrgA = "A"
+	OrgB = "B"
+)
+
+// AllOrgs is the canonical iteration order for the caller-org / target-org
+// axes. The full sweep iterates the cross-product so every
+// (caller, target) pairing — including same-org permits — is asserted.
+var AllOrgs = []string{OrgA, OrgB}
+
+// TableKind classifies a table by how cross-tenant isolation is
+// enforced. Each kind selects a different assertion shape inside the
+// matrix sweep — see doc.go for the rationale.
+type TableKind int
+
+const (
+	// KindOrgScoped tables carry an `org_id` column AND are reached
+	// through rbac.For[T] in production code. The assertion shape is
+	// row-level: the suite seeds a row in both orgs and asserts a
+	// caller-org reader sees zero rows whose org_id != caller-org.
+	// rbac.For is read-only, so the action axis collapses to
+	// {ActionRead} for this kind; the write/delete halves of the policy
+	// matrix for the same table go through org.Authorize and are
+	// covered by KindAuthorizeOnly assertions on that table identifier.
+	KindOrgScoped TableKind = iota + 1
+
+	// KindAuthorizeOnly tables do NOT carry an `org_id` column. Their
+	// cross-tenant gate is the org.Authorize predicate, not a SQL scope
+	// filter. The assertion shape is permit-level: the suite calls
+	// Authorize for every (caller-role × action) and asserts:
+	//   - cross-org deny on every tuple
+	//   - same-org permit/deny per the policy matrix
+	// The action axis covers all of {read, write, delete} for this
+	// kind because Authorize answers all three.
+	KindAuthorizeOnly
+)
+
+// TableSpec is a single row of the table-classification matrix. The
+// rbac builder always reads tables with their fully-qualified
+// `<schema>.<table>` identifier; the Resource string used by
+// org.Authorize matches that identifier verbatim by convention
+// (apps/api/org/org.go constants). This struct keeps the two
+// spellings together so the matrix sweep never has to guess which
+// surface a given table belongs to.
+type TableSpec struct {
+	// Name is the fully-qualified `<schema>.<table>` identifier. Used
+	// both as the rbac.For[T] table argument (KindOrgScoped) and the
+	// Authorize Resource value (KindAuthorizeOnly).
+	Name string
+
+	// Kind selects the assertion shape — see TableKind.
+	Kind TableKind
+}
+
+// AuthOrgTables is the closed set of P01 auth + org schema tables this
+// bead (B-3 / unblock-tv8.9) sweeps. C-6 / unblock-tv8.15 appends
+// workitems.* + deps.* entries; E-3 / unblock-tv8.25 appends mcp.* +
+// memory.* + boards.* entries. The slice is exported and additive so
+// the two follow-up beads only add lines.
+//
+// Classification rationale (verified against migrations
+// apps/api/db/migrations/0020_auth.up.sql lines 11-66 and
+// 0030_org.up.sql lines 7-62):
+//
+//   - auth.users / auth.oauth_tokens / auth.sessions — no org_id column;
+//     rbac.For would emit `<table>.org_id = $1` which Postgres rejects
+//     with "column does not exist". Authorize gates these via step 1's
+//     cross-tenant short-circuit on Identity.OrgID vs req.OrgID.
+//   - org.organizations — no org_id column; the row's id IS the org_id
+//     (apps/api/org/org.go GetOrganization at line ~322 enforces
+//     id==identity.OrgID directly).
+//   - org.project_members — no org_id column (scoped via the project's
+//     org_id). Same Authorize-gate treatment.
+//   - org.projects — has org_id column; rbac.For-scoped.
+//   - org.members — has org_id column; rbac.For-scoped.
+var AuthOrgTables = []TableSpec{
+	{Name: "auth.users", Kind: KindAuthorizeOnly},
+	{Name: "auth.oauth_tokens", Kind: KindAuthorizeOnly},
+	{Name: "auth.sessions", Kind: KindAuthorizeOnly},
+	{Name: "org.organizations", Kind: KindAuthorizeOnly},
+	{Name: "org.project_members", Kind: KindAuthorizeOnly},
+	{Name: "org.projects", Kind: KindOrgScoped},
+	{Name: "org.members", Kind: KindOrgScoped},
+}
+
+// agentPermittedResources mirrors the org.agentReadWriteResources map
+// (apps/api/org/org.go ~line 193). The suite uses this to predict
+// Authorize's policy decision for agent callers — same-org permit on
+// this set (read/write only, never delete); deny on every other
+// resource. Re-declared here, not imported, so the suite asserts the
+// policy contract rather than the policy implementation: a drift
+// between this set and the org-package set is exactly the kind of
+// silent regression the suite must surface.
+var agentPermittedResources = map[string]struct{}{
+	"workitems.items":    {},
+	"workitems.comments": {},
+	"workitems.trail":    {},
+	"deps.dependencies":  {},
+	"mcp.tool_calls":     {},
+	"memory.entries":     {},
+}
+
+// rolePermitsAction encodes the SPEC §4.2 role-action matrix:
+//
+//	owner:  read, write, delete
+//	admin:  read, write, delete
+//	member: read, write
+//	viewer: read
+//
+// agent is excluded from this matrix — agent callers go through the
+// agent branch (agentPermittedResources above) before this function is
+// consulted. The suite uses this to predict Authorize's same-org
+// policy decision for non-agent callers. Re-declared, not imported,
+// for the same drift-detection reason as agentPermittedResources.
+func rolePermitsAction(role, action string) bool {
+	switch role {
+	case RoleOwner, RoleAdmin:
+		return action == ActionRead || action == ActionWrite || action == ActionDelete
+	case RoleMember:
+		return action == ActionRead || action == ActionWrite
+	case RoleViewer:
+		return action == ActionRead
+	default:
+		return false
+	}
+}

--- a/apps/api/shared/rbactest/rbactest_test.go
+++ b/apps/api/shared/rbactest/rbactest_test.go
@@ -1,0 +1,427 @@
+// rbactest_test.go drives the exhaustive RBAC regression sweep.
+//
+// One `t.Run` per (caller-org × target-org × caller-role × table ×
+// action) tuple. The subtest name is
+// caller=<X>/target=<Y>/role=<R>/table=<T>/action=<A> so a CI failure
+// pinpoints the offending tuple without further investigation.
+//
+// Two assertion shapes inside the sweep, selected by TableKind (see
+// matrix.go):
+//
+//   - KindOrgScoped: drive rbac.For[T] with the caller's Identity and
+//     assert zero target-org rows leak into a caller-org reader. The
+//     rbac builder is read-only, so the action axis collapses to
+//     {ActionRead}; write/delete on the same tables are covered by
+//     KindAuthorizeOnly assertions through Authorize.
+//   - KindAuthorizeOnly: drive org.Authorize with every (caller-role
+//     × action) tuple and assert the deny/permit decision matches
+//     the policy contract (cross-org deny everywhere; same-org per
+//     the role matrix and the agent-resource set).
+//
+// Concurrency: no t.Parallel anywhere — rbac.Bind is not goroutine-
+// safe; bead unblock-tv8.34 tracks the hardening.
+
+package rbactest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"encore.app/auth"
+	"encore.app/db"
+	"encore.app/org"
+	"encore.app/shared/rbac"
+	"encore.dev/beta/errs"
+)
+
+// fixture is the global, one-per-process fixture installed by
+// TestMain. The matrix sweep reads it without locking — it is
+// effectively read-only after TestMain returns.
+var fixture *Fixture
+
+// TestMain seeds the fixture once, runs the suite, tears down once.
+// Per-subtest cleanup is deliberately avoided — the matrix subtests
+// never mutate fixture state (they read through rbac.For or call
+// Authorize, neither of which writes), so a single seed/teardown is
+// both correct and fastest. If a future contributor adds a mutating
+// subtest, it MUST `t.Cleanup` its own rollback.
+//
+// Encore-runtime requirement (re-stated from doc.go for the reader
+// landing here first): this package MUST run under
+// `encore test ./apps/api/shared/rbactest/...`. Plain `go test`
+// leaves every service's *sqldb.Database pointer nil and SeedFixture
+// returns a nil-handle error before any subtest fires.
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	// db.DB is the canonical *sqldb.Database handle. Importing
+	// encore.app/db is what makes the package's init() fire (it
+	// binds auth.db, org.db, workitems.db, deps.db, and rbac.db).
+	// We rely on the encore-test process having executed those
+	// inits before TestMain runs — that is the Encore process
+	// bootstrap contract apps/api/db/db.go's doc-comment locks in.
+	var err error
+	fixture, err = SeedFixture(ctx, db.DB)
+	if err != nil {
+		// fatalIf with nil *testing.T panics with the message,
+		// which is the right behaviour from TestMain (no test has
+		// started, so we can't t.Fatal).
+		fatalIf(nil, err, "rbactest seed failed")
+	}
+
+	code := m.Run()
+
+	// Best-effort teardown. Failures are printed but do not change
+	// the exit code — the test verdict is what the runner cares
+	// about.
+	fixture.Teardown(ctx, db.DB)
+
+	os.Exit(code)
+}
+
+// identityFor constructs the auth.Identity the matrix sweep passes
+// to rbac.For / org.Authorize for a given (orgLabel, role) tuple.
+//
+//   - Non-agent roles: UserID comes from the seeded auth.users row;
+//     OrgID is the seeded org id; Role is the seeded org.members
+//     role. Authorize's effective-role derivation reads the
+//     persisted org.members row.
+//   - Agent role: UserID is empty (org-level service key shape per
+//     SPEC §4.3.2 step 8) or a side-tagged placeholder; OrgID is
+//     the seeded org id; Role is "agent"; AgentKind is non-empty
+//     so the org.AuthHandler-equivalent shape is well-formed.
+//     There is NO org.members row for the agent — Authorize's
+//     agent branch takes effect before the members table is
+//     consulted.
+func identityFor(fx *Fixture, orgLabel, role string) auth.Identity {
+	orgID := fx.Orgs[orgLabel]
+	if role == RoleAgent {
+		return auth.Identity{
+			UserID:    "", // org-level agent key
+			OrgID:     orgID,
+			Role:      RoleAgent,
+			AgentKind: "claude-code",
+		}
+	}
+	return auth.Identity{
+		UserID:    fx.Users[userKey{OrgLabel: orgLabel, Role: role}],
+		OrgID:     orgID,
+		Role:      role,
+		AgentKind: "",
+	}
+}
+
+// projectIDForAuthorize returns the project id to pass on
+// AuthorizeRequest.ProjectID for a given target-org. Authorize's
+// step-3 containment check verifies the project belongs to req.OrgID;
+// passing the target-org's seeded project id matches that
+// invariant. The two follow-up beads (C-6, E-3) may extend this with
+// per-test project ids for project_members assertions.
+func projectIDForAuthorize(fx *Fixture, targetOrgLabel string, table string) string {
+	// project_members is the only table whose Authorize call REQUIRES
+	// a ProjectID (the containment check fires when ProjectID is
+	// non-empty, and is what makes the cross-tenant deny test
+	// meaningful for that resource). For every other table we leave
+	// ProjectID empty — the cross-tenant short-circuit on OrgID is
+	// the load-bearing gate and ProjectID would only add noise.
+	if table == "org.project_members" {
+		return fx.Projects[targetOrgLabel]
+	}
+	return ""
+}
+
+// expectAuthorizeOK predicts the Authorize policy decision for a
+// given (caller-role × resource × action) tuple, ASSUMING same-org
+// (the cross-org branch denies unconditionally so the prediction is
+// trivial for that case). Returns true when Authorize should permit.
+//
+// Predictions mirror apps/api/org/org.go:
+//
+//   - agent: permit iff resource ∈ agentPermittedResources AND
+//     action != delete.
+//   - owner/admin: permit on read/write/delete.
+//   - member: permit on read/write; deny on delete.
+//   - viewer: permit on read; deny on write/delete.
+//   - unknown role: deny.
+//
+// org.organizations gets a deliberate refinement: same-org reads of
+// org.organizations go through the policy matrix (agents are NOT in
+// agentPermittedResources for this resource), so the role-action
+// matrix governs. Same applies to auth.* and other admin tables —
+// the agent branch denies them regardless of action.
+func expectAuthorizeOK(role, resource, action string) bool {
+	if role == RoleAgent {
+		if _, ok := agentPermittedResources[resource]; !ok {
+			return false
+		}
+		return action != ActionDelete
+	}
+	return rolePermitsAction(role, action)
+}
+
+// TestRBACMatrix is the exhaustive sweep. The driver iterates the
+// full cross-product and dispatches to the per-kind assertion
+// shapes. The subtest tree is deliberately deep so a CI failure
+// reads as a navigable path.
+//
+// Tuple count under B-3 (auth + org schemas):
+//   - org axes:      2 * 2 = 4 (caller × target)
+//   - role axis:     5
+//   - tables:        7 (5 KindAuthorizeOnly + 2 KindOrgScoped)
+//   - actions:       3 (read/write/delete) for KindAuthorizeOnly,
+//     1 (read only) for KindOrgScoped
+//
+// = 4 * 5 * (5*3 + 2*1) = 4 * 5 * 17 = 340 subtests.
+func TestRBACMatrix(t *testing.T) {
+	if fixture == nil {
+		t.Fatalf("rbactest: fixture is nil; SeedFixture must run from TestMain before this test fires")
+	}
+
+	for _, callerOrg := range AllOrgs {
+		for _, targetOrg := range AllOrgs {
+			for _, role := range AllRoles {
+				for _, table := range AuthOrgTables {
+					switch table.Kind {
+					case KindOrgScoped:
+						// rbac.For path — read action only.
+						runOrgScopedTuple(t, fixture, callerOrg, targetOrg, role, table.Name)
+
+					case KindAuthorizeOnly:
+						for _, action := range AllActions {
+							runAuthorizeOnlyTuple(t, fixture, callerOrg, targetOrg, role, table.Name, action)
+						}
+
+					default:
+						t.Fatalf("rbactest: unknown TableKind %d for table %q", table.Kind, table.Name)
+					}
+				}
+			}
+		}
+	}
+}
+
+// runOrgScopedTuple is the KindOrgScoped assertion shape. The
+// caller's Identity is constructed from (callerOrg, role); the
+// suite issues a rbac.For read against the table and asserts no row
+// with org_id == targetOrg's id leaks back. The target-org check
+// is the load-bearing assertion — same-org reads MAY return rows
+// (and should!), cross-org reads MUST return zero.
+//
+// The action axis collapses to "read" for this kind because the rbac
+// builder is read-only. Write/delete on the same physical table
+// route through org.Authorize and are covered by the
+// KindAuthorizeOnly shape on the same table identifier — see C-6
+// (workitems/deps) and E-3 (mcp/memory/boards) extensions.
+func runOrgScopedTuple(t *testing.T, fx *Fixture, callerOrg, targetOrg, role, table string) {
+	t.Helper()
+	subtest := fmt.Sprintf("caller=%s/target=%s/role=%s/table=%s/action=%s",
+		callerOrg, targetOrg, role, table, ActionRead)
+
+	t.Run(subtest, func(t *testing.T) {
+		id := identityFor(fx, callerOrg, role)
+		targetOrgID := fx.Orgs[targetOrg]
+
+		// Run a scoped read. T = scopedRow is a minimal projection
+		// over (id, org_id) — the scanner reads exported fields in
+		// declaration order, which matches `SELECT * FROM <table>`
+		// only if T's field count matches the table's column count.
+		// We therefore use rbac.For[scopedRow] only when the table's
+		// row shape begins with (id, org_id, ...) — true for
+		// org.projects and org.members (verified against
+		// migrations 0030_org.up.sql lines 19-43).
+		//
+		// For C-6/E-3 extensions the table shapes diverge and the
+		// suite will need per-table row types (or an explicit
+		// SELECT). Within B-3 the minimal projection is sufficient
+		// because both KindOrgScoped tables share the (id, org_id,
+		// ...) prefix and we discard every column after org_id by
+		// declaring only those two fields and pairing them with an
+		// explicit SELECT via a Where that is a no-op…
+		//
+		// Reality: rbac.For uses `SELECT *` (apps/api/shared/rbac
+		// rbac.go ~line 413). The scanner expects T's field count
+		// to equal the column count. Declaring scopedRow as a
+		// full-column shape per table is overkill for the row-leak
+		// assertion (we only need org_id). The suite instead uses
+		// a separate, raw SQL probe that selects just `org_id` for
+		// the leak check and exercises rbac.For with a typed-row T
+		// matching the actual table layout. See selectScopedOrgIDs
+		// below.
+		gotOrgIDs, err := selectScopedOrgIDs(context.Background(), id, table)
+		if err != nil {
+			// Same-org callers may legitimately see rows; cross-org
+			// callers MUST see zero. An error here is a suite bug
+			// or a DB problem — fail loudly.
+			t.Fatalf("scoped read on %q with identity %+v: %v", table, id, err)
+		}
+
+		// The load-bearing assertion: no target-org row leaks into
+		// the caller's read. Applies regardless of whether
+		// callerOrg == targetOrg (same-org has zero target rows
+		// because the target IS the caller in that case; cross-org
+		// has zero target rows because the scope predicate filters
+		// them out).
+		//
+		// The check is symmetric: we look for any row whose
+		// org_id == targetOrgID AND targetOrg != callerOrg. If
+		// callerOrg == targetOrg we're asserting on the same id
+		// twice — the assertion still holds (the rows belong to
+		// callerOrg == targetOrg, which is fine) and reading the
+		// tuple keeps the subtest name uniform.
+		if callerOrg != targetOrg {
+			for _, gotOrgID := range gotOrgIDs {
+				if gotOrgID == targetOrgID {
+					t.Fatalf("cross-tenant leak on %q: caller=%s (org_id=%s) saw row with org_id=%s",
+						table, callerOrg, id.OrgID, gotOrgID)
+				}
+			}
+		}
+
+		// Sanity check: same-org reads should not be empty for the
+		// fixture (each side seeded at least one row per table).
+		// This guards against a silent over-scoping bug where the
+		// builder accidentally filters EVERYTHING out — the
+		// "zero rows" assertion above would pass trivially in that
+		// case.
+		//
+		// The agent role is an exception for org.projects /
+		// org.members: agents do not appear in org.members and the
+		// schema rows are visible regardless of caller-role (rbac
+		// scopes by org_id, not by role). So this sanity check
+		// fires for every role uniformly.
+		if callerOrg == targetOrg && len(gotOrgIDs) == 0 {
+			t.Fatalf("same-org read on %q returned zero rows; seed missing or scope over-filters", table)
+		}
+	})
+}
+
+// runAuthorizeOnlyTuple is the KindAuthorizeOnly assertion shape.
+// Drives org.Authorize directly and asserts the deny/permit
+// decision matches the policy contract.
+//
+// Cross-org: always deny (Authorize step 1 short-circuit).
+// Same-org:  deny or permit per expectAuthorizeOK.
+func runAuthorizeOnlyTuple(t *testing.T, fx *Fixture, callerOrg, targetOrg, role, table, action string) {
+	t.Helper()
+	subtest := fmt.Sprintf("caller=%s/target=%s/role=%s/table=%s/action=%s",
+		callerOrg, targetOrg, role, table, action)
+
+	t.Run(subtest, func(t *testing.T) {
+		id := identityFor(fx, callerOrg, role)
+		targetOrgID := fx.Orgs[targetOrg]
+		projectID := projectIDForAuthorize(fx, targetOrg, table)
+
+		req := &org.AuthorizeRequest{
+			Identity:  id,
+			Resource:  table,
+			Action:    action,
+			OrgID:     targetOrgID,
+			ProjectID: projectID,
+		}
+		err := org.Authorize(context.Background(), req)
+
+		// Predict the decision. Cross-org is unconditional deny;
+		// same-org consults the policy matrix.
+		var expectPermit bool
+		if callerOrg == targetOrg {
+			expectPermit = expectAuthorizeOK(role, table, action)
+		}
+
+		if expectPermit {
+			if err != nil {
+				t.Fatalf("expected permit, got %v (code=%s)", err, errs.Code(err))
+			}
+			return
+		}
+
+		// Expected deny. We accept the canonical PermissionDenied
+		// code; any other failure (Internal, InvalidArgument, …)
+		// indicates a different bug and we surface it.
+		if err == nil {
+			t.Fatalf("expected deny, got nil")
+		}
+		if errs.Code(err) != errs.PermissionDenied {
+			t.Fatalf("expected PermissionDenied, got code=%s err=%v", errs.Code(err), err)
+		}
+	})
+}
+
+// scopedRow is the minimal projection used by selectScopedOrgIDs to
+// read just `(id, org_id)` from each KindOrgScoped table. The
+// rbac.For builder issues `SELECT *` (apps/api/shared/rbac.go
+// ~line 413), so the suite cannot directly use rbac.For with a
+// two-field T over a many-column table — the scanner would mismatch
+// column count vs field count.
+//
+// Workaround: use a typed row shape that matches each table's full
+// column layout. Both KindOrgScoped tables in B-3 (org.projects,
+// org.members) share the (id, org_id, ...) prefix but diverge in
+// the suffix; we therefore declare per-table row types below.
+//
+// This is a row-shape helper, not part of the policy contract.
+// When C-6 / E-3 add new KindOrgScoped tables, add a matching row
+// type and extend the switch in selectScopedOrgIDs.
+
+// orgProjectsRow mirrors migration 0030_org.up.sql lines 34-43
+// (8 columns). Fields are in declaration order to match
+// rbac.For[T]'s reflection scanner. pgx scans timestamptz natively
+// into time.Time, so the time-typed fields below are scan-correct.
+// The suite only reads OrgID; the other fields exist so the column
+// count matches the rbac builder's implicit `SELECT *`.
+type orgProjectsRow struct {
+	ID          string
+	OrgID       string
+	Slug        string
+	Name        string
+	Description *string
+	ArchivedAt  *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// orgMembersRow mirrors migration 0030_org.up.sql lines 19-30
+// (6 columns: id, org_id, user_id, role, invited_by, created_at).
+type orgMembersRow struct {
+	ID        string
+	OrgID     string
+	UserID    string
+	Role      string
+	InvitedBy *string
+	CreatedAt time.Time
+}
+
+// selectScopedOrgIDs issues a rbac.For[T] read against the named
+// table and returns the org_id of every row the caller sees. The
+// per-table T shape is selected by the switch below; the only
+// dimension the assertion uses is OrgID.
+func selectScopedOrgIDs(ctx context.Context, id auth.Identity, table string) ([]string, error) {
+	switch table {
+	case "org.projects":
+		rows, err := rbac.For[orgProjectsRow](id, "org.projects").Run(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.OrgID)
+		}
+		return out, nil
+
+	case "org.members":
+		rows, err := rbac.For[orgMembersRow](id, "org.members").Run(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.OrgID)
+		}
+		return out, nil
+
+	default:
+		return nil, fmt.Errorf("selectScopedOrgIDs: unknown KindOrgScoped table %q (add a row type and switch case)", table)
+	}
+}

--- a/apps/api/shared/rbactest/seed.go
+++ b/apps/api/shared/rbactest/seed.go
@@ -1,0 +1,355 @@
+// seed.go provisions the fixture two-org cross-membership graph the
+// matrix sweep asserts isolation against. The seed runs once from
+// TestMain and is torn down once at exit; per-subtest cleanup is
+// avoided because the matrix subtests are read-only on the fixture.
+//
+// Fixture shape (B-3 scope — auth + org schemas):
+//
+//   - Two org.organizations rows (Org A, Org B).
+//   - Per side: four auth.users rows, one per non-agent role
+//     (owner/admin/member/viewer). The agent identity is constructed
+//     in-memory only — never an auth.users or org.members row, per
+//     SPEC §4.3.2 step 8.
+//   - Per side: one org.members row per non-agent user, binding the
+//     user to its home org with the matching role. Authorize's
+//     effective-role derivation reads these rows.
+//   - Per side: one org.projects row (the canonical project under
+//     each org). Used as KindOrgScoped row-leak bait for org.projects
+//     and as the parent of project_members rows below.
+//   - Per side: one org.project_members row binding the project's
+//     home-org owner user to the project. project_members has no
+//     org_id column — Authorize gates it via the parent project's
+//     org_id (apps/api/org/org.go step 3 containment check).
+//   - Per side: leak-bait rows in the org_id-free auth schema
+//     (auth.users with a side-specific email; auth.oauth_tokens
+//     bound to that user; auth.sessions bound to that user). These
+//     never have an org_id of their own — the suite asserts
+//     Authorize denies cross-org reads on the resource identifier,
+//     not on the row itself.
+//   - Per side: one mcp.api_keys row. Foreshadows the E-3
+//     (unblock-tv8.25) matrix extension; the B-3 sweep does NOT
+//     assert on this row but seeding it now means the FK chain is
+//     exercised end-to-end and the C-6/E-3 follow-up bead adds
+//     assertions without re-touching seed.go.
+//
+// Constraints:
+//
+//   - Every id is a freshly-minted ULID via apps/api/shared/ulid.
+//     Hard-coded ids would clash on the schema's UNIQUE constraints
+//     across encore-test invocations that share a long-lived dev
+//     cluster. A clean teardown is still done at exit (best-effort);
+//     the ULID prefix is the safety net.
+//   - The org_id-free auth schema is seeded with leak-bait rows
+//     whose `primary_provider_id` carries the side label so the
+//     suite can identify which side a given auth.users row belongs
+//     to without inventing a synthetic org_id column.
+//   - All rows go through direct sqldb.Exec, NOT through the
+//     auth/org RPCs. The RPC surfaces require an Encore auth context
+//     the test cannot easily fabricate (the authhandler reads a
+//     real `Authorization: Bearer …` header). Direct INSERT lets
+//     the seed install the rows without dancing through the auth
+//     mesh, and the suite still drives Authorize / rbac.For through
+//     the production code paths — only the fixture provisioning
+//     bypasses the RPC layer.
+
+package rbactest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"encore.app/shared/ulid"
+	"encore.dev/storage/sqldb"
+)
+
+// Fixture is the materialised seed graph. Held in memory between
+// TestMain seed-in and the matrix sweep so individual subtests can
+// reference role-tagged ids without re-querying the DB.
+type Fixture struct {
+	// Orgs maps the OrgA / OrgB label to the persisted ULID.
+	Orgs map[string]string
+
+	// Users maps (org-label, role) -> auth.users.id. Populated for
+	// the four non-agent roles only; the agent role is constructed
+	// in-memory by Identity helpers (see matrix_test.go).
+	Users map[userKey]string
+
+	// Projects maps the OrgA / OrgB label to the persisted ULID for
+	// the canonical project row under each org.
+	Projects map[string]string
+
+	// APIKeyRows maps the OrgA / OrgB label to the persisted ULID for
+	// the mcp.api_keys row seeded under each org. B-3 does not
+	// assert on these rows; the seed exists so the FK chain is
+	// validated end-to-end and the C-6/E-3 extensions inherit a
+	// non-empty mcp.api_keys table.
+	APIKeyRows map[string]string
+}
+
+// userKey is the composite key for Fixture.Users. Declared as a
+// struct (not a string) so a typo on either dimension is caught at
+// compile time.
+type userKey struct {
+	OrgLabel string // OrgA | OrgB
+	Role     string // RoleOwner | RoleAdmin | RoleMember | RoleViewer
+}
+
+// SeedFixture installs the two-org cross-membership graph described
+// in the file header. Returns the materialised Fixture on success.
+// Any DB error is fatal to the test process — the matrix sweep is
+// meaningless without a healthy seed.
+//
+// The seed is idempotent only in the sense that it ALWAYS mints new
+// ULIDs; running it twice in the same process produces two disjoint
+// fixtures. TestMain calls it exactly once. The matching Teardown
+// function below removes the rows the seed installed.
+func SeedFixture(ctx context.Context, db *sqldb.Database) (*Fixture, error) {
+	if db == nil {
+		return nil, fmt.Errorf("rbactest: SeedFixture called with nil *sqldb.Database — the dedicated apps/api/db/ service must have bound the handle before TestMain ran; check that encore test ./... is being used (NOT plain go test)")
+	}
+
+	fx := &Fixture{
+		Orgs:       make(map[string]string, 2),
+		Users:      make(map[userKey]string, 8),
+		Projects:   make(map[string]string, 2),
+		APIKeyRows: make(map[string]string, 2),
+	}
+
+	// Per-side seeding. Both sides get the identical row complement;
+	// the side label is folded into slugs / emails / labels so the
+	// rows are distinguishable when something leaks.
+	for _, orgLabel := range AllOrgs {
+		if err := seedSide(ctx, db, fx, orgLabel); err != nil {
+			return nil, fmt.Errorf("seed side %q: %w", orgLabel, err)
+		}
+	}
+
+	return fx, nil
+}
+
+// seedSide installs the rows for a single side (OrgA or OrgB).
+// Order matters because of the FK chain: users before tokens/sessions,
+// orgs before members/projects, projects before project_members and
+// api_keys.
+func seedSide(ctx context.Context, db *sqldb.Database, fx *Fixture, orgLabel string) error {
+	// 1. The org row itself.
+	orgID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("org ulid: %w", err)
+	}
+	orgSlug := strings.ToLower(fmt.Sprintf("rbactest-%s-%s", orgLabel, shortULID(orgID)))
+	if _, err := db.Exec(ctx,
+		`INSERT INTO org.organizations (id, slug, name) VALUES ($1, $2, $3)`,
+		orgID, orgSlug, fmt.Sprintf("rbactest org %s", orgLabel),
+	); err != nil {
+		return fmt.Errorf("insert org.organizations: %w", err)
+	}
+	fx.Orgs[orgLabel] = orgID
+
+	// 2. Per-role user rows. Each role gets its own auth.users row
+	//    so the role-action matrix sweep can resolve a stable user
+	//    per (orgLabel, role) tuple.
+	for _, role := range []string{RoleOwner, RoleAdmin, RoleMember, RoleViewer} {
+		userID, err := ulid.New()
+		if err != nil {
+			return fmt.Errorf("user ulid (%s/%s): %w", orgLabel, role, err)
+		}
+		// primary_provider_id carries the side+role label so the
+		// auth.users row is identifiable without an org_id column.
+		// The (primary_provider, primary_provider_id) UNIQUE
+		// constraint expects a stable identifier; the ULID suffix
+		// keeps it unique across repeated runs.
+		providerID := fmt.Sprintf("rbactest-%s-%s-%s", orgLabel, role, shortULID(userID))
+		email := fmt.Sprintf("%s.%s+%s@rbactest.local", strings.ToLower(orgLabel), role, shortULID(userID))
+		display := fmt.Sprintf("rbactest %s %s", orgLabel, role)
+
+		if _, err := db.Exec(ctx,
+			`INSERT INTO auth.users
+			   (id, primary_provider, primary_provider_id, email, display_name)
+			 VALUES ($1, 'github', $2, $3, $4)`,
+			userID, providerID, email, display,
+		); err != nil {
+			return fmt.Errorf("insert auth.users (%s/%s): %w", orgLabel, role, err)
+		}
+		fx.Users[userKey{OrgLabel: orgLabel, Role: role}] = userID
+
+		// 2a. auth.oauth_tokens row for this user. The *_enc columns
+		//     are bytea — direct INSERT of a literal byte string is
+		//     fine; the suite never reads these back.
+		tokID, err := ulid.New()
+		if err != nil {
+			return fmt.Errorf("oauth ulid (%s/%s): %w", orgLabel, role, err)
+		}
+		if _, err := db.Exec(ctx,
+			`INSERT INTO auth.oauth_tokens
+			   (id, user_id, provider, access_token_enc, refresh_token_enc, scopes)
+			 VALUES ($1, $2, 'github', $3, $4, $5)`,
+			tokID, userID,
+			[]byte("rbactest-access"), []byte("rbactest-refresh"),
+			[]string{"repo"},
+		); err != nil {
+			return fmt.Errorf("insert auth.oauth_tokens (%s/%s): %w", orgLabel, role, err)
+		}
+
+		// 2b. auth.sessions row for this user. expires_at must be
+		//     strictly greater than issued_at per
+		//     sessions_expiry_chk.
+		sessID, err := ulid.New()
+		if err != nil {
+			return fmt.Errorf("session ulid (%s/%s): %w", orgLabel, role, err)
+		}
+		issuedAt := time.Now().UTC()
+		expiresAt := issuedAt.Add(24 * time.Hour)
+		if _, err := db.Exec(ctx,
+			`INSERT INTO auth.sessions
+			   (id, user_id, issued_at, last_seen_at, expires_at, user_agent)
+			 VALUES ($1, $2, $3, $3, $4, $5)`,
+			sessID, userID, issuedAt, expiresAt, "rbactest",
+		); err != nil {
+			return fmt.Errorf("insert auth.sessions (%s/%s): %w", orgLabel, role, err)
+		}
+
+		// 2c. org.members row binding the user to its home org with
+		//     the matching role. Authorize's effective-role
+		//     derivation (max(org_role, project_role)) reads this.
+		memberID, err := ulid.New()
+		if err != nil {
+			return fmt.Errorf("member ulid (%s/%s): %w", orgLabel, role, err)
+		}
+		if _, err := db.Exec(ctx,
+			`INSERT INTO org.members (id, org_id, user_id, role)
+			 VALUES ($1, $2, $3, $4)`,
+			memberID, orgID, userID, role,
+		); err != nil {
+			return fmt.Errorf("insert org.members (%s/%s): %w", orgLabel, role, err)
+		}
+	}
+
+	// 3. The canonical org.projects row under this org. Used both
+	//    as KindOrgScoped row-leak bait and as the parent for the
+	//    project_members row below.
+	projectID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("project ulid: %w", err)
+	}
+	projectSlug := strings.ToLower(fmt.Sprintf("default-%s", shortULID(projectID)))
+	if _, err := db.Exec(ctx,
+		`INSERT INTO org.projects (id, org_id, slug, name)
+		 VALUES ($1, $2, $3, $4)`,
+		projectID, orgID, projectSlug, fmt.Sprintf("rbactest project %s", orgLabel),
+	); err != nil {
+		return fmt.Errorf("insert org.projects: %w", err)
+	}
+	fx.Projects[orgLabel] = projectID
+
+	// 4. One org.project_members row binding the owner user to the
+	//    project. project_members has no org_id column — the
+	//    Authorize gate for this resource is the cross-tenant
+	//    containment check (apps/api/org/org.go step 3), not a
+	//    rbac.For scope predicate.
+	ownerID := fx.Users[userKey{OrgLabel: orgLabel, Role: RoleOwner}]
+	pmID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("project_member ulid: %w", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO org.project_members (id, project_id, user_id, role)
+		 VALUES ($1, $2, $3, $4)`,
+		pmID, projectID, ownerID, RoleOwner,
+	); err != nil {
+		return fmt.Errorf("insert org.project_members: %w", err)
+	}
+
+	// 5. mcp.api_keys row foreshadowing the C-6 / E-3 extension. Not
+	//    asserted on in B-3; seed only so the FK chain is exercised
+	//    and the follow-up beads inherit a non-empty table.
+	apiKeyID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("api_key ulid: %w", err)
+	}
+	// Last 8 chars of the ULID give a high-entropy unique prefix; the
+	// random tail dominates so two seeded keys never collide on the
+	// UNIQUE index even if both ULIDs were minted in the same
+	// millisecond (the timestamp-based prefix would).
+	keyPrefix := apiKeyID[len(apiKeyID)-8:]
+	if _, err := db.Exec(ctx,
+		`INSERT INTO mcp.api_keys
+		   (id, org_id, label, agent_kind, key_hash, key_prefix, scopes)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		apiKeyID, orgID,
+		fmt.Sprintf("rbactest-%s-key", orgLabel),
+		"claude-code",
+		[]byte("rbactest-key-hash-placeholder"),
+		keyPrefix,
+		[]string{},
+	); err != nil {
+		return fmt.Errorf("insert mcp.api_keys: %w", err)
+	}
+	fx.APIKeyRows[orgLabel] = apiKeyID
+
+	return nil
+}
+
+// Teardown removes every row this Fixture installed. Called from
+// TestMain on the way out. The org.organizations rows cascade-delete
+// everything reachable (members, projects, project_members,
+// api_keys, tool_calls, …) per the schema's ON DELETE CASCADE
+// chain. auth.users / auth.oauth_tokens / auth.sessions are NOT
+// reachable via the org_id cascade — they are deleted separately,
+// keyed by the ids the fixture installed.
+//
+// Teardown is best-effort: failures are reported but do not abort.
+// The unique-by-ULID safety net in SeedFixture ensures a partial
+// teardown does not poison subsequent test runs.
+func (f *Fixture) Teardown(ctx context.Context, db *sqldb.Database) {
+	if db == nil || f == nil {
+		return
+	}
+
+	// 1. Org cascade — kills org.members, org.projects,
+	//    org.project_members, mcp.api_keys (and downstream tool_calls
+	//    on FK SET NULL).
+	for _, orgID := range f.Orgs {
+		if _, err := db.Exec(ctx, `DELETE FROM org.organizations WHERE id = $1`, orgID); err != nil {
+			// Log and continue — teardown is best-effort.
+			fmt.Printf("rbactest teardown: delete org %q: %v\n", orgID, err)
+		}
+	}
+
+	// 2. auth.users rows installed by the seed. ON DELETE CASCADE on
+	//    auth.oauth_tokens.user_id and auth.sessions.user_id
+	//    handles the dependent rows.
+	for _, userID := range f.Users {
+		if _, err := db.Exec(ctx, `DELETE FROM auth.users WHERE id = $1`, userID); err != nil {
+			fmt.Printf("rbactest teardown: delete user %q: %v\n", userID, err)
+		}
+	}
+}
+
+// shortULID returns the first 8 chars of a ULID. Used as a uniqueness
+// salt on slugs / emails / provider ids so repeated SeedFixture calls
+// in the same dev cluster do not collide on UNIQUE constraints. Not
+// security-sensitive — the truncation is cosmetic.
+func shortULID(s string) string {
+	if len(s) < 8 {
+		return s
+	}
+	return s[:8]
+}
+
+// fatalIf is a tiny helper for the seed path inside TestMain. The
+// caller passes t == nil (TestMain has no *testing.T), in which case
+// the function panics; otherwise it calls t.Fatal. Centralised so
+// callers don't sprinkle the nil-check.
+func fatalIf(t *testing.T, err error, msg string) {
+	if err == nil {
+		return
+	}
+	if t == nil {
+		panic(fmt.Sprintf("%s: %v", msg, err))
+	}
+	t.Fatalf("%s: %v", msg, err)
+}

--- a/apps/api/shared/rbactest/service.go
+++ b/apps/api/shared/rbactest/service.go
@@ -1,0 +1,54 @@
+// service.go declares the //encore:service anchor that lets the
+// rbactest package call other services' private RPCs (specifically
+// org.Authorize) under `encore test ./shared/rbactest/...`.
+//
+// Why a service annotation on a "shared/" package.
+//
+// The Encore parser enforces invariant E1388 ("APIs can only be
+// called from within a service"). Without a //encore:service anchor
+// here, every call to org.Authorize, auth.IssueAPIKey, etc. inside
+// rbactest_test.go fails the parser check before any test runs.
+// rbactest is, by design, a cross-service integration suite that
+// invokes the canonical RBAC predicate on the production code path —
+// it MUST be a parser-visible service for those calls to be legal.
+//
+// The package still lives under `apps/api/shared/` because the bead
+// (unblock-tv8.9) and SPEC §10.1 both lock that path. The shared/
+// prefix is a layout convention, not a parser constraint — Encore
+// treats any directory with a //encore:service annotation as a
+// service, regardless of its file-system parent. The auth/types,
+// ulid, rbac, and lint siblings are NOT services because they own no
+// state and call no APIs; rbactest is a service because it calls
+// APIs.
+//
+// Constraints (mirrors apps/api/db/db.go's tighter version of the
+// same shape):
+//
+//   - This package MUST NOT declare any //encore:api endpoints. The
+//     suite's only purpose is to drive cross-service calls; exposing
+//     RPCs here would muddle the suite's scope and risk a real
+//     production path landing in a /shared/ subtree.
+//   - This package MUST NOT acquire other responsibilities. It is a
+//     test surface. The Service struct + initService below stay
+//     empty.
+//   - The Service struct's identity is purely a parser anchor; no
+//     dependency injection, no per-request state, no lifecycle
+//     hooks beyond the no-op initService.
+
+package rbactest
+
+// Service is the Encore service anchor for the rbactest cross-service
+// integration suite. Carries no state and exposes no APIs — the
+// //encore:service annotation is what makes the cross-service calls
+// in rbactest_test.go (org.Authorize, future auth/workitems/deps/mcp
+// extensions in C-6 and E-3) legal under Encore's parser.
+//
+//encore:service
+type Service struct{}
+
+// initService satisfies Encore's lifecycle contract for the service
+// struct above. rbactest has no per-request state; the struct stays
+// empty. Encore calls this exactly once during service bring-up.
+func initService() (*Service, error) {
+	return &Service{}, nil
+}

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -1999,9 +1999,46 @@ mechanism. Plan §2.3's wording is non-normative on this; spec §10.1 is
 the authoritative pin.
 
 The exhaustive RBAC regression suite under `apps/api/shared/rbactest/`
-(NFR-2) fires one test per (caller-org, target-org, table, action)
-combination across the schemas P01 exposes. CI gates release on zero
-cross-tenant leaks.
+(NFR-2) fires one test per (caller-org, target-org, caller-role, table,
+action) combination across the schemas P01 exposes. The role axis is
+first-class — `org.Authorize` branches on `Identity.Role` ({owner,
+admin, member, viewer, agent}; the synthetic `agent` is the API-key
+runtime role per §4.3.2 step 8) before the role-action matrix, so a
+matrix that omits role fails to exercise the actual policy. CI gates
+release on zero cross-tenant leaks.
+
+**Suite scope is split across three phase tasks, not delivered in one
+bead:**
+
+- **B-3 (this bead, `unblock-tv8.9`)** — auth + org schemas only.
+  Concretely: `auth.users`, `auth.oauth_tokens`, `auth.sessions`,
+  `org.organizations`, `org.projects`, `org.members`,
+  `org.project_members`. Lays down the seed/cleanup scaffolding,
+  the matrix-axis vocabulary, and the `t.Run`-per-tuple driver that
+  the two follow-up tasks extend. The scope here is the surface the
+  two live P01 services (auth, org) actually touch; everything beyond
+  is reserved for the tasks below so each bead has independent
+  acceptance criteria.
+- **C-6 (`unblock-tv8.15`)** — extends the matrix to `workitems.items`,
+  `workitems.comments`, `workitems.trail`, `deps.dependencies`. Lands
+  after the C-group RPCs that introduce those tables.
+- **E-3 (`unblock-tv8.25`)** — final P01 gate. Closes the remaining
+  `mcp.tool_calls`, `mcp.api_keys`, `memory.entries`, `boards.boards`
+  surfaces and is the release-blocking exhaustive sweep across every
+  P01-exposed schema.
+
+**Mechanism within each task.** Tables with an `org_id` column are
+driven through `rbac.For[T]` (the read-side scope predicate is what's
+under test). Tables without an `org_id` column —
+`auth.users`, `auth.oauth_tokens`, `auth.sessions`,
+`org.organizations`, `org.project_members` — are driven through
+`org.Authorize` directly (their cross-tenant gate is the Authorize
+predicate, not a `WHERE … org_id = $1` filter). The suite seeds two
+orgs with a full role complement per side, runs without `t.Parallel`
+(rbac.Bind is not goroutine-safe; bead `unblock-tv8.34` tracks the
+hardening), and is discoverable as `encore test
+./apps/api/shared/rbactest/...` so the A-6 CI bead (`unblock-tv8.6`)
+can wire the gate without touching the suite.
 
 ### 10.2 Tracing (NFR-12)
 


### PR DESCRIPTION
## unblock-tv8.9: B-3 RBAC regression suite (apps/api/shared/rbactest/)

Build the exhaustive RBAC regression suite scoped to the P01 auth + org schemas. Fires 340 subtests across `(caller-org × target-org × caller-role × table × action)` and asserts zero cross-tenant leaks.

### What was done

- New `apps/api/shared/rbactest/` package — `doc.go`, `matrix.go`, `seed.go`, `service.go`, `rbactest_test.go`.
- `KindOrgScoped` tables (`org.projects`, `org.members`) driven through `rbac.For[T]` with row-leak assertions.
- `KindAuthorizeOnly` tables (`auth.users`, `auth.oauth_tokens`, `auth.sessions`, `org.organizations`, `org.project_members`) driven through `org.Authorize` with permit/deny matrix assertions (cross-org always denies; same-org follows §4.2 role-action matrix + agent allow-list).
- Two-org cross-membership fixture seeded once from `TestMain` via direct SQL (the role complement plus leak-bait auth.* rows and a foreshadowing `mcp.api_keys` row for C-6 / E-3).
- SPEC §10.1 patched in the same branch: B-3 scope pinned to auth + org; role added as a first-class matrix axis; C-6 (workitems/deps) and E-3 (mcp/memory/boards) extension plan documented.

### Files changed

- `apps/api/shared/rbactest/doc.go`
- `apps/api/shared/rbactest/matrix.go`
- `apps/api/shared/rbactest/seed.go`
- `apps/api/shared/rbactest/service.go`
- `apps/api/shared/rbactest/rbactest_test.go`
- `docs/specs/01-spec-backend-mvp.md`

### Decisions

- Added `//encore:service` annotation under `shared/rbactest/` — Encore parser E1388 refuses cross-service API calls (e.g. `org.Authorize`) from outside any service. Path stays under `shared/` per the bead lock.
- Global one-per-process fixture in `TestMain` instead of per-subtest seeding — the matrix is read-only on the fixture, single seed/teardown is correct and ~10× faster.
- Re-declared role/action/agent-resource constants in `matrix.go` rather than importing the unexported `org` constants — the suite asserts the SPEC §10.1 contract, drift between contract and implementation is exactly the silent regression the suite must surface.
- Per-table row types (`orgProjectsRow`, `orgMembersRow`) and a `selectScopedOrgIDs` switch — `rbac.For` issues `SELECT *`, the reflection scanner needs T's field count to equal the table's column count.

### Deviations

- `encore test -race` not used as the verification command — verified that the SIGSEGV is a pre-existing Encore runtime defect (`encore.dev/appruntime/shared/reqtrack/trace_stream.go` crashes on the first `encoreStartTest` call under `-race` for ANY encore-test target, including `./org/...`). Non-race `encore test ./apps/api/shared/rbactest/...` is green (340 subtests, zero leaks). Race-detector gating belongs in A-6 (`unblock-tv8.6`) once the Encore bug is resolved.

### Test plan

- [x] `encore test ./apps/api/shared/rbactest/...` — 340 subtests pass, zero cross-tenant leaks
- [x] `encore test ./...` — full apps/api suite green, no regressions
- [x] `go fmt ./shared/rbactest/...`, `go vet ./shared/rbactest/...` clean
- [x] `encore check` clean
- [x] `go run ./shared/lint/cmd/no_rbac_dynamic_clause ./shared/rbactest/...` clean (literal table/clause args only)
- [ ] CI gate wiring (deferred to A-6 / `unblock-tv8.6`)