### PR TITLE
unblock-tv8.60: widen D1 initialize client timeout to 30s (fix flaky cold-start race)

### DIFF
--- a/apps/api/shared/mcpaudittest/d1_transport_test.go
+++ b/apps/api/shared/mcpaudittest/d1_transport_test.go
@@ -73,6 +73,31 @@ const mcpInitializeBody = `{
 	}
 }`
 
+// mcpInitializeTimeout bounds the wall-clock budget for a single
+// MCP `initialize` round-trip in the D-1 suite. The 5s default that
+// peer auth-only tests use is too tight here: the initialize path
+// pays the full cold-start cost the first time it runs in the suite
+// — Docker Postgres warmup, migrations, seedOrg INSERT, the
+// auth.IssueAPIKey path (HMAC + INSERT into mcp.api_keys), the SDK
+// Connect() handshake, and the in-process Bearer hot path lookup.
+// On a CPU-throttled or contended host that easily exceeds 5s, which
+// surfaces as `read body: context deadline exceeded` at io.ReadAll
+// (the client cancels the request ctx, the deferred recordToolCall
+// then runs against the canceled ctx and emits a fire-and-forget
+// `recordToolCall: insert failed err="canceled: context canceled"`
+// log line — symptom, not cause).
+//
+// 30s is the spec-aligned headroom: SPEC §11.2 NFR-1 measures
+// latency on a warm local emulator, so the integration test that
+// includes the seed work is explicitly outside that budget. The
+// peer test `callTool` at d2_tools_test.go:199 uses 10s for a
+// session-resuming tools/call; the initialize variant runs first
+// and pays the higher cold-start cost, so it gets the wider margin.
+// If a future regression actually causes the server to hang, the
+// test still bounds the suite — it just gives the cold path room
+// to land first.
+const mcpInitializeTimeout = 30 * time.Second
+
 // mcpTestServer is a process-wide httptest.Server wrapping
 // mcp.ServeMCPForTest. Created lazily on first use so test packages
 // that exercise only the audit writer (TestRecordToolCallPersistsRow
@@ -167,7 +192,7 @@ func TestD1_POSTInitializeReturnsSessionID(t *testing.T) {
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 
-	resp := httpDo(t, req, 5*time.Second)
+	resp := httpDo(t, req, mcpInitializeTimeout)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -250,7 +275,10 @@ func TestD1_GETOpensSSEStream(t *testing.T) {
 	postReq.Header.Set("Accept", "application/json, text/event-stream")
 	postReq.Header.Set("Authorization", "Bearer "+rawKey)
 
-	postResp := httpDo(t, postReq, 5*time.Second)
+	// Use the same wide budget as the dedicated initialize test —
+	// this POST pays the same cold-start cost (seedOrg + IssueAPIKey
+	// + SDK Connect) and was a coupled flake source.
+	postResp := httpDo(t, postReq, mcpInitializeTimeout)
 	sessionID := postResp.Header.Get("Mcp-Session-Id")
 	postResp.Body.Close()
 	if sessionID == "" {


### PR DESCRIPTION
## unblock-tv8.60: Fix flaky TestD1_POSTInitializeReturnsSessionID cold-start race

The 5s `http.Client.Timeout` at `apps/api/shared/mcpaudittest/d1_transport_test.go:170` raced cold-start work (Docker Postgres warmup, migrations, `seedOrg`, `auth.IssueAPIKey`, SDK `Connect()` handshake) and surfaced as `read body: context deadline exceeded` with a cascading `recordToolCall: insert failed err=\"canceled: context canceled\"` log line. The audit log line is a symptom of the client cancelling the request ctx, not the cause.

### What was done
Replaced both initialize POST timeouts with a named constant `mcpInitializeTimeout = 30 * time.Second` and a block doc comment that captures the cold-start rationale and SPEC §11.2 NFR-1 alignment (NFR-1 measures latency on a warm local emulator; integration tests with seed work are outside that budget).

### Files changed
- `apps/api/shared/mcpaudittest/d1_transport_test.go`

### Decisions
None — followed Sherlock's investigation Approach verbatim (named constant + 30s + doc comment). Investigation explicitly forbade the two alternative options the bead originally listed:
- `Accept: application/json` only — violates SPEC §5.1 line 1103 and the SDK rejects it with 400.
- `StreamableHTTPOptions.JSONResponse = true` — wire-format change applied to all clients to fix a test.

### Deviations
None — implemented as the investigation prescribed.

### Tests
- `encore test ./shared/mcpaudittest/... -run TestD1 -count=3` — pass
- `encore test ./shared/mcpaudittest/... -run TestD1_POSTInitializeReturnsSessionID -count=5` — pass
- `encore test ./shared/mcpaudittest/... -count=1` (full package) — pass
- `go fmt` / `go vet` — clean