### PR TITLE
unblock-tv8.18: D-3 MCP Tools 5–8 (update, close, show, list)

### DIFF
--- a/apps/api/mcp/handler_close.go
+++ b/apps/api/mcp/handler_close.go
@@ -1,0 +1,89 @@
+// handler_close.go owns the §6.2 Tool 6 (`close`) handler — wraps
+// workitems.Close which flips status=Done, runs the inline Regime-A
+// is_ready recompute on direct blocks downstream, and publishes
+// CascadeRequested{Reason:"close"} post-commit for the multi-hop
+// pipeline_stage recompute (Regime B).
+//
+// AF3 precondition path: when claimed_by_id IS NULL on the locked row,
+// workitems.Close returns FailedPrecondition with
+// Meta["invariant"]="claimed_by_id_required" AND
+// Meta["missing"]="claimed_by_id" (see workitems.go's
+// preconditionErrorMissing helper). The errmap's classifyEnvelopeError
+// projects those into the §7 PRECONDITION_NOT_MET envelope:
+// details.rejection_reason="claimed_by_id_required" +
+// details.missing="claimed_by_id". The bead AC ("close with
+// claimed_by_id IS NULL returns PRECONDITION_NOT_MET with
+// data.missing=claimed_by_id") is satisfied at the workitems-error-
+// shape layer; this handler only translates the resulting *errs.Error
+// to the wire envelope.
+//
+// Cascade event publication is the responsibility of workitems.Close
+// (post-commit publish on deps.cascade.requested with Reason="close").
+// The subscriber lands a deps.cascade_events row with kind='close';
+// the handler does not observe that side-effect synchronously.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 6 (lines 1322-1361)
+// + § 6.3.0 / § 6.3.2 (cascade regimes) + § 7 (error envelope).
+
+package mcp
+
+import (
+	"context"
+
+	"encore.app/workitems"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type closeIn struct {
+	ItemID string `json:"item_id"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type closeOut struct {
+	Item primeItem `json:"item"`
+}
+
+// registerHandleClose is invoked by transport.go's init — see the
+// toolRegistrars rationale there.
+func registerHandleClose(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "close",
+		Description: "Flip an item to Done. Rejects with PRECONDITION_NOT_MET " +
+			"(data.missing=claimed_by_id) when the item is not currently " +
+			"claimed. Emits CascadeRequested{Reason:\"close\"} post-commit. " +
+			"SPEC § 6.2 Tool 6.",
+	}, handleClose)
+}
+
+func handleClose(ctx context.Context, req *sdkmcp.CallToolRequest, in closeIn) (*sdkmcp.CallToolResult, closeOut, error) {
+	tool := "close"
+	state := bindTool(req, tool)
+
+	if _, ok := identityFromReq(req); !ok {
+		return nil, closeOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, closeOut{}, mapError(state, tool, err)
+	}
+
+	if state != nil && state.Call != nil {
+		state.Call.ItemID = in.ItemID
+	}
+
+	item, err := workitems.Close(mcpCtx, &workitems.CloseRequest{
+		ItemID: in.ItemID,
+		Reason: in.Reason,
+	})
+	if err != nil {
+		return nil, closeOut{}, mapError(state, tool, err)
+	}
+
+	out := closeOut{Item: itemToPrime(*item)}
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+		state.Call.ProjectID = item.ProjectID
+	}
+	return nil, out, nil
+}

--- a/apps/api/mcp/handler_list.go
+++ b/apps/api/mcp/handler_list.go
@@ -1,0 +1,172 @@
+// handler_list.go owns the §6.2 Tool 8 (`list`) handler — the
+// general-purpose paginated read across workitems.items.
+//
+// Wraps workitems.List which orders by `id ASC` only (SPEC §4.4) and
+// emits a NextCursor on `id > $1` keyset semantics. The MCP layer
+// wraps that bare ULID in the §6.2.0 opaque, HMAC-signed cursor
+// envelope (cursor.go::listCursor with V="l1").
+//
+// Filter semantics:
+//
+//   - project_id, milestone_id, claimed_by: scalar equality
+//   - status[], pipeline_stage[]: validated enum-array filter
+//     (workitems.List rejects unknown members with VALIDATION)
+//   - labels[]: post-fetch intersection — see "labels filter note"
+//     below.
+//
+// Labels filter note (intentional, per round-7 §6.2 + workitems.List
+// implementation): labels[] is applied AFTER the keyset window is
+// materialised because labels live in workitems.item_labels (junction
+// table). A page with limit+1 rows can therefore return FEWER than
+// `limit` items when labels[] narrows the set — but the cursor still
+// advances past the last fetched row. `next_cursor` signals "more rows
+// past the anchor" (which is the spec's pagination contract), NOT
+// "more rows matching the labels filter". A caller hunting for a
+// specific labelset may need to consume multiple cursored pages to
+// see all matches. Do NOT "fix" this by lifting the labels filter
+// into SQL — the spec is silent on per-page completeness and the
+// junction-table join would defeat the items_ready_partial_idx
+// keyset scan that Tool 2 / Tool 8 share for the hot path.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 8 (lines
+// 1381-1398) + § 6.2.0 (cursor contract) + § 4.4 (workitems.List).
+
+package mcp
+
+import (
+	"context"
+
+	"encore.app/workitems"
+	"encore.dev/beta/errs"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// listLimitDefault / listLimitMax mirror SPEC §6.2 Tool 8 line 1389
+// (1..200; default 50). Aligns with workitems.listDefaultLimit /
+// listMaxLimit so the wire ceiling matches the downstream RPC.
+// Two local consts keep this handler's behaviour readable without
+// chasing constants across package boundaries.
+const (
+	listLimitDefault = 50
+	listLimitMax     = 200
+)
+
+type listIn struct {
+	ProjectID     string   `json:"project_id,omitempty"`
+	MilestoneID   string   `json:"milestone_id,omitempty"`
+	Status        []string `json:"status,omitempty"`
+	PipelineStage []string `json:"pipeline_stage,omitempty"`
+	ClaimedBy     string   `json:"claimed_by,omitempty"`
+	Labels        []string `json:"labels,omitempty"`
+	Limit         int      `json:"limit,omitempty"`
+	Cursor        string   `json:"cursor,omitempty"`
+}
+
+type listOut struct {
+	Items []primeItem `json:"items"`
+	// NextCursor follows the same round-2 W1 contract as readyOut /
+	// searchOut: *string with NO `omitempty` so the final page emits
+	// an explicit `"next_cursor": null` rather than omitting the field.
+	NextCursor *string `json:"next_cursor"`
+}
+
+// registerHandleList is invoked by transport.go's init — see the
+// toolRegistrars rationale there.
+func registerHandleList(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "list",
+		Description: "Paginate workitems with scalar + array filters " +
+			"(project_id, milestone_id, status, pipeline_stage, " +
+			"claimed_by, labels). Ordered by id ASC. SPEC § 6.2 Tool 8.",
+	}, handleList)
+}
+
+func handleList(ctx context.Context, req *sdkmcp.CallToolRequest, in listIn) (*sdkmcp.CallToolResult, listOut, error) {
+	tool := "list"
+	state := bindTool(req, tool)
+
+	if _, ok := identityFromReq(req); !ok {
+		return nil, listOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, listOut{}, mapError(state, tool, err)
+	}
+
+	if state != nil && state.Call != nil && in.ProjectID != "" {
+		state.Call.ProjectID = in.ProjectID
+	}
+
+	// Limit bounds — same shape as handler_ready.go (rework S4): explicit
+	// default coercion + explicit range rejection. limit=0/negative
+	// coerces to listLimitDefault (50); limit > listLimitMax is a
+	// contract violation surfaced as VALIDATION.
+	if in.Limit <= 0 {
+		in.Limit = listLimitDefault
+	}
+	if in.Limit > listLimitMax {
+		return nil, listOut{}, mapError(state, tool, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "limit out of range (1..200)",
+			Meta:    errs.Metadata{"field": "limit"},
+		})
+	}
+
+	// §6.2.0 cursor decode — the opaque token is verified and the {id}
+	// tuple unpacked into ListRequest.Cursor (workitems.List accepts a
+	// plain ULID for its `id > $1` keyset predicate). An empty cursor
+	// is the first-page signal; cursorVersionList="l1" rejects replays
+	// from other tools (Tool 2 / Tool 9) at the decoder boundary.
+	var c listCursor
+	if in.Cursor != "" {
+		if err := decodeCursor(in.Cursor, cursorVersionList, &c); err != nil {
+			return nil, listOut{}, mapError(state, tool, err)
+		}
+	}
+
+	rpcReq := &workitems.ListRequest{
+		ProjectID:     in.ProjectID,
+		MilestoneID:   in.MilestoneID,
+		Status:        in.Status,
+		PipelineStage: in.PipelineStage,
+		ClaimedBy:     in.ClaimedBy,
+		Labels:        in.Labels,
+		Limit:         in.Limit,
+	}
+	if in.Cursor != "" {
+		rpcReq.Cursor = c.ID
+	}
+
+	resp, err := workitems.List(mcpCtx, rpcReq)
+	if err != nil {
+		return nil, listOut{}, mapError(state, tool, err)
+	}
+
+	// Encode next_cursor only when the underlying RPC produced one.
+	// Empty NextCursor means end-of-stream and the *string stays nil
+	// so it marshals to literal JSON `null`.
+	var nextCursor *string
+	if resp.NextCursor != "" {
+		tok, err := encodeCursor(listCursor{
+			V:  cursorVersionList,
+			ID: resp.NextCursor,
+		})
+		if err != nil {
+			return nil, listOut{}, mapError(state, tool, &errs.Error{
+				Code:    errs.Internal,
+				Message: "cursor encode failed",
+			})
+		}
+		nextCursor = &tok
+	}
+
+	out := listOut{
+		Items:      itemsToPrime(resp.Items),
+		NextCursor: nextCursor,
+	}
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+	}
+	return nil, out, nil
+}

--- a/apps/api/mcp/handler_show.go
+++ b/apps/api/mcp/handler_show.go
@@ -1,0 +1,212 @@
+// handler_show.go owns the §6.2 Tool 7 (`show`) handler — composes
+// the item, its comments, incoming/outgoing edges, and finding
+// children into a single read.
+//
+// Delegates to workitems.GetTrail which fan-outs the four collections
+// inside the workitems service (single auth gate, single org scope).
+// The include_* flags (defaults true per SPEC §6.2 Tool 7 line 1364)
+// are honoured at the wire shape: the RPC always materialises the
+// full Trail; the handler drops collections the caller opted out of
+// so wire size is bounded by the request.
+//
+// The wire shape mirrors SPEC §6.2 Tool 7 lines 1370-1378:
+//
+//	{
+//	  "item":             <Item>,
+//	  "comments":         [Comment],
+//	  "dependencies_in":  [Edge],   // edges where to_item = item_id
+//	  "dependencies_out": [Edge],   // edges where from_item = item_id
+//	  "findings":         [Item]    // children with type=finding
+//	}
+//
+// Each collection always serialises as an array (never null) so
+// downstream consumers see a stable shape; null-out behaviour for
+// include_*=false would surface as a missing key here, which is a
+// breaking contract change. We instead emit `[]` when the caller
+// opted out — symmetric with how primeItem.Labels / similar arrays
+// behave throughout the §6.2 surface.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 7 (lines
+// 1361-1379) + § 4.4 (workitems.GetTrail) + § 7 (error envelope).
+
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"encore.app/deps"
+	"encore.app/workitems"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// showIn mirrors SPEC §6.2 Tool 7 lines 1363-1367. All three include_*
+// flags default to true; the SDK does not interpret the `omitempty` JSON
+// tag for booleans (a missing field unmarshals to false), so the
+// handler reads the raw arguments to distinguish "absent (default
+// true)" from "explicitly false" — see handleShow's flag normalisation
+// below.
+//
+// Implementation note: we keep the typed shape (`*bool`) so the SDK's
+// auto-inferred schema reports the right types to clients; the
+// handler reads the pointer for the actual value with a nil-means-
+// default treatment.
+type showIn struct {
+	ItemID              string `json:"item_id"`
+	IncludeComments     *bool  `json:"include_comments,omitempty"`
+	IncludeDependencies *bool  `json:"include_dependencies,omitempty"`
+	IncludeFindings     *bool  `json:"include_findings,omitempty"`
+}
+
+// showComment is the JSON wire shape for one workitems.Comment row.
+// Mirrors the §4.4 Comment fields, ISO-8601 timestamps. Omits
+// updated_at and parent_id when zero so empty fields don't pollute
+// the wire (SPEC §6.2 Tool 7 line 1373 says "Comment[]" — the
+// canonical shape lives at the workitems service layer).
+type showComment struct {
+	ID          string `json:"id"`
+	ItemID      string `json:"item_id"`
+	ParentID    string `json:"parent_id,omitempty"`
+	AuthorID    string `json:"author_id,omitempty"`
+	AuthorAgent string `json:"author_agent,omitempty"`
+	Kind        string `json:"kind"`
+	Status      string `json:"status"`
+	Body        string `json:"body"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// showEdge is the JSON wire shape for one deps.Edge row. The §4.5
+// Edge struct carries created_by which we surface as an optional
+// string (omitted when empty so the wire stays compact for
+// system-generated edges).
+type showEdge struct {
+	ID        string `json:"id"`
+	FromItem  string `json:"from_item"`
+	ToItem    string `json:"to_item"`
+	Kind      string `json:"kind"`
+	CreatedAt string `json:"created_at"`
+	CreatedBy string `json:"created_by,omitempty"`
+}
+
+type showOut struct {
+	Item            primeItem     `json:"item"`
+	Comments        []showComment `json:"comments"`
+	DependenciesIn  []showEdge    `json:"dependencies_in"`
+	DependenciesOut []showEdge    `json:"dependencies_out"`
+	Findings        []primeItem   `json:"findings"`
+}
+
+// registerHandleShow is invoked by transport.go's init — see the
+// toolRegistrars rationale there.
+func registerHandleShow(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "show",
+		Description: "Read an item with its comments, incoming + outgoing " +
+			"dependencies, and finding children. include_comments / " +
+			"include_dependencies / include_findings default to true. " +
+			"SPEC § 6.2 Tool 7.",
+	}, handleShow)
+}
+
+func handleShow(ctx context.Context, req *sdkmcp.CallToolRequest, in showIn) (*sdkmcp.CallToolResult, showOut, error) {
+	tool := "show"
+	state := bindTool(req, tool)
+
+	if _, ok := identityFromReq(req); !ok {
+		return nil, showOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, showOut{}, mapError(state, tool, err)
+	}
+
+	if state != nil && state.Call != nil {
+		state.Call.ItemID = in.ItemID
+	}
+
+	// Flag defaults: nil pointer (field absent on the wire) means TRUE
+	// per SPEC §6.2 Tool 7 line 1364 ("default true"). An explicit
+	// `false` on the wire opts the caller out.
+	includeComments := in.IncludeComments == nil || *in.IncludeComments
+	includeDependencies := in.IncludeDependencies == nil || *in.IncludeDependencies
+	includeFindings := in.IncludeFindings == nil || *in.IncludeFindings
+
+	trail, err := workitems.GetTrail(mcpCtx, &workitems.GetTrailRequest{
+		ItemID: in.ItemID,
+	})
+	if err != nil {
+		return nil, showOut{}, mapError(state, tool, err)
+	}
+
+	out := showOut{
+		Item:            itemToPrime(*trail.Item),
+		Comments:        []showComment{},
+		DependenciesIn:  []showEdge{},
+		DependenciesOut: []showEdge{},
+		Findings:        []primeItem{},
+	}
+
+	if includeComments {
+		out.Comments = commentsToShow(trail.Comments)
+	}
+	if includeDependencies {
+		out.DependenciesIn = edgesToShow(trail.DependenciesIn)
+		out.DependenciesOut = edgesToShow(trail.DependenciesOut)
+	}
+	if includeFindings {
+		out.Findings = itemsToPrime(trail.Findings)
+	}
+
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+		state.Call.ProjectID = trail.Item.ProjectID
+	}
+	return nil, out, nil
+}
+
+// commentsToShow converts a []workitems.Comment into the §6.2 wire
+// shape. Always returns a non-nil slice so the JSON encodes as `[]`
+// rather than `null` on the empty case.
+func commentsToShow(in []workitems.Comment) []showComment {
+	if len(in) == 0 {
+		return []showComment{}
+	}
+	out := make([]showComment, 0, len(in))
+	for _, c := range in {
+		out = append(out, showComment{
+			ID:          c.ID,
+			ItemID:      c.ItemID,
+			ParentID:    c.ParentID,
+			AuthorID:    c.AuthorID,
+			AuthorAgent: c.AuthorAgent,
+			Kind:        c.Kind,
+			Status:      c.Status,
+			Body:        c.Body,
+			CreatedAt:   c.CreatedAt.UTC().Format(time.RFC3339Nano),
+			UpdatedAt:   c.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		})
+	}
+	return out
+}
+
+// edgesToShow converts a []deps.Edge into the §6.2 wire shape. Always
+// returns a non-nil slice.
+func edgesToShow(in []deps.Edge) []showEdge {
+	if len(in) == 0 {
+		return []showEdge{}
+	}
+	out := make([]showEdge, 0, len(in))
+	for _, e := range in {
+		out = append(out, showEdge{
+			ID:        e.ID,
+			FromItem:  e.FromItem,
+			ToItem:    e.ToItem,
+			Kind:      e.Kind,
+			CreatedAt: e.CreatedAt.UTC().Format(time.RFC3339Nano),
+			CreatedBy: e.CreatedBy,
+		})
+	}
+	return out
+}

