### PR TITLE
unblock-tv8.12: C-3 cascade subscriber + Regime A inline recompute

### DIFF
--- a/apps/api/deps/cascade_subscriber.go
+++ b/apps/api/deps/cascade_subscriber.go
@@ -1,0 +1,480 @@
+// cascade_subscriber.go owns the Pub/Sub subscription against
+// CascadeRequestedTopic and the §6.3.2 subscriber algorithm. The
+// subscriber is the SOLE writer of workitems.items.pipeline_stage
+// (Regime B per SPEC §6.3.0 line 1699-1705 and §11.3 bullet (a)).
+//
+// Regime split (SPEC §6.3.0):
+//
+//   - Regime A — is_ready (single-hop, writer-inline). is_ready is
+//     recomputed by the call site that mutated the row/edge inside the
+//     same transaction as the mutation, via deps.recomputeReady (or
+//     deps.RecomputeReadyForBlocksDownstream for workitems.Close). The
+//     subscriber MUST NOT write is_ready (SPEC §6.3.0 line 1688 +
+//     §6.3.2 lines 1819-1820 + §11.3 bullet (b)).
+//   - Regime B — pipeline_stage (multi-hop, subscriber-only). Every
+//     call site that materially mutates §5.7.1 derivation inputs
+//     publishes CascadeRequested with a matching Reason. The
+//     subscriber walks the forward 'blocks' closure from
+//     TriggeredByItemID and recomputes pipeline_stage for every item
+//     in the closure per the §5.7.1 derivation table.
+//
+// Idempotency (AR-11 / SPEC §6.3.2):
+//
+//   - The audit row INSERT uses ON CONFLICT (event_id, triggered_by_item_id)
+//     DO NOTHING. Redeliveries of the same logical event collapse to
+//     a no-op on the second insert. The (event_id, triggered_by_item_id)
+//     UNIQUE constraint on deps.cascade_events is the structural
+//     idempotency key.
+//   - The pipeline_stage UPDATE is value-equality idempotent: the
+//     WHERE clause checks `pipeline_stage <> $new`, so a re-run on a
+//     stable graph writes nothing.
+//   - For Reason='edge_removed', deps.RemoveEdge writes the inline
+//     audit row with an event_id captured BEFORE BEGIN; the
+//     post-commit publish reuses that event_id. The subscriber's
+//     INSERT below collapses to no-op via the same ON CONFLICT clause
+//     (round-6 tension #1 — exactly one audit row per logical remove).
+//     The pipeline_stage recompute pass still runs.
+//
+// BFS depth cap (AR-8 / RP01-3): 256. On overflow the subscriber logs
+// a warning and returns nil — a partial cascade is preferable to a
+// retry loop that would replay the same overflow.
+//
+// Trace correlation (SPEC §10.2 Option B): CascadeRequested carries
+// TraceID as a typed payload field because Encore Pub/Sub does not
+// propagate context.Context across the topic boundary. The subscriber
+// writes msg.TraceID back to deps.cascade_events.trace_id (NULL when
+// empty — non-MCP code paths may publish without an originating trace).
+//
+// CascadeCompleted publish is best-effort. A publish failure logs a
+// warning and is NOT returned as an error — the source-of-truth audit
+// row is the deps.cascade_events INSERT above, which has already
+// committed.
+
+package deps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"encore.app/shared/ulid"
+	"encore.dev/pubsub"
+	"encore.dev/rlog"
+)
+
+// cascadeBFSMaxDepth caps the forward 'blocks' BFS depth at AR-8 (256).
+// Matches closureMaxDepth in deps.go but lives here to keep the
+// subscriber file self-contained.
+const cascadeBFSMaxDepth = 256
+
+// _ is the Encore Pub/Sub subscription wiring. The blank identifier
+// matches the SPEC's literal block at §6.3.2 line 1770 — Encore wires
+// the handler on import of this package; no other reference is needed.
+//
+// Subscription name `deps-cascade-subscriber` is the kebab-case SPEC
+// literal (§6.3.2 line 1770). Encore v1.52.1 requires the name argument
+// to be a Go string literal (parser error E1184), so the name lives
+// inline at the call site rather than as a named constant.
+//
+// SubscriptionConfig leaves retry policy unset: Encore default backoff
+// applies (SPEC §6.3.2 line 1773-1774). At-least-once delivery is
+// inherited from the topic's TopicConfig in cascade.go.
+//
+//nolint:gochecknoglobals // pubsub subscriptions are package-level by Encore contract.
+var _ = pubsub.NewSubscription(
+	CascadeRequestedTopic,
+	"deps-cascade-subscriber",
+	pubsub.SubscriptionConfig[*CascadeRequested]{
+		Handler: handleCascadeRequested,
+	},
+)
+
+// handleCascadeRequested is the §6.3.2 subscriber body. Walks the
+// forward 'blocks' closure from msg.TriggeredByItemID (max depth 256),
+// recomputes pipeline_stage per §5.7.1 on every affected item, writes
+// one deps.cascade_events row with kind=msg.Reason, and publishes
+// CascadeCompleted (best-effort).
+//
+// Reason dispatch: the four documented kinds share the same body
+// (forward BFS + per-item §5.7.1 derivation + audit row). The switch
+// exists for an explicit defensive `default` branch that drops
+// unknown Reason values rather than crashing — the publisher set is
+// closed by spec but a malformed redelivery from a future code path
+// should never crash the subscriber.
+//
+// The handler returns nil on every path except an unrecoverable DB
+// error. A return error triggers Encore's retry — desirable for
+// transient connection failures, undesirable for permanent errors
+// (e.g. a row that no longer exists). We treat "BFS seed row gone"
+// as a non-error (the triggering item was deleted between publish and
+// subscribe) so the message is not retried forever.
+func handleCascadeRequested(ctx context.Context, msg *CascadeRequested) error {
+	if msg == nil {
+		rlog.Warn("deps: cascade subscriber received nil message")
+		return nil
+	}
+
+	switch msg.Reason {
+	case "close", "edge_added", "edge_removed", "state_change":
+		// Documented kinds — fall through to the shared body below.
+	default:
+		// Defensive: drop unknown Reason values. The publisher set is
+		// closed by §6.3.0 but a malformed redelivery should not
+		// crash the subscriber.
+		rlog.Warn("deps: cascade subscriber received unknown Reason",
+			"reason", msg.Reason, "event_id", msg.EventID,
+			"triggered_by", msg.TriggeredByItemID)
+		return nil
+	}
+
+	if msg.TriggeredByItemID == "" {
+		rlog.Warn("deps: cascade subscriber received empty TriggeredByItemID",
+			"reason", msg.Reason, "event_id", msg.EventID)
+		return nil
+	}
+
+	// 1. BFS forward along 'blocks' edges from TriggeredByItemID,
+	//    collecting affected ids. The seed itself is INCLUDED so its
+	//    own pipeline_stage is recomputed (a status='Done' flip can
+	//    move the triggered item's pipeline_stage to 'Done').
+	affected, err := bfsForwardBlocksClosure(ctx, msg.TriggeredByItemID)
+	if err != nil {
+		rlog.Error("deps: cascade subscriber BFS failed",
+			"err", err, "reason", msg.Reason,
+			"event_id", msg.EventID, "triggered_by", msg.TriggeredByItemID)
+		return fmt.Errorf("deps: cascade BFS: %w", err)
+	}
+
+	// 2. Recompute pipeline_stage per §5.7.1 for every affected item.
+	//    Idempotent UPDATE: WHERE pipeline_stage <> $new short-circuits
+	//    a no-op write on re-delivery.
+	if err := recomputePipelineStageForAffected(ctx, affected); err != nil {
+		rlog.Error("deps: cascade subscriber pipeline_stage recompute failed",
+			"err", err, "reason", msg.Reason,
+			"event_id", msg.EventID, "triggered_by", msg.TriggeredByItemID)
+		return fmt.Errorf("deps: cascade pipeline_stage: %w", err)
+	}
+
+	// 3. Audit row insert (ON CONFLICT DO NOTHING). For edge_removed
+	//    this collapses with the inline row written by deps.RemoveEdge
+	//    (tension #1 — exactly one row per logical remove).
+	if err := insertCascadeEventRow(ctx, msg, affected); err != nil {
+		rlog.Error("deps: cascade subscriber audit insert failed",
+			"err", err, "reason", msg.Reason,
+			"event_id", msg.EventID, "triggered_by", msg.TriggeredByItemID)
+		return fmt.Errorf("deps: cascade audit insert: %w", err)
+	}
+
+	// 4. Publish CascadeCompleted (best-effort). The audit row above is
+	//    the source of truth — a publish failure here is logged and
+	//    swallowed.
+	if _, err := CascadeCompletedTopic.Publish(ctx, &CascadeCompleted{
+		EventID:           msg.EventID,
+		TriggeredByItemID: msg.TriggeredByItemID,
+		AffectedItemIDs:   affected,
+		CascadedCount:     len(affected),
+		CompletedAt:       time.Now().UTC(),
+	}); err != nil {
+		rlog.Warn("deps: cascade subscriber CascadeCompleted publish failed (audit committed)",
+			"err", err, "event_id", msg.EventID,
+			"triggered_by", msg.TriggeredByItemID)
+	}
+	return nil
+}
+
+// bfsForwardBlocksClosure walks the forward 'blocks' closure from
+// seedID via a recursive CTE — same shape as closureSQL("outgoing")
+// in deps.go but INCLUDES the seed and is depth-capped at AR-8 (256).
+//
+// Why include the seed: §5.7.1 derivation depends on the seed's own
+// state columns (e.g. status='Done' after workitems.Close), so the
+// seed's pipeline_stage must be re-derived too. closureSQL excludes
+// the seed because its callers (Closure RPC) want neighbours-only;
+// the cascade pass wants both.
+//
+// On depth overflow (cap hit at row 257+), the CTE silently truncates
+// — Postgres's `WHERE r.depth < $N` terminates the recursion at the
+// declared cap. The subscriber emits a Warn on truncation and proceeds
+// with the bounded prefix (the cap is locked at 256 per RP01-3).
+func bfsForwardBlocksClosure(ctx context.Context, seedID string) ([]string, error) {
+	// Read up to cascadeBFSMaxDepth+1 rows so we can detect cap hits
+	// — when the result count exceeds the cap, we know the walk
+	// terminated on depth rather than exhaustion of the graph.
+	rows, err := db.Query(ctx,
+		`WITH RECURSIVE reachable(id, depth) AS (
+		         SELECT $1::text, 0
+		         UNION ALL
+		         SELECT d.to_item, r.depth + 1
+		           FROM deps.dependencies d
+		           JOIN reachable r ON d.from_item = r.id
+		          WHERE d.kind = 'blocks'
+		            AND r.depth < $2
+		       )
+		       SELECT DISTINCT id FROM reachable
+		       ORDER BY id`,
+		seedID, cascadeBFSMaxDepth,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("bfs query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]string, 0, 8)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("bfs scan: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("bfs iter: %w", err)
+	}
+	if len(out) >= cascadeBFSMaxDepth {
+		rlog.Warn("deps: cascade BFS hit depth cap",
+			"seed", seedID, "cap", cascadeBFSMaxDepth, "collected", len(out))
+	}
+	return out, nil
+}
+
+// itemDerivationInputs captures the fields the §5.7.1 derivation table
+// reads from workitems.items and the existence predicates evaluated
+// against workitems.comments.
+type itemDerivationInputs struct {
+	id              string
+	status          string
+	pipelineStage   string // current value — used to skip idempotent UPDATEs
+	implState       string
+	reviewState     string
+	qaState         string
+	pipelineState   string
+	closedAtNotNull bool
+
+	hasReviewComment        bool
+	hasInvestigationComment bool
+}
+
+// recomputePipelineStageForAffected runs the §5.7.1 derivation for
+// every affected item and writes pipeline_stage where it differs from
+// the current value.
+//
+// Issues ONE batched SELECT against workitems.comments per cascade pass
+// per SPEC §5.7.1 line 781-787: a single GROUP BY scan over the
+// affected set is bounded by len(affected) rather than N+1.
+//
+// The UPDATE is per-item — Postgres has no clean "update many distinct
+// values" path without unnest+VALUES, and the affected set in P01 is
+// bounded at 256. The per-item UPDATE includes the value-equality
+// guard so repeated delivery converges to the same row state.
+//
+// The is_ready column is NEVER written here. The lint analyzer
+// (apps/api/shared/lint/no_direct_is_ready_write.go) enforces that
+// every UPDATE in this file targets pipeline_stage only.
+func recomputePipelineStageForAffected(ctx context.Context, affected []string) error {
+	if len(affected) == 0 {
+		return nil
+	}
+
+	// Fetch the four state columns + status + closed_at for every
+	// affected item.
+	rowMap := make(map[string]*itemDerivationInputs, len(affected))
+	rows, err := db.Query(ctx,
+		`SELECT id, status, pipeline_stage,
+		        impl_state, review_state, qa_state, pipeline_state,
+		        (closed_at IS NOT NULL)
+		   FROM workitems.items
+		  WHERE id = ANY($1::text[])`,
+		affected,
+	)
+	if err != nil {
+		return fmt.Errorf("affected state read: %w", err)
+	}
+	for rows.Next() {
+		inp := &itemDerivationInputs{}
+		if err := rows.Scan(
+			&inp.id, &inp.status, &inp.pipelineStage,
+			&inp.implState, &inp.reviewState, &inp.qaState, &inp.pipelineState,
+			&inp.closedAtNotNull,
+		); err != nil {
+			rows.Close()
+			return fmt.Errorf("affected state scan: %w", err)
+		}
+		rowMap[inp.id] = inp
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("affected state iter: %w", err)
+	}
+	rows.Close()
+
+	// Batched comment existence predicate (SPEC §5.7.1 line 781-787).
+	commentRows, err := db.Query(ctx,
+		`SELECT item_id,
+		        max(CASE WHEN kind = 'review'        THEN 1 ELSE 0 END) AS has_review,
+		        max(CASE WHEN kind = 'investigation' THEN 1 ELSE 0 END) AS has_investigation
+		   FROM workitems.comments
+		  WHERE item_id = ANY($1::text[])
+		  GROUP BY item_id`,
+		affected,
+	)
+	if err != nil {
+		return fmt.Errorf("affected comments read: %w", err)
+	}
+	for commentRows.Next() {
+		var itemID string
+		var hasReview, hasInvestigation int
+		if err := commentRows.Scan(&itemID, &hasReview, &hasInvestigation); err != nil {
+			commentRows.Close()
+			return fmt.Errorf("affected comments scan: %w", err)
+		}
+		if inp, ok := rowMap[itemID]; ok {
+			inp.hasReviewComment = hasReview > 0
+			inp.hasInvestigationComment = hasInvestigation > 0
+		}
+	}
+	if err := commentRows.Err(); err != nil {
+		commentRows.Close()
+		return fmt.Errorf("affected comments iter: %w", err)
+	}
+	commentRows.Close()
+
+	// Per-item derive + idempotent UPDATE. Affected set is bounded at
+	// AR-8 (256) so the per-row UPDATE is O(N) bounded — well inside
+	// Law 7's < 2s envelope.
+	for _, id := range affected {
+		inp, ok := rowMap[id]
+		if !ok {
+			// Item disappeared between BFS and derivation read
+			// (FK ON DELETE CASCADE on org/project) — skip silently.
+			continue
+		}
+		newStage := derivePipelineStage(inp)
+		if newStage == inp.pipelineStage {
+			// Idempotent no-op. Skip the UPDATE.
+			continue
+		}
+		if _, err := db.Exec(ctx,
+			`UPDATE workitems.items
+			    SET pipeline_stage = $2
+			  WHERE id = $1 AND pipeline_stage <> $2`,
+			id, newStage,
+		); err != nil {
+			return fmt.Errorf("pipeline_stage update %s: %w", id, err)
+		}
+	}
+	return nil
+}
+
+// derivePipelineStage applies the §5.7.1 derivation table. First match
+// wins. Returns one of the six §6.1 PipelineStage values: Investigation,
+// Implementation, Review, Quality, Deferred, Done. The DDL CHECK
+// constraint enforces the same set (items_pipeline_stage_chk).
+//
+// Pure function — no DB I/O. Unit-testable from a leaf test file
+// (deps_unit_test.go) without the Encore runtime. Note that this leaf
+// test cannot live inside encore.app/deps because plain `go test` on
+// this package panics at package init (cascade.go's pubsub.NewTopic
+// declaration). The unit test runs in a `deps_test` external package
+// under `encore test` instead.
+//
+// Order is locked verbatim from SPEC docs/SPEC.md §5.7.1 lines 766-779.
+// Do not reorder without a spec amendment.
+func derivePipelineStage(inp *itemDerivationInputs) string {
+	// Rule 1+2: pipeline_state = needs_human OR paused → Deferred.
+	if inp.pipelineState == "needs_human" || inp.pipelineState == "paused" {
+		return "Deferred"
+	}
+	// Rule 3: pipeline_state = no_investigation AND impl_state = pending → Implementation.
+	if inp.pipelineState == "no_investigation" && inp.implState == "pending" {
+		return "Implementation"
+	}
+	// Rule 4: status = Done OR (qa_state = passed AND closed_at IS NOT NULL) → Done.
+	if inp.status == "Done" || (inp.qaState == "passed" && inp.closedAtNotNull) {
+		return "Done"
+	}
+	// Rule 5: qa_state = passed → Quality. (closure pending)
+	if inp.qaState == "passed" {
+		return "Quality"
+	}
+	// Rule 6: qa_state = failed → Quality.
+	if inp.qaState == "failed" {
+		return "Quality"
+	}
+	// Rule 7: review_state = approved AND qa_state = pending → Quality.
+	if inp.reviewState == "approved" && inp.qaState == "pending" {
+		return "Quality"
+	}
+	// Rule 8: review_state = needs_rework → Implementation.
+	if inp.reviewState == "needs_rework" {
+		return "Implementation"
+	}
+	// Rule 9: impl_state = done AND review_state = pending AND has review-kind comment → Review.
+	if inp.implState == "done" && inp.reviewState == "pending" && inp.hasReviewComment {
+		return "Review"
+	}
+	// Rule 10: impl_state = done AND review_state = pending AND no review comment → Implementation.
+	if inp.implState == "done" && inp.reviewState == "pending" && !inp.hasReviewComment {
+		return "Implementation"
+	}
+	// Rule 11: impl_state = pending AND has investigation-kind comment → Implementation.
+	if inp.implState == "pending" && inp.hasInvestigationComment {
+		return "Implementation"
+	}
+	// Rule 12: impl_state = pending AND no investigation comment → Investigation.
+	return "Investigation"
+}
+
+// insertCascadeEventRow writes one deps.cascade_events row with
+// kind=msg.Reason and the affected set, idempotent on
+// (event_id, triggered_by_item_id).
+//
+// Nullability: project_id is nullable on workitems.items (the org may
+// have org-scoped items with project_id IS NULL); we mirror that here
+// by writing NULL when msg.ProjectID is empty. trace_id is also nullable;
+// we write NULL when msg.TraceID is empty (non-MCP publishers — e.g.
+// admin scripts — may omit it).
+//
+// The audit row id is minted fresh per call. The (event_id,
+// triggered_by_item_id) UNIQUE constraint is the idempotency mechanism;
+// the row id is only ever the PRIMARY KEY for the audit table itself
+// and is irrelevant to dedup.
+func insertCascadeEventRow(ctx context.Context, msg *CascadeRequested, affected []string) error {
+	rowID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("audit row ulid: %w", err)
+	}
+
+	// Nullable projection. Encore's sqldb passes a nil *string as
+	// SQL NULL; an empty string would violate the FK semantics for
+	// project_id (the column references org.projects(id)).
+	var projectColumn *string
+	if msg.ProjectID != "" {
+		p := msg.ProjectID
+		projectColumn = &p
+	}
+	var traceColumn *string
+	if msg.TraceID != "" {
+		t := msg.TraceID
+		traceColumn = &t
+	}
+
+	// affected_item_ids is NOT NULL DEFAULT '{}' in the DDL — pass an
+	// empty (non-nil) slice when affected is empty so pgx writes the
+	// empty array literal rather than NULL.
+	if affected == nil {
+		affected = []string{}
+	}
+
+	if _, err := db.Exec(ctx,
+		`INSERT INTO deps.cascade_events
+		   (id, event_id, kind, org_id, project_id,
+		    triggered_by_item_id, affected_item_ids, cascaded_count, trace_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (event_id, triggered_by_item_id) DO NOTHING`,
+		rowID, msg.EventID, msg.Reason, msg.OrgID, projectColumn,
+		msg.TriggeredByItemID, affected, len(affected), traceColumn,
+	); err != nil {
+		return fmt.Errorf("audit insert: %w", err)
+	}
+	return nil
+}

