### PR TITLE
tv8.56: provision Encore secrets across all env types

### DIFF
--- a/apps/api/auth/secrets.go
+++ b/apps/api/auth/secrets.go
@@ -16,9 +16,33 @@ package auth
 //	GITHUB_OAUTH_CLIENT_ID  ↔ GitHubOAuthClientID
 //	GITHUB_OAUTH_CLIENT_SECRET ↔ GitHubOAuthClientSecret
 //
-// Production values are seeded by Olive via `encore secret set --type prod`
-// before deploy; staging via `--type dev`. Local emulator reads the four
-// fields from `apps/api/.secrets.local.cue` (gitignored).
+// Provisioning policy across Encore Cloud env types (per tv8.56):
+//
+//	--type prod   — real production values (Olive seeds before prod deploy).
+//	                MemoryDEK + APIKeyHMACSecret carry real long-lived
+//	                values; rotating either is a destructive operation
+//	                (invalidates issued API keys, paginated cursors, or
+//	                encrypted oauth_tokens rows). GitHubOAuth* must be
+//	                rotated to the real GitHub OAuth app credentials
+//	                before the prod OAuth flow is first exercised.
+//	--type dev    — staging values (Olive seeds before staging deploy).
+//	--type pr     — CI placeholder values. Required so Encore Cloud's
+//	                pre-deploy `encore test` step on PR / preview-env
+//	                builds boots without tripping the mcp/transport.go
+//	                fail-fast on APIKeyHMACSecret. Internal mapping:
+//	                ephemeral → preview (encoredev/encore set.go:179).
+//	--type local  — CI placeholder values. Provisioned defensively
+//	                because Encore Cloud does not document which env type
+//	                its pre-deploy CI test runner queries; covering all
+//	                four documented types eliminates the variable.
+//
+// Local emulator (`encore run`) reads the four fields from
+// `apps/api/.secrets.local.cue` (gitignored), which overlays on top of
+// whatever the platform returns for `--type dev`.
+//
+// All four secrets MUST be set across all four types before deploy. Missing
+// values surface as: APIKeyHMACSecret → boot panic (mcp/transport.go:114);
+// MemoryDEK, GitHubOAuth* → runtime panic when their code path fires.
 //
 //nolint:unused // referenced by RPC bodies starting in beads B-1..D-3.
 var secrets struct {


### PR DESCRIPTION
## unblock-tv8.56: Resolve Encore Cloud post-merge CI test secret resolution for mcp.init() panic

After PR merges to main, Encore Cloud's pre-deploy `encore test` step panicked at boot for every package that boots the mcp service (`deps`, `mcp`, `org`, `workitems`, `shared/mcpaudittest`, `shared/rbactest`) with:

```
panic: mcp: APIKeyHMACSecret is empty — provision via `encore secret set`
```

The fail-fast was introduced by D-2 (tv8.17) and guards §6.2.0 cursor signing + §4.1 API-key HMAC — it is correct. The fix is operational: provision the 4 declared secrets in `apps/api/auth/secrets.go` across all 4 Encore Cloud env types so whichever group the Cloud CI test runner queries on main-merge resolves successfully.

### What was done

Operationally (via `encore secret set`):

- `APIKeyHMACSecret`        `--type local,pr` (32-byte hex placeholder)
- `MemoryDEK`               `--type local,pr` (32-byte hex placeholder)
- `GitHubOAuthClientID`     `--type local,pr` (CI placeholder)
- `GitHubOAuthClientSecret` `--type local,pr` (CI placeholder)
- `GitHubOAuthClientID`     `--type prod` (prod placeholder — rotate before OAuth flow)
- `GitHubOAuthClientSecret` `--type prod` (prod placeholder — rotate before OAuth flow)

Production values for `APIKeyHMACSecret` + `MemoryDEK` NOT touched (rotation is destructive — invalidates issued API keys, paginated cursors, oauth_tokens encryption).

Post-fix `encore secret list` shows all 4 secrets ticked for Production / Development / Local / Preview.

In-repo: documented the provisioning policy in `apps/api/auth/secrets.go` doc comment, including failure modes per secret and the rotation constraints on production values.

### Files changed

- `apps/api/auth/secrets.go`

### Decisions

1. Defensive provisioning across all 4 env types rather than waiting to identify the exact type Cloud CI queries — verification cost (single live build log) exceeds the trivial cost of 8 extra secret-set operations.
2. Placeholder values for prod `GitHubOAuth*` — real GitHub OAuth app credentials live in the user's GitHub OAuth app dashboard and are out of scope for this CI-unblock task. The doc comment instructs the user to rotate before the prod OAuth flow is first exercised.

### Deviations

None — implemented as the investigation's recommended fix sequence.

### Verification

- `encore secret list` confirms all 4 secrets ticked across all 4 env types.
- `encore check` clean.
- `encore test ./mcp/... ./deps/... ./org/... ./workitems/... ./shared/mcpaudittest/... ./shared/rbactest/...` — all 6 previously failing packages PASS locally.
- `go vet ./...` clean.
- The real CI verification (acceptance criterion #3) happens on the main-merge build after this PR lands. A follow-up comment on tv8.56 will identify which env type Cloud CI actually resolves against, locking down the answer for future debugging (acceptance criterion #4).