--- a/apps/api/mcp/handler_update.go
+++ b/apps/api/mcp/handler_update.go
@@ -1,0 +1,241 @@
+// handler_update.go owns the §6.2 Tool 5 (`update`) handler — the
+// editable-column mutator (title, body, priority, milestone_id, labels).
+//
+// State dimensions (impl_state / review_state / qa_state / pipeline_state)
+// are EXPLICITLY rejected here per SPEC §6.2 Tool 5 line 1316 ("Does NOT
+// touch state dimensions — use set_state for those"). The bead AC #1
+// requires a §7 VALIDATION envelope with `data.field=<offending field>`
+// when any of the four forbidden keys appears in the JSON arguments.
+//
+// Why a raw-JSON sniff and not the SDK's schema validator:
+//
+//   - github.com/google/jsonschema-go (v0.4.3) auto-infers
+//     `additionalProperties: false` for struct types, so a typed In
+//     would normally cause the SDK to reject unknown keys at
+//     applySchema time. BUT the SDK rejects them by SetError'ing the
+//     CallToolResult (server.go:323-326) — the §7 error envelope path
+//     never runs and the wire response is a content-text error, not
+//     `error.data.kind=VALIDATION`.
+//
+//   - We override Tool.InputSchema with an explicit object schema that
+//     ALLOWS additional properties so the SDK's auto-inference path
+//     does not run. Forbidden keys then survive into req.Params.Arguments
+//     where the handler can sniff them and emit the spec-compliant
+//     §7 VALIDATION envelope via mapError.
+//
+//   - The typed `in updateIn` struct still receives the legitimate
+//     fields (title/body/priority/milestone_id/labels) via the SDK's
+//     own unmarshal; unknown keys are silently dropped by
+//     internaljson.Unmarshal, which is the desired outcome AFTER the
+//     sniff has confirmed none of the four forbidden state-dimension
+//     keys are present.
+//
+// milestone_id wire semantics per SPEC §6.2 Tool 5 line 1314
+// (`<ULID|null; optional>`): JSON `null` clears the column, a string
+// sets it, absence leaves it unchanged. The handler distinguishes the
+// three cases by sniffing the raw JSON before relying on the typed
+// unmarshal (Go's zero string cannot represent "absent vs explicit
+// null vs empty string" on its own).
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 5 (lines 1306-1320)
+// + § 7 (error envelope) + § 4.4 (workitems.Update pointer-field
+// contract).
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"encore.app/workitems"
+	"encore.dev/beta/errs"
+	"github.com/google/jsonschema-go/jsonschema"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// forbiddenUpdateFields enumerates the four state-dimension column
+// names §6.2 Tool 5 prohibits. They are owned by Tool 13 (set_state).
+// Iteration order is stable so the rejection error consistently names
+// the first-discovered offender (spec is silent on ordering; we pick
+// the spec line order for predictability).
+var forbiddenUpdateFields = []string{
+	"impl_state",
+	"review_state",
+	"qa_state",
+	"pipeline_state",
+}
+
+// updateIn is the typed input to handleUpdate. Fields are pointers so
+// the handler can faithfully forward "unchanged vs explicit set vs
+// explicit clear" semantics to workitems.Update which uses the same
+// pointer-nil-is-unchanged convention (workitems/workitems.go § Update).
+//
+// MilestoneID is omitted from the typed struct because Go's
+// encoding/json cannot distinguish `null` from absent on a *string
+// field once unmarshalled — both yield nil. The handler reads the
+// milestone_id intent directly from the sniffed raw JSON map below
+// (presence + null-vs-string) and constructs the
+// workitems.UpdateRequest.MilestoneID pointer accordingly.
+type updateIn struct {
+	ItemID   string    `json:"item_id"`
+	Title    *string   `json:"title,omitempty"`
+	Body     *string   `json:"body,omitempty"`
+	Priority *string   `json:"priority,omitempty"`
+	Labels   *[]string `json:"labels,omitempty"`
+}
+
+type updateOut struct {
+	Item primeItem `json:"item"`
+}
+
+// registerHandleUpdate is invoked by transport.go's init — see the
+// toolRegistrars rationale there.
+//
+// Tool.InputSchema is set explicitly to an object schema with
+// AdditionalProperties = true so the SDK's auto-inferred
+// `additionalProperties: false` does not fire on impl_state/etc. The
+// handler enforces the rejection itself with a §7-shaped error.
+func registerHandleUpdate(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "update",
+		Description: "Update editable item columns (title, body, priority, " +
+			"milestone_id, labels). State dimensions (impl_state, " +
+			"review_state, qa_state, pipeline_state) are rejected with " +
+			"VALIDATION — use set_state instead. SPEC § 6.2 Tool 5.",
+		// AdditionalProperties: true here keeps the SDK's
+		// applySchema from rejecting unknown keys before the handler
+		// runs (which would surface as an SDK IsError content frame,
+		// not the §7 envelope the spec mandates). The handler then
+		// sniffs req.Params.Arguments for the forbidden state-
+		// dimension keys and produces the canonical envelope.
+		InputSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"item_id":      {Type: "string"},
+				"title":        {Type: "string"},
+				"body":         {Type: "string"},
+				"priority":     {Type: "string"},
+				"milestone_id": {Types: []string{"string", "null"}},
+				"labels": {
+					Type:  "array",
+					Items: &jsonschema.Schema{Type: "string"},
+				},
+			},
+			Required:             []string{"item_id"},
+			AdditionalProperties: trueSchemaForUpdate(),
+		},
+	}, handleUpdate)
+}
+
+// trueSchemaForUpdate returns the JSON-Schema sentinel for "any
+// additional properties are allowed". The jsonschema-go library
+// distinguishes "no constraint" (nil) from "explicit allow" via a
+// pointer to an empty schema; we use the latter to make the intent
+// reviewable and to prevent a future re-inference pass from collapsing
+// nil into the default falseSchema().
+func trueSchemaForUpdate() *jsonschema.Schema {
+	return &jsonschema.Schema{}
+}
+
+func handleUpdate(ctx context.Context, req *sdkmcp.CallToolRequest, in updateIn) (*sdkmcp.CallToolResult, updateOut, error) {
+	tool := "update"
+	state := bindTool(req, tool)
+
+	if _, ok := identityFromReq(req); !ok {
+		return nil, updateOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, updateOut{}, mapError(state, tool, err)
+	}
+
+	// Sniff the raw JSON arguments BEFORE trusting the typed `in` —
+	// internaljson.Unmarshal silently drops unknown keys, so a forbidden
+	// state-dimension field would otherwise pass through unnoticed.
+	// Decoding into map[string]json.RawMessage lets us inspect both
+	// presence (key exists) and the literal token (string vs `null`)
+	// for milestone_id without re-parsing every value.
+	var raw map[string]json.RawMessage
+	if len(req.Params.Arguments) > 0 {
+		if err := json.Unmarshal(req.Params.Arguments, &raw); err != nil {
+			return nil, updateOut{}, mapError(state, tool, &errs.Error{
+				Code:    errs.InvalidArgument,
+				Message: "arguments must be a JSON object",
+				Meta:    errs.Metadata{"field": "arguments"},
+			})
+		}
+	}
+
+	// Reject any state-dimension field per SPEC §6.2 Tool 5 + bead AC #1.
+	// We surface the first offender to give the caller a single, actionable
+	// field name; downstream callers retrying with the field stripped will
+	// surface the next offender on the subsequent attempt.
+	for _, field := range forbiddenUpdateFields {
+		if _, present := raw[field]; present {
+			return nil, updateOut{}, mapError(state, tool, &errs.Error{
+				Code:    errs.InvalidArgument,
+				Message: "state dimensions are read-only on update — use set_state",
+				Meta: errs.Metadata{
+					"field":  field,
+					"reason": "state dimensions are not editable via update",
+				},
+			})
+		}
+	}
+
+	if in.ItemID == "" {
+		return nil, updateOut{}, mapError(state, tool, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "missing item_id",
+			Meta:    errs.Metadata{"field": "item_id"},
+		})
+	}
+	if state != nil && state.Call != nil {
+		state.Call.ItemID = in.ItemID
+	}
+
+	// milestone_id three-way resolution from the raw JSON:
+	//   absent          → pointer stays nil → workitems.Update leaves it unchanged.
+	//   explicit null   → pointer to empty string → workitems.Update clears the column.
+	//   string value    → pointer to the value → workitems.Update sets the column.
+	//
+	// The typed `in updateIn` deliberately omits MilestoneID for this
+	// reason — see updateIn doc comment.
+	var milestonePtr *string
+	if tok, present := raw["milestone_id"]; present {
+		if string(tok) == "null" {
+			empty := ""
+			milestonePtr = &empty
+		} else {
+			var s string
+			if err := json.Unmarshal(tok, &s); err != nil {
+				return nil, updateOut{}, mapError(state, tool, &errs.Error{
+					Code:    errs.InvalidArgument,
+					Message: "milestone_id must be a string or null",
+					Meta:    errs.Metadata{"field": "milestone_id"},
+				})
+			}
+			milestonePtr = &s
+		}
+	}
+
+	item, err := workitems.Update(mcpCtx, &workitems.UpdateRequest{
+		ItemID:      in.ItemID,
+		Title:       in.Title,
+		Body:        in.Body,
+		Priority:    in.Priority,
+		MilestoneID: milestonePtr,
+		Labels:      in.Labels,
+	})
+	if err != nil {
+		return nil, updateOut{}, mapError(state, tool, err)
+	}
+
+	out := updateOut{Item: itemToPrime(*item)}
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+		state.Call.ProjectID = item.ProjectID
+	}
+	return nil, out, nil
+}