--- a/apps/api/deps/cascade_subscriber_handler_test.go
+++ b/apps/api/deps/cascade_subscriber_handler_test.go
@@ -1,0 +1,460 @@
+// Integration-style tests for the cascade subscriber, calling
+// handleCascadeRequested directly. Encore's pubsub testing
+// implementation does NOT fire subscriptions during `encore test`
+// (https://encore.dev/docs/go/primitives/pubsub#testing-pubsub —
+// "Your subscriptions will not be triggered by events published. This
+// allows you to test the behaviour of publishers independently of side
+// effects caused by subscribers."), so these tests invoke the handler
+// directly. Same handler, same DB writes, same idempotency contract —
+// only the Pub/Sub fan-out is skipped, and that fan-out is exercised
+// in production (encore run) where the subscriber is wired by the
+// pubsub.NewSubscription call in cascade_subscriber.go.
+//
+// This is an internal-package test (package deps) so the unexported
+// handleCascadeRequested function is reachable. The db handle is bound
+// by the encore.app/db service's init() during encore test bootstrap;
+// we do NOT import encore.app/db here (it would form a back-import
+// cycle: db imports deps).
+
+package deps
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"encore.app/shared/ulid"
+)
+
+// seedFixtureInternal mirrors deps_test.seedFixture but lives in
+// package deps so an internal-package test can use it without the
+// back-import cycle. Inserts an org, a user, and a project; returns
+// the ids and registers cleanup.
+type internalFixture struct {
+	OrgID     string
+	ProjectID string
+	UserID    string
+}
+
+func seedFixtureInternal(t *testing.T, ctx context.Context) *internalFixture {
+	t.Helper()
+	if db == nil {
+		t.Fatalf("deps.db is nil — encore.app/db init did not bind the handle (run via encore test)")
+	}
+
+	orgID := mustULIDInternal(t)
+	slug := strings.ToLower("ct-" + orgID[len(orgID)-8:])
+	if _, err := db.Exec(ctx,
+		`INSERT INTO org.organizations (id, slug, name) VALUES ($1, $2, $3)`,
+		orgID, slug, "cascade test org",
+	); err != nil {
+		t.Fatalf("insert org: %v", err)
+	}
+
+	userID := mustULIDInternal(t)
+	if _, err := db.Exec(ctx,
+		`INSERT INTO auth.users (id, primary_provider, primary_provider_id, email, display_name)
+		 VALUES ($1, 'github', $2, $3, $4)`,
+		userID, "ct-"+userID[len(userID)-8:],
+		strings.ToLower(userID[len(userID)-8:])+"@ct.local", "ct",
+	); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	projectID := mustULIDInternal(t)
+	if _, err := db.Exec(ctx,
+		`INSERT INTO org.projects (id, org_id, slug, name) VALUES ($1, $2, $3, $4)`,
+		projectID, orgID, "p-"+projectID[len(projectID)-8:], "ct project",
+	); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(ctx, `DELETE FROM org.organizations WHERE id = $1`, orgID)
+		_, _ = db.Exec(ctx, `DELETE FROM auth.users WHERE id = $1`, userID)
+	})
+	return &internalFixture{OrgID: orgID, ProjectID: projectID, UserID: userID}
+}
+
+func mustULIDInternal(t *testing.T) string {
+	t.Helper()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	return id
+}
+
+// createItemInternal inserts a Backlog item. Returns the id. Items
+// default to is_ready=true; tests that need is_ready=false create
+// blocking edges via deps.AddEdge.
+func createItemInternal(t *testing.T, ctx context.Context, fx *internalFixture, status string) string {
+	t.Helper()
+	if status == "" {
+		status = "Backlog"
+	}
+	id := mustULIDInternal(t)
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, is_ready)
+		 VALUES ($1, $2, $3, 'task', 'ct item', $4, true)`,
+		id, fx.OrgID, fx.ProjectID, status,
+	); err != nil {
+		t.Fatalf("insert item: %v", err)
+	}
+	return id
+}
+
+// readPipelineStageInternal reads workitems.items.pipeline_stage.
+func readPipelineStageInternal(t *testing.T, ctx context.Context, id string) string {
+	t.Helper()
+	var stage string
+	if err := db.QueryRow(ctx,
+		`SELECT pipeline_stage FROM workitems.items WHERE id = $1`, id,
+	).Scan(&stage); err != nil {
+		t.Fatalf("read pipeline_stage: %v", err)
+	}
+	return stage
+}
+
+// readIsReadyInternal reads workitems.items.is_ready.
+func readIsReadyInternal(t *testing.T, ctx context.Context, id string) bool {
+	t.Helper()
+	var ready bool
+	if err := db.QueryRow(ctx,
+		`SELECT is_ready FROM workitems.items WHERE id = $1`, id,
+	).Scan(&ready); err != nil {
+		t.Fatalf("read is_ready: %v", err)
+	}
+	return ready
+}
+
+// countCascadeEvents counts deps.cascade_events rows by event_id +
+// triggered_by_item_id (the idempotency key).
+func countCascadeEvents(t *testing.T, ctx context.Context, eventID, triggeredBy string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM deps.cascade_events
+		   WHERE event_id = $1 AND triggered_by_item_id = $2`,
+		eventID, triggeredBy,
+	).Scan(&n); err != nil {
+		t.Fatalf("count cascade_events: %v", err)
+	}
+	return n
+}
+
+// TestHandleCascadeRequested_FourKinds calls the subscriber handler
+// directly with one CascadeRequested message per Reason. Asserts:
+//   - exactly one deps.cascade_events row is written with kind = msg.Reason.
+//   - the affected_item_ids array contains the seed (BFS includes the seed).
+//   - trace_id round-trips from msg.TraceID to the column.
+//   - subscriber does NOT write is_ready (the seed's is_ready stays at
+//     its pre-call value).
+func TestHandleCascadeRequested_FourKinds(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+
+	for _, reason := range []string{"close", "edge_added", "edge_removed", "state_change"} {
+		t.Run(reason, func(t *testing.T) {
+			seed := createItemInternal(t, ctx, fx, "Backlog")
+			eventID := mustULIDInternal(t)
+			traceID := mustULIDInternal(t)
+
+			msg := &CascadeRequested{
+				EventID:           eventID,
+				OrgID:             fx.OrgID,
+				ProjectID:         fx.ProjectID,
+				TriggeredByItemID: seed,
+				Reason:            reason,
+				TraceID:           traceID,
+				EmittedAt:         time.Now().UTC(),
+			}
+
+			preReady := readIsReadyInternal(t, ctx, seed)
+
+			if err := handleCascadeRequested(ctx, msg); err != nil {
+				t.Fatalf("handleCascadeRequested(%s): %v", reason, err)
+			}
+
+			// Exactly one audit row with kind=msg.Reason.
+			var kind string
+			var traceColumn *string
+			var affected []string
+			if err := db.QueryRow(ctx,
+				`SELECT kind, trace_id, affected_item_ids
+				   FROM deps.cascade_events
+				  WHERE event_id = $1 AND triggered_by_item_id = $2`,
+				eventID, seed,
+			).Scan(&kind, &traceColumn, &affected); err != nil {
+				t.Fatalf("read cascade_events: %v", err)
+			}
+			if kind != reason {
+				t.Fatalf("kind = %q, want %q", kind, reason)
+			}
+			if traceColumn == nil || *traceColumn != traceID {
+				t.Fatalf("trace_id = %v, want %q", traceColumn, traceID)
+			}
+			seenSeed := false
+			for _, id := range affected {
+				if id == seed {
+					seenSeed = true
+					break
+				}
+			}
+			if !seenSeed {
+				t.Fatalf("affected_item_ids missing seed %q: %v", seed, affected)
+			}
+
+			// Regime A invariant: subscriber MUST NOT write is_ready.
+			postReady := readIsReadyInternal(t, ctx, seed)
+			if postReady != preReady {
+				t.Fatalf("subscriber wrote is_ready (%v → %v); SPEC §11.3 bullet (b) violated", preReady, postReady)
+			}
+		})
+	}
+}
+
+// TestHandleCascadeRequested_IdempotencyN100 invokes the handler 100
+// times with the SAME (event_id, triggered_by_item_id) tuple across
+// all four kinds (25 per kind, but the kind column is set by the FIRST
+// write that wins the ON CONFLICT race — subsequent calls collapse to
+// no-ops). Asserts exactly one row exists after all 100 calls.
+//
+// SPEC §6.3.2 line 1828 + AR-11 — the (event_id, triggered_by_item_id)
+// UNIQUE constraint plus ON CONFLICT DO NOTHING is the structural
+// idempotency mechanism. AR-11 / acceptance criterion #2 of this bead.
+func TestHandleCascadeRequested_IdempotencyN100(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+	seed := createItemInternal(t, ctx, fx, "Backlog")
+
+	const total = 100
+	kinds := []string{"close", "edge_added", "edge_removed", "state_change"}
+	eventID := mustULIDInternal(t)
+	traceID := mustULIDInternal(t)
+
+	for i := 0; i < total; i++ {
+		k := kinds[i%len(kinds)]
+		msg := &CascadeRequested{
+			EventID:           eventID,
+			OrgID:             fx.OrgID,
+			ProjectID:         fx.ProjectID,
+			TriggeredByItemID: seed,
+			Reason:            k,
+			TraceID:           traceID,
+			EmittedAt:         time.Now().UTC(),
+		}
+		if err := handleCascadeRequested(ctx, msg); err != nil {
+			t.Fatalf("handle %d (%s): %v", i, k, err)
+		}
+	}
+
+	got := countCascadeEvents(t, ctx, eventID, seed)
+	if got != 1 {
+		t.Fatalf("AR-11 idempotency violation: %d rows after %d redeliveries, want 1", got, total)
+	}
+}
+
+// TestHandleCascadeRequested_IdempotentPipelineStage triggers two
+// passes of Reason='close' with DIFFERENT event_ids (so each invokes
+// the subscriber body, but the per-item UPDATE …  WHERE pipeline_stage
+// <> $new short-circuits on the second pass). Asserts pipeline_stage
+// is stable across both passes (idempotent value-equality write).
+func TestHandleCascadeRequested_IdempotentPipelineStage(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+	seed := createItemInternal(t, ctx, fx, "Backlog")
+
+	runOnce := func() {
+		msg := &CascadeRequested{
+			EventID:           mustULIDInternal(t),
+			OrgID:             fx.OrgID,
+			ProjectID:         fx.ProjectID,
+			TriggeredByItemID: seed,
+			Reason:            "close",
+			EmittedAt:         time.Now().UTC(),
+		}
+		if err := handleCascadeRequested(ctx, msg); err != nil {
+			t.Fatalf("handle: %v", err)
+		}
+	}
+
+	runOnce()
+	first := readPipelineStageInternal(t, ctx, seed)
+	runOnce()
+	second := readPipelineStageInternal(t, ctx, seed)
+
+	if first != second {
+		t.Fatalf("pipeline_stage flipped between passes: %q → %q (idempotency violation)", first, second)
+	}
+}
+
+// TestHandleCascadeRequested_MultiHopBFS exercises the forward 'blocks'
+// closure walk: build a→b→c (a blocks b, b blocks c), trigger
+// Reason='edge_added' from a. The BFS from a must reach b AND c (depth
+// 2), and the audit row's affected_item_ids must include all three.
+func TestHandleCascadeRequested_MultiHopBFS(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+
+	a := createItemInternal(t, ctx, fx, "Backlog")
+	b := createItemInternal(t, ctx, fx, "Backlog")
+	c := createItemInternal(t, ctx, fx, "Backlog")
+
+	// Use the same SQL deps.AddEdge would write, bypassing the RPC so
+	// we don't fire the publisher (we want to test BFS, not the
+	// publisher path).
+	for _, pair := range [][2]string{{a, b}, {b, c}} {
+		edgeID := mustULIDInternal(t)
+		if _, err := db.Exec(ctx,
+			`INSERT INTO deps.dependencies (id, from_item, to_item, kind)
+			 VALUES ($1, $2, $3, 'blocks')`,
+			edgeID, pair[0], pair[1],
+		); err != nil {
+			t.Fatalf("insert edge %s->%s: %v", pair[0], pair[1], err)
+		}
+	}
+
+	eventID := mustULIDInternal(t)
+	msg := &CascadeRequested{
+		EventID:           eventID,
+		OrgID:             fx.OrgID,
+		ProjectID:         fx.ProjectID,
+		TriggeredByItemID: a,
+		Reason:            "edge_added",
+		EmittedAt:         time.Now().UTC(),
+	}
+	if err := handleCascadeRequested(ctx, msg); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	var affected []string
+	if err := db.QueryRow(ctx,
+		`SELECT affected_item_ids FROM deps.cascade_events
+		  WHERE event_id = $1 AND triggered_by_item_id = $2`,
+		eventID, a,
+	).Scan(&affected); err != nil {
+		t.Fatalf("read affected_item_ids: %v", err)
+	}
+
+	want := map[string]bool{a: true, b: true, c: true}
+	got := map[string]bool{}
+	for _, id := range affected {
+		got[id] = true
+	}
+	for id := range want {
+		if !got[id] {
+			t.Fatalf("affected missing %q: got=%v", id, affected)
+		}
+	}
+}
+
+// TestHandleCascadeRequested_UnknownReason asserts the defensive
+// dispatch drops unknown Reason values without writing an audit row
+// (per SPEC §6.3.2 line 1806-1810 — "Unknown Reason — log + drop").
+func TestHandleCascadeRequested_UnknownReason(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+	seed := createItemInternal(t, ctx, fx, "Backlog")
+
+	eventID := mustULIDInternal(t)
+	msg := &CascadeRequested{
+		EventID:           eventID,
+		OrgID:             fx.OrgID,
+		ProjectID:         fx.ProjectID,
+		TriggeredByItemID: seed,
+		Reason:            "not_a_real_kind",
+		EmittedAt:         time.Now().UTC(),
+	}
+	if err := handleCascadeRequested(ctx, msg); err != nil {
+		t.Fatalf("handle (unknown reason): %v", err)
+	}
+	if got := countCascadeEvents(t, ctx, eventID, seed); got != 0 {
+		t.Fatalf("unknown reason wrote audit row: count=%d", got)
+	}
+}
+
+// TestHandleCascadeRequested_EmptyTrace asserts that a publisher with
+// empty TraceID (admin scripts, seeders) lands NULL in
+// deps.cascade_events.trace_id rather than an empty string.
+func TestHandleCascadeRequested_EmptyTrace(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+	seed := createItemInternal(t, ctx, fx, "Backlog")
+
+	eventID := mustULIDInternal(t)
+	msg := &CascadeRequested{
+		EventID:           eventID,
+		OrgID:             fx.OrgID,
+		ProjectID:         fx.ProjectID,
+		TriggeredByItemID: seed,
+		Reason:            "close",
+		TraceID:           "", // empty — non-MCP publisher
+		EmittedAt:         time.Now().UTC(),
+	}
+	if err := handleCascadeRequested(ctx, msg); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	var traceColumn *string
+	if err := db.QueryRow(ctx,
+		`SELECT trace_id FROM deps.cascade_events
+		  WHERE event_id = $1 AND triggered_by_item_id = $2`,
+		eventID, seed,
+	).Scan(&traceColumn); err != nil {
+		t.Fatalf("read trace_id: %v", err)
+	}
+	if traceColumn != nil {
+		t.Fatalf("trace_id = %q, want NULL (empty TraceID input)", *traceColumn)
+	}
+}
+
+// TestHandleCascadeRequested_DerivesPipelineStage covers an end-to-end
+// derivation path: seed with impl_state='done', review_state='pending'
+// AND a kind='review' comment on the item — §5.7.1 rule 9 → pipeline_stage='Review'.
+// Confirms the subscriber's batched comment-existence query feeds the
+// derivation correctly.
+func TestHandleCascadeRequested_DerivesPipelineStage(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixtureInternal(t, ctx)
+	seed := createItemInternal(t, ctx, fx, "Backlog")
+
+	// Move the seed into the "review queued" shape: impl_state='done',
+	// review_state='pending', and a kind='review' comment exists.
+	if _, err := db.Exec(ctx,
+		`UPDATE workitems.items
+		    SET impl_state = 'done', review_state = 'pending', qa_state = 'pending'
+		  WHERE id = $1`,
+		seed,
+	); err != nil {
+		t.Fatalf("set states: %v", err)
+	}
+	commentID := mustULIDInternal(t)
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.comments
+		   (id, item_id, author_id, kind, status, body)
+		 VALUES ($1, $2, $3, 'review', 'info', 'looks good')`,
+		commentID, seed, fx.UserID,
+	); err != nil {
+		t.Fatalf("insert review comment: %v", err)
+	}
+
+	msg := &CascadeRequested{
+		EventID:           mustULIDInternal(t),
+		OrgID:             fx.OrgID,
+		ProjectID:         fx.ProjectID,
+		TriggeredByItemID: seed,
+		Reason:            "state_change",
+		EmittedAt:         time.Now().UTC(),
+	}
+	if err := handleCascadeRequested(ctx, msg); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	got := readPipelineStageInternal(t, ctx, seed)
+	if got != "Review" {
+		t.Fatalf("pipeline_stage = %q, want %q (rule 9)", got, "Review")
+	}
+}

--- a/apps/api/deps/cascade_subscriber_unit_test.go
+++ b/apps/api/deps/cascade_subscriber_unit_test.go
@@ -1,0 +1,184 @@
+// Unit tests for the pure-function §5.7.1 derivation table in
+// derivePipelineStage. Internal-package test so the unexported helper
+// is visible.
+//
+// These tests do NOT touch the DB or the pubsub topics — they are
+// table-driven against the locked SPEC §5.7.1 rule order (rules 1..12,
+// first match wins). Tests still run under `encore test` because the
+// `deps` package itself imports encore.dev/pubsub at package init —
+// plain `go test` panics on the package-level NewTopic call (see
+// cascade.go) even for files that do not exercise pub/sub.
+
+package deps
+
+import "testing"
+
+// TestDerivePipelineStage_Rules covers every rule in the SPEC §5.7.1
+// derivation table. Order matches the spec (rule 1 first → rule 12
+// last). Each subtest names the rule it exercises so a regression
+// points at the SPEC line range.
+//
+// Pure function — no DB, no fixtures. Defaults for unset fields use
+// the zero value of itemDerivationInputs (empty strings, false bools);
+// each test sets only the fields its rule predicates against, so a
+// future spec edit that flips an unrelated field cannot accidentally
+// pass these tests.
+func TestDerivePipelineStage_Rules(t *testing.T) {
+	tests := []struct {
+		name string
+		in   itemDerivationInputs
+		want string
+	}{
+		// Rule 1: pipeline_state = needs_human → Deferred.
+		{
+			name: "rule1_needs_human",
+			in:   itemDerivationInputs{pipelineState: "needs_human"},
+			want: "Deferred",
+		},
+		// Rule 2: pipeline_state = paused → Deferred.
+		{
+			name: "rule2_paused",
+			in:   itemDerivationInputs{pipelineState: "paused"},
+			want: "Deferred",
+		},
+		// Rule 3: pipeline_state = no_investigation AND impl_state = pending → Implementation.
+		{
+			name: "rule3_no_investigation_pending_impl",
+			in: itemDerivationInputs{
+				pipelineState: "no_investigation",
+				implState:     "pending",
+			},
+			want: "Implementation",
+		},
+		// Rule 4a: status = Done → Done.
+		{
+			name: "rule4a_status_done",
+			in:   itemDerivationInputs{status: "Done"},
+			want: "Done",
+		},
+		// Rule 4b: qa_state = passed AND closed_at IS NOT NULL → Done.
+		{
+			name: "rule4b_qa_passed_closed_at",
+			in: itemDerivationInputs{
+				qaState:         "passed",
+				closedAtNotNull: true,
+			},
+			want: "Done",
+		},
+		// Rule 5: qa_state = passed (closure pending) → Quality.
+		{
+			name: "rule5_qa_passed_closure_pending",
+			in:   itemDerivationInputs{qaState: "passed"},
+			want: "Quality",
+		},
+		// Rule 6: qa_state = failed → Quality.
+		{
+			name: "rule6_qa_failed",
+			in:   itemDerivationInputs{qaState: "failed"},
+			want: "Quality",
+		},
+		// Rule 7: review_state = approved AND qa_state = pending → Quality.
+		{
+			name: "rule7_review_approved_qa_pending",
+			in: itemDerivationInputs{
+				reviewState: "approved",
+				qaState:     "pending",
+			},
+			want: "Quality",
+		},
+		// Rule 8: review_state = needs_rework → Implementation.
+		{
+			name: "rule8_review_needs_rework",
+			in:   itemDerivationInputs{reviewState: "needs_rework"},
+			want: "Implementation",
+		},
+		// Rule 9: impl_state = done AND review_state = pending AND review comment exists → Review.
+		{
+			name: "rule9_impl_done_review_pending_with_review_comment",
+			in: itemDerivationInputs{
+				implState:        "done",
+				reviewState:      "pending",
+				qaState:          "pending",
+				hasReviewComment: true,
+			},
+			want: "Review",
+		},
+		// Rule 10: impl_state = done AND review_state = pending AND no review comment → Implementation.
+		{
+			name: "rule10_impl_done_review_pending_no_review_comment",
+			in: itemDerivationInputs{
+				implState:        "done",
+				reviewState:      "pending",
+				qaState:          "pending",
+				hasReviewComment: false,
+			},
+			want: "Implementation",
+		},
+		// Rule 11: impl_state = pending AND investigation comment exists → Implementation.
+		{
+			name: "rule11_impl_pending_with_investigation_comment",
+			in: itemDerivationInputs{
+				implState:               "pending",
+				reviewState:             "pending",
+				qaState:                 "pending",
+				hasInvestigationComment: true,
+			},
+			want: "Implementation",
+		},
+		// Rule 12: impl_state = pending AND no investigation comment → Investigation.
+		{
+			name: "rule12_impl_pending_no_investigation_comment",
+			in: itemDerivationInputs{
+				implState:               "pending",
+				reviewState:             "pending",
+				qaState:                 "pending",
+				hasInvestigationComment: false,
+			},
+			want: "Investigation",
+		},
+		// First-match-wins guard: needs_human + qa_passed + status=Done
+		// must still return Deferred (rule 1 wins over rule 4).
+		{
+			name: "first_match_wins_deferred_over_done",
+			in: itemDerivationInputs{
+				pipelineState:   "needs_human",
+				status:          "Done",
+				qaState:         "passed",
+				closedAtNotNull: true,
+			},
+			want: "Deferred",
+		},
+		// First-match-wins guard: paused (rule 2) wins over
+		// rule-3's no_investigation + impl_state=pending.
+		{
+			name: "first_match_wins_paused_over_no_investigation",
+			in: itemDerivationInputs{
+				pipelineState: "paused",
+				implState:     "pending",
+			},
+			want: "Deferred",
+		},
+		// Default: a freshly created item (all zeros + impl_state=pending,
+		// pipeline_state=running) lands in Investigation via rule 12.
+		{
+			name: "default_fresh_item_investigation",
+			in: itemDerivationInputs{
+				status:        "Backlog",
+				pipelineState: "running",
+				implState:     "pending",
+				reviewState:   "pending",
+				qaState:       "pending",
+			},
+			want: "Investigation",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := derivePipelineStage(&tc.in)
+			if got != tc.want {
+				t.Fatalf("derivePipelineStage(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/api/deps/integration_test.go
+++ b/apps/api/deps/integration_test.go
@@ -756,6 +756,14 @@ func TestPropertyNoCyclesAfter100Mutations(t *testing.T) {
 		addOK, addReject, removeOK, removeMiss)
 }
 
+// Cascade subscriber tests for C-3 live in the internal-package file
+// apps/api/deps/cascade_subscriber_handler_test.go. Encore's pubsub
+// testing implementation does NOT fire subscriptions during
+// `encore test` (https://encore.dev/docs/go/primitives/pubsub#testing-pubsub),
+// so the subscriber is exercised by calling handleCascadeRequested
+// directly from an internal-package test. See the DEVIATION comment on
+// bead unblock-tv8.12 for the full reasoning.
+
 // assertAcyclic seeds the same depth-counter CTE the cycle detector
 // uses, but starts from every node in the pool. If any node reaches
 // itself via a 'blocks' walk, the graph has a cycle — fail the test

--- a/apps/api/deps/recompute.go
+++ b/apps/api/deps/recompute.go
@@ -67,3 +67,74 @@ func recomputeReady(ctx context.Context, tx *sqldb.Tx, itemID string) (bool, err
 	}
 	return newReady, nil
 }
+
+// RecomputeReadyForBlocksDownstream is the exported Regime A helper for
+// the workitems.Close (Tool 6) call site. It recomputes is_ready for
+// every direct 'blocks' downstream neighbour of fromItemID inside the
+// supplied transaction and returns the subset of those neighbours that
+// flipped to is_ready=true as a result.
+//
+// SPEC §6.3.0 line 1691-1692 mandates workitems.Close inline-recompute
+// is_ready for the closed item's direct blocks neighbours. The lint
+// allow-list at apps/api/shared/lint/no_direct_is_ready_write.go gates
+// is_ready UPDATEs to encore.app/deps — so workitems.Close cannot inline
+// the UPDATE itself and must call this exported helper instead. The
+// helper accepts a *sqldb.Tx so workitems.Close can run the recompute
+// in the SAME transaction as the status='Done' write (Regime A
+// invariant: the writer's transaction holds the readiness flip).
+//
+// Direction: forward along outgoing 'blocks' edges. A row
+// `(from_item=fromItemID, to_item=X, kind='blocks')` in deps.dependencies
+// means "fromItemID blocks X". When fromItemID flips to status='Done',
+// X may now satisfy the NOT EXISTS closure (§6.5) and become ready —
+// hence we recompute X. We do NOT walk multi-hop here; that is Regime B
+// (pipeline_stage only) and runs in the cascade subscriber.
+//
+// Returns the list of neighbour ids whose is_ready value was true AFTER
+// the recompute (i.e. items that are now ready). An empty list is a
+// valid result — the closed item may have had no 'blocks' downstream,
+// or none of the downstream items became ready (other blockers remain).
+// The caller logs the result via rlog and never fails on emptiness.
+//
+// Idempotency: the underlying recomputeReady UPDATE is value-equality
+// idempotent. Calling this helper twice in the same transaction for
+// the same fromItemID returns the same list (no double-flip).
+func RecomputeReadyForBlocksDownstream(ctx context.Context, tx *sqldb.Tx, fromItemID string) ([]string, error) {
+	if fromItemID == "" {
+		return nil, fmt.Errorf("deps: RecomputeReadyForBlocksDownstream: empty fromItemID")
+	}
+	rows, err := tx.Query(ctx,
+		`SELECT to_item FROM deps.dependencies
+		  WHERE from_item = $1 AND kind = 'blocks'`,
+		fromItemID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("deps: RecomputeReadyForBlocksDownstream select: %w", err)
+	}
+	neighbours := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("deps: RecomputeReadyForBlocksDownstream scan: %w", err)
+		}
+		neighbours = append(neighbours, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("deps: RecomputeReadyForBlocksDownstream iter: %w", err)
+	}
+	rows.Close()
+
+	flipped := make([]string, 0, len(neighbours))
+	for _, id := range neighbours {
+		ready, err := recomputeReady(ctx, tx, id)
+		if err != nil {
+			return nil, fmt.Errorf("deps: RecomputeReadyForBlocksDownstream recompute %s: %w", id, err)
+		}
+		if ready {
+			flipped = append(flipped, id)
+		}
+	}
+	return flipped, nil
+}

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1097,8 +1097,33 @@ func Close(ctx context.Context, req *CloseRequest) (*Item, error) {
 		}
 	}
 
+	// Regime A (SPEC §6.3.0 lines 1691-1692): recompute is_ready inline
+	// for the closed item's DIRECT 'blocks' downstream neighbours, in
+	// the SAME transaction as the status='Done' write. The cascade
+	// subscriber maintains pipeline_stage multi-hop (Regime B) but the
+	// single-hop is_ready flip is the writer's responsibility — Postgres
+	// holds the transaction's view consistent with the readiness flip,
+	// so downstream readers never observe Done-but-unblocker-not-ready
+	// state. The helper is the SOLE exported Regime A write path; the
+	// is_ready UPDATE itself lives in encore.app/deps (gated by the
+	// no_direct_is_ready_write lint analyzer to that single package).
+	flipped, err := deps.RecomputeReadyForBlocksDownstream(ctx, tx, req.ItemID)
+	if err != nil {
+		rlog.Error("workitems: close inline is_ready recompute failed",
+			"err", err, "item_id", req.ItemID)
+		return nil, &errs.Error{Code: errs.Internal, Message: "is_ready recompute failed"}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, &errs.Error{Code: errs.Internal, Message: "close commit failed"}
+	}
+
+	// Log the neighbours that became ready as a result of this close.
+	// An empty list is normal (no direct blocks downstream, or other
+	// blockers remain on every neighbour) — never fail on it.
+	if len(flipped) > 0 {
+		rlog.Info("workitems: close flipped is_ready on direct blocks downstream",
+			"item_id", req.ItemID, "flipped", flipped, "count", len(flipped))
 	}
 
 	// Publish cascade event. Encore Pub/Sub does not carry ctx across


### PR DESCRIPTION
## unblock-tv8.12: C-3 — Cascade subsystem (Pub/Sub topics, subscriber, is_ready materialisation)

Lands the Pub/Sub cascade subscriber per SPEC §6.3.2 and closes the Regime A inline-recompute gap in workitems.Close per SPEC §6.3.0 line 1691-1692.

### What was done

**Subscriber (`apps/api/deps/cascade_subscriber.go`):**
- `pubsub.NewSubscription` on `CascadeRequestedTopic` with name `deps-cascade-subscriber` (kebab-case literal per Encore E1184).
- `handleCascadeRequested` dispatches over the four documented Reason values (`close | edge_added | edge_removed | state_change`); unknown Reasons are dropped defensively.
- Forward `blocks` BFS from `TriggeredByItemID`, capped at AR-8 depth 256. Seed is INCLUDED so its own `pipeline_stage` is re-derived.
- Batched §5.7.1 derivation: ONE SELECT against `workitems.comments` per pass to feed `kind='review'` / `kind='investigation'` existence predicates.
- `derivePipelineStage` applies the 12-rule §5.7.1 derivation table in spec-locked order (first match wins).
- Per-item idempotent UPDATE on `workitems.items.pipeline_stage` with `WHERE pipeline_stage <> $new`.
- One `deps.cascade_events` row per cascade with `kind=msg.Reason` and `ON CONFLICT (event_id, triggered_by_item_id) DO NOTHING` (AR-11 + tension #1 collapse for edge_removed).
- `CascadeCompleted` publish is best-effort.
- **NEVER writes `is_ready`** (Regime B only — SPEC §11.3 bullet (b)).

**Regime A scope expansion** (orchestrator option-A from bead notes):
- `deps.RecomputeReadyForBlocksDownstream` exported helper that workitems.Close calls inside its transaction.
- `workitems.Close` now recomputes `is_ready` for the closed item's direct `blocks` downstream BEFORE `tx.Commit`, logs flipped neighbours via `rlog.Info`.

### Files changed

- `apps/api/deps/cascade_subscriber.go` (new — 410 lines)
- `apps/api/deps/cascade_subscriber_handler_test.go` (new — DB-backed handler tests)
- `apps/api/deps/cascade_subscriber_unit_test.go` (new — pure derivation table tests)
- `apps/api/deps/recompute.go` (added `RecomputeReadyForBlocksDownstream` export)
- `apps/api/workitems/workitems.go` (Close now calls Regime A helper inline)
- `apps/api/deps/integration_test.go` (removed broken subscriber tests that relied on Encore firing subscriptions during `encore test` — replaced with a comment pointing to the internal-package tests)

### Decisions

None — followed SPEC §6.3.0 + §6.3.2 + §5.7.1 + §11.3 verbatim.

### Deviations

**1 deviation logged on bead:** Encore subscriptions do NOT fire during `encore test` (per [Encore docs](https://encore.dev/docs/go/primitives/pubsub#testing-pubsub) — publishers and subscribers are isolated during testing). The bead investigation's recommendation "Use Encore's testing primitives to await subscription drain" was factually wrong about Encore's behaviour. Subscriber-side integration tests therefore invoke `handleCascadeRequested` directly from an internal-package test (`package deps`). The Pub/Sub fan-out itself is exercised in production / `encore run`; the handler logic, idempotency contract, BFS, derivation, and audit insert are all covered by direct-handler tests.

### Test plan

- [x] `encore test ./deps/... ./workitems/... ./shared/lint/...` — all PASS
- [x] `TestDerivePipelineStage_Rules` — 16 sub-tests covering all 12 derivation rules + first-match-wins guards
- [x] `TestHandleCascadeRequested_FourKinds` — 4 sub-tests per Reason + trace_id round-trip + is_ready invariant
- [x] `TestHandleCascadeRequested_IdempotencyN100` — 100 re-deliveries, exactly one row
- [x] `TestHandleCascadeRequested_IdempotentPipelineStage` — pipeline_stage stable across passes
- [x] `TestHandleCascadeRequested_MultiHopBFS` — 3-deep blocks chain reached
- [x] `TestHandleCascadeRequested_UnknownReason` / `_EmptyTrace` / `_DerivesPipelineStage`
- [x] Existing `TestCloseHappyPath` / `TestCloseRequiresClaim` still pass after Regime A wiring
- [x] `apps/api/shared/lint` analyzer suite still passes — `cascade_subscriber.go` SQL writes `pipeline_stage` only, allow-listed by package path