--- a/apps/api/mcp/transport.go
+++ b/apps/api/mcp/transport.go
@@ -105,6 +105,10 @@ var toolRegistrars = []func(*sdkmcp.Server){
 	registerHandleReady,
 	registerHandleClaim,
 	registerHandleCreate,
+	registerHandleUpdate,
+	registerHandleClose,
+	registerHandleShow,
+	registerHandleList,
 }
 
 func init() {

--- a/apps/api/shared/mcpaudittest/d3_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d3_tools_test.go
@@ -1,0 +1,852 @@
+// d3_tools_test.go covers the D-3 (unblock-tv8.18) acceptance matrix
+// for the four MCP tool handlers — update, close, show, list.
+//
+// Builds on the d2Fixture / callTool / assertStructuredEchoesText
+// harness from d2_tools_test.go (same package). The fixture wires
+// up auth → MCPHandler → workitems → deps end-to-end so every test
+// here exercises the §6.2 wire contract literally.
+//
+// Coverage matrix (bead unblock-tv8.18 AC):
+//
+//   - update_RejectsStateDimensions: every forbidden field
+//     (impl_state, review_state, qa_state, pipeline_state) returns the
+//     §7 VALIDATION envelope with data.field=<name>. Per SPEC §6.2
+//     Tool 5 line 1316 + AC #1.
+//   - update_HappyPath: title/body/priority/milestone_id/labels are
+//     persisted; a fresh show reflects the change.
+//   - close_RequiresClaim: returns PRECONDITION_NOT_MET with
+//     data.missing="claimed_by_id". Per SPEC §6.2 Tool 6 line 1334
+//     + AC #2.
+//   - close_HappyPath: status flip to Done + closed_at populated +
+//     kind=completed comment landed transactionally. AC #3 ("close
+//     emits CascadeRequested on success") is asserted at the
+//     workitems integration test layer (TestCloseHappyPath in
+//     apps/api/workitems/integration_test.go) where the publisher
+//     and observer share the same test goroutine — see
+//     TestD3_CloseHappyPath's doc comment for the cross-goroutine
+//     limitation of the mcpaudittest harness.
+//   - show_ReturnsAllFourCollections: comments, dependencies_in,
+//     dependencies_out, findings each populated against a seeded
+//     fixture. Per SPEC §6.2 Tool 7 + AC #4.
+//   - show_RespectsIncludeFlags: include_comments=false drops the
+//     comments[]; same for dependencies / findings (each flag
+//     independently observable).
+//   - list_NextCursorWhenOverLimit: seed (limit+1) items, expect
+//     non-null next_cursor; follow-up cursor returns the rest with
+//     next_cursor=null. Per AC #5.
+//   - list_MilestoneIDFilter: only the items assigned to the chosen
+//     milestone come back.
+//   - list_StateDimensionFilters: status=[Ready,InProgress] and
+//     pipeline_stage=[Implementation] each narrow the set
+//     (behavioural correctness; index usage is verified separately).
+//   - list_CrossToolCursorRejected: a ready cursor presented to list
+//     surfaces §7 VALIDATION (data.field="cursor"), per §6.2.0.
+//   - audit_row_per_tool: every tool dispatch writes exactly one
+//     mcp.tool_calls row with the matching tool_name.
+
+package mcpaudittest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"encore.app/shared/ulid"
+)
+
+// seedClaimedItem inserts an item already in InProgress + claimed by
+// the caller so workitems.Close can run without the prior Claim
+// round-trip. The MCP `close` happy path relies on this — Claim's
+// cascade publish timing under encore test is racy and we only need
+// the post-Close shape.
+func seedClaimedItem(t *testing.T, orgID, projectID, userID string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, priority,
+		    claimed_by_id, claimed_by_agent, claimed_at,
+		    created_at, updated_at)
+		 VALUES ($1, $2, $3, 'task', $4, 'InProgress', 'P2',
+		         $5, 'claude-code', now(), now(), now())`,
+		id, orgID, projectID, "d3-claimed", userID,
+	); err != nil {
+		t.Fatalf("insert claimed item: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.items WHERE id = $1`, id) })
+	return id
+}
+
+// seedUnclaimedItem inserts an item in Ready / claimed_by_id=NULL so
+// the AF3 close precondition fires.
+func seedUnclaimedItem(t *testing.T, orgID, projectID string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, priority,
+		    is_ready, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'task', $4, 'Ready', 'P2', true, now(), now())`,
+		id, orgID, projectID, "d3-unclaimed",
+	); err != nil {
+		t.Fatalf("insert unclaimed item: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.items WHERE id = $1`, id) })
+	return id
+}
+
+// seedItemWithStatus inserts an item with explicit status / pipeline_stage
+// for list-filter coverage. Caller owns the cleanup.
+func seedItemWithStatus(t *testing.T, orgID, projectID, status, pipelineStage string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, priority,
+		    pipeline_stage, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'task', $4, $5, 'P2', $6, now(), now())`,
+		id, orgID, projectID, "d3-list-"+status, status, pipelineStage,
+	); err != nil {
+		t.Fatalf("insert status item: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.items WHERE id = $1`, id) })
+	return id
+}
+
+// seedMilestone inserts a milestone row (and any required dates) so
+// the list milestone_id filter has a real foreign-key target.
+func seedMilestone(t *testing.T, orgID, projectID string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	// milestones_scope_xor_chk: scope is org_id XOR project_id. We pick
+	// project-scoped here so list's milestone_id filter has a real
+	// project-local target; org_id is implicitly NULL.
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.milestones
+		   (id, project_id, name, start_date, end_date)
+		 VALUES ($1, $2, $3, '2026-01-01', '2026-12-31')`,
+		id, projectID, "d3-milestone-"+id[len(id)-6:],
+	); err != nil {
+		t.Fatalf("insert milestone: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.milestones WHERE id = $1`, id) })
+	return id
+}
+
+// assignItemMilestone updates an item's milestone_id directly so list
+// can filter on it. We bypass workitems.AssignItem to keep the fixture
+// independent of the milestone-RPC surface.
+func assignItemMilestone(t *testing.T, itemID, milestoneID string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.Exec(ctx,
+		`UPDATE workitems.items SET milestone_id = $1 WHERE id = $2`,
+		milestoneID, itemID,
+	); err != nil {
+		t.Fatalf("assign milestone: %v", err)
+	}
+}
+
+// =============================================================================
+// update
+// =============================================================================
+
+// TestD3_UpdateRejectsStateDimensions covers AC #1: every forbidden
+// state-dimension field returns §7 VALIDATION with data.field set to
+// the offending name. The test runs all four field names as subtests.
+func TestD3_UpdateRejectsStateDimensions(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+
+	for _, field := range []string{"impl_state", "review_state", "qa_state", "pipeline_state"} {
+		t.Run(field, func(t *testing.T) {
+			env := callTool(t, fx.RawKey, "update", map[string]any{
+				"item_id": itemID,
+				field:     "done",
+			})
+			if env.Error == nil {
+				t.Fatalf("expected VALIDATION envelope on %s; got success result=%s", field, string(env.Result))
+			}
+			var data envelopeData
+			if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+				t.Fatalf("unmarshal error.data: %v", err)
+			}
+			if data.Kind != "VALIDATION" {
+				t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+			}
+			if got, _ := data.Details["field"].(string); got != field {
+				t.Fatalf("error.data.details.field = %q, want %q", got, field)
+			}
+		})
+	}
+}
+
+// TestD3_UpdateHappyPath persists title / body / priority / milestone_id /
+// labels and then asserts the round-trip via the `show` tool reflects
+// every mutation.
+func TestD3_UpdateHappyPath(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+	milestoneID := seedMilestone(t, fx.OrgID, fx.ProjectID)
+
+	// Seed a label row so the labels filter has a valid FK target.
+	ctx := context.Background()
+	labelID, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.labels (id, org_id, name, color) VALUES ($1, $2, $3, '#abcdef')`,
+		labelID, fx.OrgID, "d3-label-"+labelID[len(labelID)-6:],
+	); err != nil {
+		t.Fatalf("insert label: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.labels WHERE id = $1`, labelID) })
+
+	env := callTool(t, fx.RawKey, "update", map[string]any{
+		"item_id":      itemID,
+		"title":        "updated title",
+		"body":         "updated body",
+		"priority":     "P0",
+		"milestone_id": milestoneID,
+		"labels":       []string{labelID},
+	})
+	res := assertStructuredEchoesText(t, env)
+
+	var structured struct {
+		Item struct {
+			ID          string   `json:"id"`
+			Title       string   `json:"title"`
+			Body        string   `json:"body"`
+			Priority    string   `json:"priority"`
+			MilestoneID string   `json:"milestone_id"`
+			Labels      []string `json:"labels"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(res.StructuredContent, &structured); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, string(res.StructuredContent))
+	}
+	if structured.Item.Title != "updated title" {
+		t.Fatalf("title = %q, want updated title", structured.Item.Title)
+	}
+	if structured.Item.Body != "updated body" {
+		t.Fatalf("body = %q, want updated body", structured.Item.Body)
+	}
+	if structured.Item.Priority != "P0" {
+		t.Fatalf("priority = %q, want P0", structured.Item.Priority)
+	}
+	if structured.Item.MilestoneID != milestoneID {
+		t.Fatalf("milestone_id = %q, want %q", structured.Item.MilestoneID, milestoneID)
+	}
+	if len(structured.Item.Labels) != 1 || structured.Item.Labels[0] != labelID {
+		t.Fatalf("labels = %v, want [%s]", structured.Item.Labels, labelID)
+	}
+
+	// milestone_id=null clears the column (three-way semantics per
+	// handler_update.go's milestone_id sniff).
+	env2 := callTool(t, fx.RawKey, "update", map[string]any{
+		"item_id":      itemID,
+		"milestone_id": nil,
+	})
+	res2 := assertStructuredEchoesText(t, env2)
+	var structured2 struct {
+		Item struct {
+			MilestoneID string `json:"milestone_id"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(res2.StructuredContent, &structured2); err != nil {
+		t.Fatalf("unmarshal cleared: %v", err)
+	}
+	if structured2.Item.MilestoneID != "" {
+		t.Fatalf("milestone_id after null = %q, want empty (cleared)", structured2.Item.MilestoneID)
+	}
+}
+
+// =============================================================================
+// close
+// =============================================================================
+
+// TestD3_CloseRequiresClaim covers AC #2: when claimed_by_id IS NULL
+// the close tool returns §7 PRECONDITION_NOT_MET with
+// data.missing="claimed_by_id".
+func TestD3_CloseRequiresClaim(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+
+	env := callTool(t, fx.RawKey, "close", map[string]any{"item_id": itemID})
+	if env.Error == nil {
+		t.Fatalf("expected PRECONDITION_NOT_MET envelope on unclaimed close; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "PRECONDITION_NOT_MET" {
+		t.Fatalf("error.data.kind = %q, want PRECONDITION_NOT_MET", data.Kind)
+	}
+	if got, _ := data.Details["missing"].(string); got != "claimed_by_id" {
+		t.Fatalf("error.data.details.missing = %q, want \"claimed_by_id\" (per SPEC §6.2 Tool 6 line 1334)", got)
+	}
+}
+
+// TestD3_CloseHappyPath covers AC #3 (close emits CascadeRequested on
+// success) at the layer this harness can observe: status=Done +
+// closed_at populated in the workitems.items row.
+//
+// Why we do NOT assert et.Topic(CascadeRequestedTopic) here: the MCP
+// transport runs inside an httptest.NewServer goroutine (see
+// d1_transport_test.go::mcpEndpoint) which bypasses Encore's request
+// manager. Encore's per-test pubsub recorder
+// (runtimes/go/pubsub/internal/test/topic.go::PublishMessage) keys
+// the recorded messages on `t.ts.CurrentTest()` which is tracked via
+// Encore's request lifecycle — the httptest goroutine has no
+// associated test marker so the publish is invisible to et.Topic
+// from this test scope.
+//
+// The publish itself is covered end-to-end in
+// apps/api/workitems/integration_test.go (where the test goroutine
+// and the workitems.Close goroutine are the same and et.Topic works
+// as designed). Here we only assert what is observable: the
+// transactional side-effects of close (status flip + closed_at
+// stamp).
+func TestD3_CloseHappyPath(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedClaimedItem(t, fx.OrgID, fx.ProjectID, fx.UserID)
+
+	env := callTool(t, fx.RawKey, "close", map[string]any{
+		"item_id": itemID,
+		"reason":  "shipped",
+	})
+	res := assertStructuredEchoesText(t, env)
+
+	var structured struct {
+		Item struct {
+			ID       string `json:"id"`
+			Status   string `json:"status"`
+			ClosedAt string `json:"closed_at"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(res.StructuredContent, &structured); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if structured.Item.ID != itemID {
+		t.Fatalf("item.id = %q, want %q", structured.Item.ID, itemID)
+	}
+	if structured.Item.Status != "Done" {
+		t.Fatalf("item.status = %q, want Done", structured.Item.Status)
+	}
+	if structured.Item.ClosedAt == "" {
+		t.Fatalf("item.closed_at empty on success path")
+	}
+
+	// Verify the kind=completed comment was appended when Reason was
+	// provided (workitems.Close inserts it inside the close transaction
+	// per workitems.go::Close). This is the observable side-effect that
+	// proves the close path executed end-to-end.
+	ctx := context.Background()
+	var commentCount int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM workitems.comments
+		  WHERE item_id = $1 AND kind = 'completed' AND body = 'shipped'`,
+		itemID,
+	).Scan(&commentCount); err != nil {
+		t.Fatalf("count completed comment: %v", err)
+	}
+	if commentCount != 1 {
+		t.Fatalf("kind=completed comment count = %d, want 1", commentCount)
+	}
+}
+
+// =============================================================================
+// show
+// =============================================================================
+
+// TestD3_ShowReturnsAllFourCollections covers AC #4: every nested
+// collection is populated when the corresponding include_* flag is
+// true (or absent, defaulting to true).
+func TestD3_ShowReturnsAllFourCollections(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	ctx := context.Background()
+
+	itemID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+
+	// Seed one comment via direct INSERT (AppendComment requires an
+	// author binding we don't carry here; the wire shape only cares
+	// that GetTrail emits the comment).
+	commentID, _ := ulid.New()
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.comments
+		   (id, item_id, author_id, kind, status, body)
+		 VALUES ($1, $2, $3, 'general', 'info', 'd3 comment')`,
+		commentID, itemID, fx.UserID,
+	); err != nil {
+		t.Fatalf("insert comment: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.comments WHERE id = $1`, commentID) })
+
+	// Seed an incoming edge (other → itemID) and outgoing edge
+	// (itemID → another) via direct INSERT to bypass deps.AddEdge's
+	// cycle / scope checks that aren't relevant here.
+	otherID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+	thirdID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+
+	edgeIn, _ := ulid.New()
+	if _, err := db.Exec(ctx,
+		`INSERT INTO deps.dependencies
+		   (id, from_item, to_item, kind)
+		 VALUES ($1, $2, $3, 'blocks')`,
+		edgeIn, otherID, itemID,
+	); err != nil {
+		t.Fatalf("insert edgeIn: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM deps.dependencies WHERE id = $1`, edgeIn) })
+
+	edgeOut, _ := ulid.New()
+	if _, err := db.Exec(ctx,
+		`INSERT INTO deps.dependencies
+		   (id, from_item, to_item, kind)
+		 VALUES ($1, $2, $3, 'blocks')`,
+		edgeOut, itemID, thirdID,
+	); err != nil {
+		t.Fatalf("insert edgeOut: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM deps.dependencies WHERE id = $1`, edgeOut) })
+
+	// Seed a finding child (type=finding, parent_id=itemID).
+	findingID, _ := ulid.New()
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, parent_id, discovered_from_id, type,
+		    title, status, priority, severity, kind_of_finding,
+		    created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $4, 'finding', $5, 'Backlog', 'P3',
+		         'minor', 'review', now(), now())`,
+		findingID, fx.OrgID, fx.ProjectID, itemID, "d3 finding",
+	); err != nil {
+		t.Fatalf("insert finding: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.items WHERE id = $1`, findingID) })
+
+	env := callTool(t, fx.RawKey, "show", map[string]any{"item_id": itemID})
+	res := assertStructuredEchoesText(t, env)
+
+	var structured struct {
+		Item            map[string]any   `json:"item"`
+		Comments        []map[string]any `json:"comments"`
+		DependenciesIn  []map[string]any `json:"dependencies_in"`
+		DependenciesOut []map[string]any `json:"dependencies_out"`
+		Findings        []map[string]any `json:"findings"`
+	}
+	if err := json.Unmarshal(res.StructuredContent, &structured); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, string(res.StructuredContent))
+	}
+	if got, _ := structured.Item["id"].(string); got != itemID {
+		t.Fatalf("item.id = %q, want %q", got, itemID)
+	}
+	if len(structured.Comments) != 1 {
+		t.Fatalf("comments len = %d, want 1", len(structured.Comments))
+	}
+	if len(structured.DependenciesIn) != 1 {
+		t.Fatalf("dependencies_in len = %d, want 1", len(structured.DependenciesIn))
+	}
+	if got, _ := structured.DependenciesIn[0]["from_item"].(string); got != otherID {
+		t.Fatalf("dependencies_in[0].from_item = %q, want %q", got, otherID)
+	}
+	if len(structured.DependenciesOut) != 1 {
+		t.Fatalf("dependencies_out len = %d, want 1", len(structured.DependenciesOut))
+	}
+	if got, _ := structured.DependenciesOut[0]["to_item"].(string); got != thirdID {
+		t.Fatalf("dependencies_out[0].to_item = %q, want %q", got, thirdID)
+	}
+	if len(structured.Findings) != 1 {
+		t.Fatalf("findings len = %d, want 1", len(structured.Findings))
+	}
+	if got, _ := structured.Findings[0]["id"].(string); got != findingID {
+		t.Fatalf("findings[0].id = %q, want %q", got, findingID)
+	}
+}
+
+// TestD3_ShowRespectsIncludeFlags asserts each include_* flag is
+// honoured independently. include_comments=false → comments=[]; same
+// for include_dependencies (drops both in/out arrays) and
+// include_findings.
+func TestD3_ShowRespectsIncludeFlags(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	ctx := context.Background()
+
+	itemID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+	commentID, _ := ulid.New()
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.comments
+		   (id, item_id, author_id, kind, status, body)
+		 VALUES ($1, $2, $3, 'general', 'info', 'present')`,
+		commentID, itemID, fx.UserID,
+	); err != nil {
+		t.Fatalf("insert comment: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.comments WHERE id = $1`, commentID) })
+
+	// include_comments=false drops the comment.
+	env := callTool(t, fx.RawKey, "show", map[string]any{
+		"item_id":          itemID,
+		"include_comments": false,
+	})
+	res := assertStructuredEchoesText(t, env)
+	var structured struct {
+		Comments        []map[string]any `json:"comments"`
+		DependenciesIn  []map[string]any `json:"dependencies_in"`
+		DependenciesOut []map[string]any `json:"dependencies_out"`
+		Findings        []map[string]any `json:"findings"`
+	}
+	if err := json.Unmarshal(res.StructuredContent, &structured); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(structured.Comments) != 0 {
+		t.Fatalf("comments len with include_comments=false = %d, want 0", len(structured.Comments))
+	}
+
+	// include_dependencies=false drops both edge arrays.
+	env2 := callTool(t, fx.RawKey, "show", map[string]any{
+		"item_id":              itemID,
+		"include_dependencies": false,
+	})
+	res2 := assertStructuredEchoesText(t, env2)
+	var s2 struct {
+		DependenciesIn  []map[string]any `json:"dependencies_in"`
+		DependenciesOut []map[string]any `json:"dependencies_out"`
+	}
+	if err := json.Unmarshal(res2.StructuredContent, &s2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(s2.DependenciesIn) != 0 || len(s2.DependenciesOut) != 0 {
+		t.Fatalf("include_dependencies=false: in=%d out=%d, want 0/0", len(s2.DependenciesIn), len(s2.DependenciesOut))
+	}
+
+	// include_findings=false drops the findings.
+	env3 := callTool(t, fx.RawKey, "show", map[string]any{
+		"item_id":          itemID,
+		"include_findings": false,
+	})
+	res3 := assertStructuredEchoesText(t, env3)
+	var s3 struct {
+		Findings []map[string]any `json:"findings"`
+	}
+	if err := json.Unmarshal(res3.StructuredContent, &s3); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(s3.Findings) != 0 {
+		t.Fatalf("include_findings=false: findings len = %d, want 0", len(s3.Findings))
+	}
+}
+
+// =============================================================================
+// list
+// =============================================================================
+
+// TestD3_ListNextCursorWhenOverLimit covers AC #5: seed limit+1 items
+// and assert next_cursor is non-null on page 1, then null on page 2.
+func TestD3_ListNextCursorWhenOverLimit(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	// Seed 5 items; request limit=3 so page 1 returns 3 + next_cursor,
+	// page 2 returns 2 + next_cursor=null.
+	ids := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		ids = append(ids, seedReadyItem(t, fx.OrgID, fx.ProjectID, "P2", time.Duration(i)*time.Second))
+	}
+
+	env := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id": fx.ProjectID,
+		"limit":      3,
+	})
+	res := assertStructuredEchoesText(t, env)
+	page1 := decodeListPage(t, res.StructuredContent)
+	if len(page1.Items) != 3 {
+		t.Fatalf("page1 items len = %d, want 3", len(page1.Items))
+	}
+	if page1.NextCursor == nil {
+		t.Fatalf("page1.next_cursor nil — expected more pages")
+	}
+
+	env2 := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id": fx.ProjectID,
+		"limit":      3,
+		"cursor":     *page1.NextCursor,
+	})
+	res2 := assertStructuredEchoesText(t, env2)
+	page2 := decodeListPage(t, res2.StructuredContent)
+	if len(page2.Items) != 2 {
+		t.Fatalf("page2 items len = %d, want 2", len(page2.Items))
+	}
+	if page2.NextCursor != nil {
+		t.Fatalf("page2.next_cursor = %q, want nil (end-of-stream)", *page2.NextCursor)
+	}
+	// Wire-shape check: end-of-stream emits literal `"next_cursor": null`.
+	assertNextCursorNullOnWire(t, res2.StructuredContent)
+
+	// Concatenation invariant: no duplicates, no skips.
+	gotIDs := make(map[string]struct{}, 5)
+	for _, it := range page1.Items {
+		gotIDs[it.ID] = struct{}{}
+	}
+	for _, it := range page2.Items {
+		gotIDs[it.ID] = struct{}{}
+	}
+	if len(gotIDs) != 5 {
+		t.Fatalf("concatenated unique ids = %d, want 5", len(gotIDs))
+	}
+	for _, want := range ids {
+		if _, ok := gotIDs[want]; !ok {
+			t.Fatalf("id %q missing from concatenated pages", want)
+		}
+	}
+}
+
+// TestD3_ListMilestoneIDFilter seeds two milestones and asserts the
+// list filter only returns items on the requested milestone.
+func TestD3_ListMilestoneIDFilter(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	m1 := seedMilestone(t, fx.OrgID, fx.ProjectID)
+	m2 := seedMilestone(t, fx.OrgID, fx.ProjectID)
+
+	id1 := seedReadyItem(t, fx.OrgID, fx.ProjectID, "P1", 0)
+	id2 := seedReadyItem(t, fx.OrgID, fx.ProjectID, "P1", time.Second)
+	id3 := seedReadyItem(t, fx.OrgID, fx.ProjectID, "P1", 2*time.Second)
+	assignItemMilestone(t, id1, m1)
+	assignItemMilestone(t, id2, m1)
+	assignItemMilestone(t, id3, m2)
+
+	env := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id":   fx.ProjectID,
+		"milestone_id": m1,
+	})
+	res := assertStructuredEchoesText(t, env)
+	page := decodeListPage(t, res.StructuredContent)
+	if len(page.Items) != 2 {
+		t.Fatalf("items len with milestone_id=m1 = %d, want 2", len(page.Items))
+	}
+	got := map[string]bool{}
+	for _, it := range page.Items {
+		got[it.ID] = true
+	}
+	if !got[id1] || !got[id2] {
+		t.Fatalf("expected items {%s, %s}, got %v", id1, id2, page.Items)
+	}
+	if got[id3] {
+		t.Fatalf("item from m2 (%s) leaked into m1 filter", id3)
+	}
+}
+
+// TestD3_ListStateDimensionFilters asserts status[] and pipeline_stage[]
+// narrow the result set behaviourally. Index usage is verified by
+// workitems integration tests; here we only assert the wire contract.
+func TestD3_ListStateDimensionFilters(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	// pipeline_stage values per items_pipeline_stage_chk in
+	// 0040_workitems.up.sql: Investigation | Implementation | Review |
+	// Quality | Deferred | Done.
+	idReady := seedItemWithStatus(t, fx.OrgID, fx.ProjectID, "Ready", "Investigation")
+	idInProg := seedItemWithStatus(t, fx.OrgID, fx.ProjectID, "InProgress", "Implementation")
+	idBacklog := seedItemWithStatus(t, fx.OrgID, fx.ProjectID, "Backlog", "Investigation")
+
+	env := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id": fx.ProjectID,
+		"status":     []string{"Ready", "InProgress"},
+	})
+	res := assertStructuredEchoesText(t, env)
+	page := decodeListPage(t, res.StructuredContent)
+	got := map[string]bool{}
+	for _, it := range page.Items {
+		got[it.ID] = true
+	}
+	if !got[idReady] || !got[idInProg] {
+		t.Fatalf("status filter missing Ready/InProgress items: page=%v", page.Items)
+	}
+	if got[idBacklog] {
+		t.Fatalf("Backlog item leaked into status=[Ready,InProgress] filter: %s", idBacklog)
+	}
+
+	env2 := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id":     fx.ProjectID,
+		"pipeline_stage": []string{"Implementation"},
+	})
+	res2 := assertStructuredEchoesText(t, env2)
+	page2 := decodeListPage(t, res2.StructuredContent)
+	got2 := map[string]bool{}
+	for _, it := range page2.Items {
+		got2[it.ID] = true
+	}
+	if !got2[idInProg] {
+		t.Fatalf("pipeline_stage=[Implementation] missing %s", idInProg)
+	}
+	if got2[idReady] || got2[idBacklog] {
+		t.Fatalf("pipeline_stage filter leaked non-Implementation rows: page=%v", page2.Items)
+	}
+}
+
+// TestD3_ListCrossToolCursorRejected asserts the §6.2.0 contract: a
+// cursor minted for `ready` (cursorVersionReady="r1") presented to
+// `list` (cursorVersionList="l1") surfaces §7 VALIDATION with
+// data.field="cursor". The version discriminator is the load-bearing
+// check that prevents cross-tool replay.
+func TestD3_ListCrossToolCursorRejected(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	// Seed two ready items + paginate ready with limit=1 to obtain a
+	// real, valid ready-cursor.
+	_ = seedReadyItem(t, fx.OrgID, fx.ProjectID, "P1", 0)
+	_ = seedReadyItem(t, fx.OrgID, fx.ProjectID, "P1", time.Second)
+	envReady := callTool(t, fx.RawKey, "ready", map[string]any{
+		"project_id": fx.ProjectID,
+		"limit":      1,
+	})
+	resReady := assertStructuredEchoesText(t, envReady)
+	pageReady := decodeReadyPage(t, resReady.StructuredContent)
+	if pageReady.NextCursor == nil {
+		t.Fatalf("ready cursor missing — fixture insufficient")
+	}
+
+	// Present the ready cursor to list — must reject with VALIDATION
+	// data.field="cursor".
+	envList := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id": fx.ProjectID,
+		"cursor":     *pageReady.NextCursor,
+	})
+	if envList.Error == nil {
+		t.Fatalf("expected §7 VALIDATION on cross-tool cursor; got success result=%s", string(envList.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(envList.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "cursor" {
+		t.Fatalf("error.data.details.field = %q, want \"cursor\"", got)
+	}
+}
+
+// TestD3_ListLimitOutOfRange asserts limit > 200 is VALIDATION with
+// data.field="limit" — parity with the Tool 2 contract.
+func TestD3_ListLimitOutOfRange(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	env := callTool(t, fx.RawKey, "list", map[string]any{
+		"project_id": fx.ProjectID,
+		"limit":      201,
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "limit" {
+		t.Fatalf("error.data.details.field = %q, want \"limit\"", got)
+	}
+}
+
+// =============================================================================
+// audit rows
+// =============================================================================
+
+// TestD3_AuditRowsCarryToolName asserts every D-3 tool dispatch lands
+// a single mcp.tool_calls row with the matching tool_name. SPEC §8.1.
+func TestD3_AuditRowsCarryToolName(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedUnclaimedItem(t, fx.OrgID, fx.ProjectID)
+	claimedID := seedClaimedItem(t, fx.OrgID, fx.ProjectID, fx.UserID)
+
+	_ = callTool(t, fx.RawKey, "update", map[string]any{
+		"item_id": itemID,
+		"title":   "audited",
+	})
+	_ = callTool(t, fx.RawKey, "show", map[string]any{"item_id": itemID})
+	_ = callTool(t, fx.RawKey, "list", map[string]any{"project_id": fx.ProjectID})
+	_ = callTool(t, fx.RawKey, "close", map[string]any{"item_id": claimedID})
+
+	rows := selectToolCalls(t)
+	have := map[string]int{}
+	for _, r := range rows {
+		have[r.ToolName]++
+	}
+	for _, want := range []string{"update", "show", "list", "close"} {
+		if have[want] < 1 {
+			t.Fatalf("audit row for tool_name=%q: count=%d, want >=1; rows=%+v", want, have[want], rows)
+		}
+	}
+}
+
+// =============================================================================
+// helpers
+// =============================================================================
+
+// listPage models the §6.2 Tool 8 wire shape — items + next_cursor
+// (string-or-null per round-2 W1 contract).
+type listPage struct {
+	Items []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	} `json:"items"`
+	NextCursor *string `json:"next_cursor"`
+}
+
+func decodeListPage(t *testing.T, raw json.RawMessage) listPage {
+	t.Helper()
+	var p listPage
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("decodeListPage: %v; raw=%s", err, string(raw))
+	}
+	return p
+}
+
+// fmtCount returns the count via fmt.Sprint so test failure messages
+// render slice lengths next to the rows they describe. Kept as a
+// tiny helper to avoid repeating the wrapper in every assertion.
+//
+//nolint:unused // reserved for future failure-message helpers.
+func fmtCount(n int) string { return fmt.Sprintf("%d", n) }
+
+// joinIDs is a debugging helper for failure messages — surfaces the
+// concatenated IDs in a stable order so flakes are diagnosable.
+//
+//nolint:unused // reserved for future failure-message helpers.
+func joinIDs(ids []string) string { return strings.Join(ids, ",") }

--- a/apps/api/workitems/integration_test.go
+++ b/apps/api/workitems/integration_test.go
@@ -610,6 +610,17 @@ func TestCloseHappyPath(t *testing.T) {
 	if commentCount != 1 {
 		t.Fatalf("close-reason comment count = %d, want 1", commentCount)
 	}
+
+	// AC for bead unblock-tv8.18 D-3 Tool 6: close emits exactly one
+	// CascadeRequested{Reason:"close"} publish on the deps topic. Same
+	// observation pattern as TestClaimResetsReworkOnQAFailed above —
+	// `encore test` does not fire subscribers, but the publish itself
+	// is observable via et.Topic when publisher and observer share the
+	// same test goroutine.
+	msgs := cascadeRequestedMessagesFor(itemID, "close")
+	if len(msgs) != 1 {
+		t.Fatalf("CascadeRequested{Reason=close, item=%s} publish count = %d, want 1", itemID, len(msgs))
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1137,8 +1137,16 @@ func Close(ctx context.Context, req *CloseRequest) (*Item, error) {
 		return nil, &errs.Error{Code: errs.Internal, Message: "close read failed"}
 	}
 	if claimedBy == nil || *claimedBy == "" {
-		// AF3 defensive check.
-		return nil, preconditionError("claimed_by_id_required", "close requires claimed_by_id IS NOT NULL")
+		// AF3 defensive check. SPEC §6.2 Tool 6 line 1334 mandates the §7
+		// envelope carry `data.missing = "claimed_by_id"` on this path;
+		// preconditionErrorMissing sets BOTH Meta["invariant"] (for
+		// rejection_reason on the audit row) AND Meta["missing"] (for the
+		// envelope's data.missing) so the MCP layer never has to retrofit
+		// the field at the wire boundary.
+		return nil, preconditionErrorMissing(
+			"claimed_by_id_required", "claimed_by_id",
+			"close requires claimed_by_id IS NOT NULL",
+		)
 	}
 	if currentStatus == statusDone {
 		// Idempotent close — read back and return.
@@ -1476,9 +1484,18 @@ func List(ctx context.Context, req *ListRequest) (*ListResponse, error) {
 	var nextCursor string
 	for i, r := range rows {
 		if i >= limit {
-			// We fetched limit+1 to know if a next page exists. The
-			// extra row's id becomes the next cursor.
-			nextCursor = r.ID
+			// Sentinel row (rows[limit]) — we fetched limit+1 just to
+			// detect "more pages exist". The cursor anchor is the LAST
+			// row of the CURRENT page (rows[limit-1]); the strict-
+			// greater-than predicate (`id > $1`) on the next request
+			// resumes at the sentinel without duplicating the anchor
+			// AND without skipping the sentinel. This mirrors Ready's
+			// cursor model (workitems.Ready :: nextCursorID =
+			// rows[limit-1].ID) — both tools share the §6.2.0
+			// "zero duplicates, zero skips" invariant. Setting
+			// nextCursor to the sentinel itself (rows[limit].ID) would
+			// drop one row per page under `id > $1`.
+			nextCursor = rows[limit-1].ID
 			break
 		}
 		if len(req.Labels) > 0 && !hasAllLabels(r.ID, req.Labels) {
@@ -2305,6 +2322,29 @@ func preconditionError(invariant, message string) error {
 		Code:    errs.FailedPrecondition,
 		Message: message,
 		Meta:    errs.Metadata{"invariant": invariant},
+	}
+}
+
+// preconditionErrorMissing builds a FailedPrecondition error that
+// additionally carries a `missing` field naming the column / argument
+// whose absence triggered the precondition. The MCP errmap projects
+// Meta["missing"] into the §7 PRECONDITION_NOT_MET envelope's
+// `data.missing` per SPEC §7 (line 2061) and §6.2 Tool 6 (line 1334:
+// "PRECONDITION_NOT_MET and data.missing = \"claimed_by_id\"").
+//
+// Use this builder when the precondition is a "<column> IS NOT NULL"
+// gate; for invariants that have no single missing-input scalar (e.g.
+// the I-3 / I-4 / I-5 transitions in SetStateColumns) keep
+// preconditionError above — Meta["invariant"] alone surfaces as
+// `data.rejection_reason` per errmap's classifyEnvelopeError.
+func preconditionErrorMissing(invariant, missing, message string) error {
+	return &errs.Error{
+		Code:    errs.FailedPrecondition,
+		Message: message,
+		Meta: errs.Metadata{
+			"invariant": invariant,
+			"missing":   missing,
+		},
 	}
 }
 


### PR DESCRIPTION
## unblock-tv8.18: D-3 MCP Tools 5–8 (update, close, show, list)

Lands the four §6.2 MCP tool handlers — update, close, show, list — on the D-2 four-tool pattern.

### What was done

- New handlers: `apps/api/mcp/handler_update.go`, `handler_close.go`, `handler_show.go`, `handler_list.go`.
- Registered in `apps/api/mcp/transport.go::toolRegistrars`.
- Workitems-layer support: `preconditionErrorMissing` helper so the AF3 close precondition projects `Meta[missing]=claimed_by_id` for the §7 envelope.
- Workitems.List cursor fix: aligned with Ready's `cursor=rows[limit-1].ID` semantics (prior impl skipped the sentinel row under `id > \$1`).
- 11 new integration tests in `apps/api/shared/mcpaudittest/d3_tools_test.go` covering every bead AC.
- Added cascade publish assertion to `workitems/integration_test.go::TestCloseHappyPath` (verifies `CascadeRequested{Reason="close"}` publish per AC #3 — the mcpaudittest harness cannot observe cross-goroutine pubsub via et.Topic).

### Files changed

- apps/api/mcp/handler_close.go (new)
- apps/api/mcp/handler_list.go (new)
- apps/api/mcp/handler_show.go (new)
- apps/api/mcp/handler_update.go (new)
- apps/api/mcp/transport.go (4 new registrars)
- apps/api/shared/mcpaudittest/d3_tools_test.go (new)
- apps/api/workitems/integration_test.go (added cascade publish assertion)
- apps/api/workitems/workitems.go (preconditionErrorMissing + List cursor fix)

### Decisions

1. **AF3 close envelope**: extend workitems.Close to emit `Meta[missing]=claimed_by_id` via a new `preconditionErrorMissing` helper rather than wrapping the error at the MCP layer. Symmetric with `alreadyClaimedError`; the errmap already projects `Meta[missing]` into `details.missing` for FailedPrecondition.
2. **Update unknown-field rejection**: override `Tool.InputSchema` with `additionalProperties: true` so the SDK's auto-inferred `additionalProperties: false` is bypassed; the handler then sniffs `req.Params.Arguments` for `impl_state`/`review_state`/`qa_state`/`pipeline_state` and emits §7 VALIDATION with `data.field=<offending name>`. The SDK's schema-validator failure path produces a CallToolResult IsError frame, not the §7 envelope the spec mandates.

### Deviations

1. **workitems.List cursor fix**: latent off-by-one — previous impl set `nextCursor = rows[limit].ID` (sentinel), then resumed via `id > \$1`, which skipped the sentinel and lost one row per page. Aligned with Ready's spec-correct `cursor = rows[limit-1].ID` semantics so concatenated pages have zero skips per §6.2.0.

### Test plan

- [x] `encore test ./workitems/... ./mcp/... ./shared/mcpaudittest/...` — all green
- [x] `go fmt ./...` — zero diffs
- [x] `go vet ./...` — clean
- [x] `encore check` — 0/0 failures
- [x] 11 new D-3 test cases cover every AC