### PR TITLE
unblock-tv8.20: D-5 MCP tools add_dependency + remove_dependency

### DIFF
--- a/apps/api/mcp/handler_add_dependency.go
+++ b/apps/api/mcp/handler_add_dependency.go
@@ -1,0 +1,180 @@
+// handler_add_dependency.go owns the §6.2 Tool 11 (`add_dependency`)
+// handler — a thin wire+identity-bridge+errmap wrapper around the
+// private deps.AddEdge RPC.
+//
+// All business logic — cycle detection (per-project advisory lock +
+// depth-counter CTE per §6.5), cross-project rejection, inline
+// is_ready recompute on to_item, default kind='blocks' substitution,
+// and the post-commit CascadeRequested{Reason:"edge_added"} publish —
+// lives in deps.AddEdgeInTx / deps.AddEdge. This handler MUST NOT
+// duplicate any of it.
+//
+// project_id derivation at the boundary (orchestrator DECISION on
+// bead unblock-tv8.20, 2026-05-18 — DRIFT-2 resolved with option (a)):
+// the spec wording at §6.2 Tool 11 line 1496 says project_id is
+// "looked up in workitems.items at the start of the transaction",
+// while deps.AddEdge's request struct REQUIRES non-empty ProjectID at
+// the validation gate. To keep tv8.11's RPC contract stable, this
+// handler does an explicit workitems.Get(to_item_id) lookup, reads
+// the ProjectID from the returned Item, and forwards it into
+// deps.AddEdge. Cross-project rejection still fires inside
+// deps.AddEdge — its own (org_id, project_id) re-derivation from the
+// DB row remains the trust boundary; this handler only solves the
+// non-empty validation gate.
+//
+// Audit row convention (orchestrator INVESTIGATION 2026-05-18): the
+// handler stamps state.Call.ItemID = in.ToItemID (the blocked item is
+// the natural single-item handle — the to_item's is_ready is the only
+// flag mutated inline) and state.Call.ProjectID = resolved
+// project_id from the workitems.Get lookup.
+//
+// Default Kind: SPEC §6.2 Tool 11 line 1484 sets default kind='blocks'.
+// deps.AddEdgeInTx:192-195 substitutes 'blocks' when req.Kind is
+// empty. We pass empty strings through verbatim — the in-tx helper is
+// the single source of truth (round-2 review S1 finding, see
+// handler_create.go:91-98).
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 11 (lines
+// 1477-1521) + § 6.5 (cycle detection CTE) + § 6.3.0 (symmetric writer
+// model) + § 7 (error envelope).
+
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"encore.app/deps"
+	"encore.app/workitems"
+	"encore.dev/beta/errs"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type addDependencyIn struct {
+	FromItemID string `json:"from_item_id"`
+	ToItemID   string `json:"to_item_id"`
+	Kind       string `json:"kind,omitempty"`
+}
+
+// edgeWire mirrors deps.Edge on the JSON wire. RFC3339Nano timestamps
+// are the canonical MCP wire format (see itemToPrime, commentWire,
+// etc.). created_by may be empty when the caller identity is not
+// recorded; we keep the field with `omitempty` so the wire form is
+// minimal.
+type edgeWire struct {
+	ID        string `json:"id"`
+	FromItem  string `json:"from_item"`
+	ToItem    string `json:"to_item"`
+	Kind      string `json:"kind"`
+	CreatedAt string `json:"created_at"`
+	CreatedBy string `json:"created_by,omitempty"`
+}
+
+type addDependencyOut struct {
+	Edge edgeWire `json:"edge"`
+}
+
+// registerHandleAddDependency is invoked by transport.go's init — see
+// the toolRegistrars rationale there.
+func registerHandleAddDependency(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "add_dependency",
+		Description: "Add a dependency edge between two work items in the " +
+			"same project. Cycle-detected inline (per-project advisory " +
+			"lock + depth-counter CTE per §6.5). Cross-project edges are " +
+			"rejected with VALIDATION. kind defaults to \"blocks\". " +
+			"SPEC § 6.2 Tool 11.",
+	}, handleAddDependency)
+}
+
+func handleAddDependency(ctx context.Context, req *sdkmcp.CallToolRequest, in addDependencyIn) (*sdkmcp.CallToolResult, addDependencyOut, error) {
+	tool := "add_dependency"
+	state := bindTool(req, tool)
+
+	identity, ok := identityFromReq(req)
+	if !ok {
+		return nil, addDependencyOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, addDependencyOut{}, mapError(state, tool, err)
+	}
+
+	// Boundary validation: surface a clearer VALIDATION envelope than
+	// the deps-layer 'missing' message. Same pattern as
+	// handler_create.go:80-86 and handler_comment.go:101-107.
+	if in.FromItemID == "" {
+		return nil, addDependencyOut{}, mapError(state, tool, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "missing from_item_id",
+			Meta:    errs.Metadata{"field": "from_item_id"},
+		})
+	}
+	if in.ToItemID == "" {
+		return nil, addDependencyOut{}, mapError(state, tool, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "missing to_item_id",
+			Meta:    errs.Metadata{"field": "to_item_id"},
+		})
+	}
+
+	// Audit-row item handle: the blocked item is the natural single-
+	// item handle for the audit row (the to_item's is_ready is the
+	// only flag mutated inline by deps.AddEdge). Set BEFORE the
+	// deps call so a downstream failure still leaves the audit row
+	// pointing at the correct item.
+	if state != nil && state.Call != nil {
+		state.Call.ItemID = in.ToItemID
+	}
+
+	// project_id derivation per orchestrator DECISION 2026-05-18
+	// (DRIFT-2 option (a)). workitems.Get enforces the org-scope
+	// predicate via rbac.For and returns NOT_FOUND when the to_item
+	// does not exist or is outside the caller's org — same envelope
+	// the cross-project rejection inside deps.AddEdge would surface
+	// for inter-org slips. Empty ProjectID on the returned Item is
+	// rejected by deps.AddEdge with VALIDATION data.field="to_item_id"
+	// — we don't need a separate check here.
+	toItem, err := workitems.Get(mcpCtx, in.ToItemID)
+	if err != nil {
+		// workitems.Get returns NotFound with no Meta — adapt the
+		// envelope to NOT_FOUND data.kind="item" / id=to_item_id so
+		// the wire payload is self-describing.
+		if errsErr, ok := err.(*errs.Error); ok && errsErr.Code == errs.NotFound {
+			return nil, addDependencyOut{}, mapError(state, tool, &errs.Error{
+				Code:    errs.NotFound,
+				Message: "to_item not found",
+				Meta:    errs.Metadata{"kind": "item", "id": in.ToItemID, "field": "to_item_id"},
+			})
+		}
+		return nil, addDependencyOut{}, mapError(state, tool, err)
+	}
+	if state != nil && state.Call != nil {
+		state.Call.ProjectID = toItem.ProjectID
+	}
+
+	edge, err := deps.AddEdge(mcpCtx, &deps.AddEdgeRequest{
+		OrgID:     identity.OrgID,
+		ProjectID: toItem.ProjectID,
+		FromItem:  in.FromItemID,
+		ToItem:    in.ToItemID,
+		Kind:      in.Kind, // pass empty through; deps.AddEdgeInTx owns the "blocks" default.
+	})
+	if err != nil {
+		return nil, addDependencyOut{}, mapError(state, tool, err)
+	}
+
+	out := addDependencyOut{Edge: edgeWire{
+		ID:        edge.ID,
+		FromItem:  edge.FromItem,
+		ToItem:    edge.ToItem,
+		Kind:      edge.Kind,
+		CreatedAt: edge.CreatedAt.UTC().Format(time.RFC3339Nano),
+		CreatedBy: edge.CreatedBy,
+	}}
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+	}
+	return nil, out, nil
+}

--- a/apps/api/mcp/handler_remove_dependency.go
+++ b/apps/api/mcp/handler_remove_dependency.go
@@ -1,0 +1,116 @@
+// handler_remove_dependency.go owns the §6.2 Tool 12
+// (`remove_dependency`) handler — a thin wire+identity-bridge+errmap
+// wrapper around the private deps.RemoveEdge RPC.
+//
+// All business logic — the EdgeID XOR (FromItem+ToItem+Kind) selection
+// gate, edge_id minting BEFORE BEGIN so the inline audit row and the
+// post-commit publish share the SAME event_id (round-6 tension #1),
+// inline DELETE + inline is_ready recompute on the direct to_item
+// (Regime A — single-hop), inline deps.cascade_events row with
+// kind='edge_removed', and the post-commit
+// CascadeRequested{Reason:"edge_removed"} publish reusing the same
+// event_id so the subscriber's ON CONFLICT (event_id,
+// triggered_by_item_id) DO NOTHING collapses to no-op — all live in
+// deps.RemoveEdge. This handler MUST NOT duplicate any of it.
+//
+// Wire shape selection: SPEC §6.2 Tool 12 line 1528 declares the
+// arguments as edge_id OR (from_item_id + to_item_id + kind). The
+// JSON-schema description carries the XOR rule; runtime enforcement
+// is owned by deps.RemoveEdge (deps/deps.go:443-457) which surfaces
+// the XOR violation as InvalidArgument → §7 VALIDATION via errmap.
+// The handler accepts both shapes verbatim and forwards.
+//
+// Audit row convention: the handler stamps state.Call.ItemID =
+// resp.ToItemID after the deps call succeeds (deps.RemoveEdgeResponse
+// carries the resolved to_item identifier regardless of which
+// selection shape the caller used). The to_item is the natural
+// single-item handle — it is the only item whose is_ready flag is
+// mutated inline. state.Call.ProjectID stays unset because
+// RemoveEdgeResponse does not surface project_id and a pre-lookup
+// would add a round-trip for a value already carried in the inline
+// audit row.
+//
+// to_item_now_ready is the SINGLE-HOP view per SPEC §6.2 Tool 12
+// lines 1578-1586: the boolean reflects ONLY the direct to_item's
+// post-DELETE is_ready value. Transitive pipeline_stage recompute
+// on downstream items is eventually consistent (driven by the
+// post-commit publish — Regime B).
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 12 (lines
+// 1523-1604) + § 6.3.0 (symmetric writer model) + § 6.5 (cycle CTE
+// shared with AddEdge — reused by recomputeReady) + § 7 (error
+// envelope).
+
+package mcp
+
+import (
+	"context"
+
+	"encore.app/deps"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type removeDependencyIn struct {
+	EdgeID     string `json:"edge_id,omitempty"`
+	FromItemID string `json:"from_item_id,omitempty"`
+	ToItemID   string `json:"to_item_id,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+}
+
+type removeDependencyOut struct {
+	Removed        bool `json:"removed"`
+	ToItemNowReady bool `json:"to_item_now_ready"`
+}
+
+// registerHandleRemoveDependency is invoked by transport.go's init —
+// see the toolRegistrars rationale there.
+func registerHandleRemoveDependency(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "remove_dependency",
+		Description: "Delete a dependency edge. Accepts edge_id OR the " +
+			"composite (from_item_id, to_item_id, kind) — exactly one " +
+			"shape. Recomputes is_ready inline for the direct to_item " +
+			"(single-hop) and publishes CascadeRequested{Reason:" +
+			"\"edge_removed\"} post-commit for the multi-hop " +
+			"pipeline_stage recompute. SPEC § 6.2 Tool 12.",
+	}, handleRemoveDependency)
+}
+
+func handleRemoveDependency(ctx context.Context, req *sdkmcp.CallToolRequest, in removeDependencyIn) (*sdkmcp.CallToolResult, removeDependencyOut, error) {
+	tool := "remove_dependency"
+	state := bindTool(req, tool)
+
+	if _, ok := identityFromReq(req); !ok {
+		return nil, removeDependencyOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, removeDependencyOut{}, mapError(state, tool, err)
+	}
+
+	// XOR selection enforcement is owned by deps.RemoveEdge
+	// (deps/deps.go:443-457) — passing both / neither surfaces
+	// InvalidArgument with no Meta.field, which errmap maps to §7
+	// VALIDATION with details.reason carrying the deps-layer message.
+	// We forward the inputs verbatim.
+	resp, err := deps.RemoveEdge(mcpCtx, &deps.RemoveEdgeRequest{
+		EdgeID:   in.EdgeID,
+		FromItem: in.FromItemID,
+		ToItem:   in.ToItemID,
+		Kind:     in.Kind,
+	})
+	if err != nil {
+		return nil, removeDependencyOut{}, mapError(state, tool, err)
+	}
+
+	out := removeDependencyOut{
+		Removed:        resp.Removed,
+		ToItemNowReady: resp.ToItemNowReady,
+	}
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+		state.Call.ItemID = resp.ToItemID
+	}
+	return nil, out, nil
+}

--- a/apps/api/mcp/transport.go
+++ b/apps/api/mcp/transport.go
@@ -111,6 +111,8 @@ var toolRegistrars = []func(*sdkmcp.Server){
 	registerHandleList,
 	registerHandleSearch,
 	registerHandleComment,
+	registerHandleAddDependency,
+	registerHandleRemoveDependency,
 }
 
 func init() {

--- a/apps/api/shared/mcpaudittest/d5_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d5_tools_test.go
@@ -569,6 +569,10 @@ func TestD5_RemoveDependencyWritesCascadeEvent(t *testing.T) {
 		t.Fatalf("cascade_events kind='edge_removed' rows for to=%s: count = %d, want 1", to, count)
 	}
 	// Clean up the audit row so cross-test isolation is preserved.
+	// A single DELETE is race-free even if the cascade subscriber fires
+	// concurrently: its INSERT carries ON CONFLICT (event_id, triggered_by_item_id)
+	// DO NOTHING, so any subscriber-side re-insert of the same audit row
+	// collapses to a no-op against the unique key.
 	t.Cleanup(func() {
 		_, _ = db.Exec(ctx,
 			`DELETE FROM deps.cascade_events WHERE triggered_by_item_id = $1 AND kind = 'edge_removed'`,

--- a/apps/api/shared/mcpaudittest/d5_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d5_tools_test.go
@@ -1,0 +1,626 @@
+// d5_tools_test.go covers the D-5 (unblock-tv8.20) acceptance matrix
+// for MCP tools 11 (`add_dependency`) and 12 (`remove_dependency`).
+//
+// Reuses the d2Fixture / callTool / assertStructuredEchoesText
+// harness — same package, full Bearer-auth roundtrip through
+// MCPHandler. Each test seeds an isolated org+user+project+api_key
+// tuple so the §7 envelopes reach the wire with real Identity
+// propagation through withIdentity.
+//
+// Coverage matrix (bead unblock-tv8.20 AC, rewritten per orchestrator
+// DECISION 2026-05-18):
+//
+//   - addDependency_HappyPath: from_item + to_item in same project
+//     succeed; structuredContent.edge populated with id/from_item/
+//     to_item/kind/created_at; deps.dependencies row landed.
+//   - addDependency_DefaultKindBlocks: omitting kind defaults to
+//     "blocks" (substitution owned by deps.AddEdgeInTx, NOT this
+//     handler — the test asserts the boundary contract).
+//   - addDependency_CycleDetected (AC #1): seed a→b→c via direct SQL
+//     then add_dependency(c→a); response is §7 CYCLE_DETECTED with
+//     data.cycle_path populated as a typed []string (the
+//     deps.AddEdgeInTx dual-encoding of cycle_path/cycle_path_list
+//     survives the gob round-trip).
+//   - addDependency_CrossProjectRejected (AC #2): two projects in the
+//     same org, one item in each; add_dependency rejected with
+//     VALIDATION data.field="to_item_id".
+//   - addDependency_MissingFromItemID / MissingToItemID: empty
+//     boundary inputs surface §7 VALIDATION with the matching
+//     data.field — clearer than the deps-layer 'missing' message.
+//   - removeDependency_HappyPath_ByEdgeID: delete by edge_id;
+//     structuredContent.{removed,to_item_now_ready} populated; row
+//     gone from deps.dependencies.
+//   - removeDependency_HappyPath_ByComposite: delete by (from, to,
+//     kind); same shape as above.
+//   - removeDependency_ToItemNowReady (AC #3): seed item_a (Done,
+//     so the closure CTE counts it as a satisfied blocker) blocking
+//     item_b (Backlog, is_ready=false because there is also a second
+//     unsatisfied blocker); call remove_dependency on the OTHER edge;
+//     structuredContent.to_item_now_ready=true and item_b.is_ready=
+//     true in workitems.items by direct SQL read.
+//   - removeDependency_WritesCascadeEvent (AC #5): exactly one
+//     deps.cascade_events row with kind='edge_removed' lands after
+//     a successful remove_dependency call (the inline INSERT inside
+//     deps.RemoveEdge writes it; the subscriber's attempted INSERT
+//     collapses via ON CONFLICT — exactly-one).
+//   - d5_AuditRowsCarryToolName: add_dependency + remove_dependency
+//     dispatches each write one mcp.tool_calls row with the matching
+//     tool_name.
+
+package mcpaudittest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"encore.app/shared/ulid"
+)
+
+// =============================================================================
+// helpers
+// =============================================================================
+
+// seedItemForEdge inserts a Backlog/unclaimed task with explicit
+// is_ready value. Edge tests need both ready and non-ready endpoints
+// so the recomputeReady result is observable post-remove. Caller owns
+// the cleanup via t.Cleanup chained from the helper.
+func seedItemForEdge(t *testing.T, orgID, projectID, status string, isReady bool) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, priority,
+		    is_ready, created_at, updated_at)
+		 VALUES ($1, $2, $3, 'task', $4, $5, 'P2', $6, now(), now())`,
+		id, orgID, projectID, "d5-edge-"+id[len(id)-6:], status, isReady,
+	); err != nil {
+		t.Fatalf("insert edge item: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.items WHERE id = $1`, id) })
+	return id
+}
+
+// seedItemForEdgeInProject is identical to seedItemForEdge but takes
+// an explicit projectID so the cross-project test can place items in
+// a sibling project.
+func seedItemForEdgeInProject(t *testing.T, orgID, projectID string) string {
+	t.Helper()
+	return seedItemForEdge(t, orgID, projectID, "Backlog", false)
+}
+
+// seedSiblingProject inserts a second project in the same org so the
+// cross-project rejection path has a real foreign key target. Cleanup
+// runs at test end via t.Cleanup.
+func seedSiblingProject(t *testing.T, orgID string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO org.projects (id, org_id, slug, name) VALUES ($1, $2, $3, $4)`,
+		id, orgID, "p-"+id[len(id)-8:], "d5 sibling project",
+	); err != nil {
+		t.Fatalf("insert sibling project: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM org.projects WHERE id = $1`, id) })
+	return id
+}
+
+// seedEdgeDirect inserts a deps.dependencies row directly via SQL —
+// bypasses deps.AddEdge so the cycle test can pre-seed a chain
+// without firing the publisher path under encore test (et.Topic is
+// invisible from this harness anyway, but the direct insert is
+// simpler and equivalent for read-side fixtures). Caller owns the
+// cleanup.
+func seedEdgeDirect(t *testing.T, fromItem, toItem, kind string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid edge: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO deps.dependencies (id, from_item, to_item, kind)
+		 VALUES ($1, $2, $3, $4)`,
+		id, fromItem, toItem, kind,
+	); err != nil {
+		t.Fatalf("insert edge: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM deps.dependencies WHERE id = $1`, id) })
+	return id
+}
+
+// edgeWireOut models the §6.2 Tool 11 wire shape — the
+// structuredContent JSON object carrying { "edge": Edge }.
+type edgeWireOut struct {
+	Edge struct {
+		ID        string `json:"id"`
+		FromItem  string `json:"from_item"`
+		ToItem    string `json:"to_item"`
+		Kind      string `json:"kind"`
+		CreatedAt string `json:"created_at"`
+		CreatedBy string `json:"created_by,omitempty"`
+	} `json:"edge"`
+}
+
+func decodeEdgeOut(t *testing.T, raw json.RawMessage) edgeWireOut {
+	t.Helper()
+	var out edgeWireOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decodeEdgeOut: %v; raw=%s", err, string(raw))
+	}
+	return out
+}
+
+// removeWireOut models the §6.2 Tool 12 wire shape —
+// { "removed": bool, "to_item_now_ready": bool }.
+type removeWireOut struct {
+	Removed        bool `json:"removed"`
+	ToItemNowReady bool `json:"to_item_now_ready"`
+}
+
+func decodeRemoveOut(t *testing.T, raw json.RawMessage) removeWireOut {
+	t.Helper()
+	var out removeWireOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decodeRemoveOut: %v; raw=%s", err, string(raw))
+	}
+	return out
+}
+
+// =============================================================================
+// add_dependency
+// =============================================================================
+
+// TestD5_AddDependencyHappyPath asserts the §6.2 Tool 11 happy path:
+// from_item + to_item in same project, kind="blocks"; response carries
+// the structured Edge; deps.dependencies row landed.
+func TestD5_AddDependencyHappyPath(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	env := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": from,
+		"to_item_id":   to,
+		"kind":         "blocks",
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeEdgeOut(t, res.StructuredContent)
+
+	if got.Edge.ID == "" {
+		t.Fatalf("edge.id empty")
+	}
+	if got.Edge.FromItem != from {
+		t.Fatalf("edge.from_item = %q, want %q", got.Edge.FromItem, from)
+	}
+	if got.Edge.ToItem != to {
+		t.Fatalf("edge.to_item = %q, want %q", got.Edge.ToItem, to)
+	}
+	if got.Edge.Kind != "blocks" {
+		t.Fatalf("edge.kind = %q, want blocks", got.Edge.Kind)
+	}
+	if got.Edge.CreatedAt == "" {
+		t.Fatalf("edge.created_at empty")
+	}
+
+	// DB read-back: row persisted.
+	ctx := context.Background()
+	var dbID string
+	if err := db.QueryRow(ctx, `SELECT id FROM deps.dependencies WHERE id = $1`, got.Edge.ID).Scan(&dbID); err != nil {
+		t.Fatalf("edge not persisted: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM deps.dependencies WHERE id = $1`, got.Edge.ID) })
+}
+
+// TestD5_AddDependencyDefaultKindBlocks asserts that omitting the
+// optional kind argument substitutes "blocks" per SPEC §6.2 Tool 11
+// line 1484. The substitution is owned by deps.AddEdgeInTx
+// (deps/deps.go:192-195), NOT the MCP handler — the handler passes
+// empty strings through verbatim. This test pins the boundary
+// contract: the wire-observable kind on the returned Edge is "blocks"
+// when the input omits the field.
+func TestD5_AddDependencyDefaultKindBlocks(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	env := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": from,
+		"to_item_id":   to,
+		// kind deliberately omitted
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeEdgeOut(t, res.StructuredContent)
+	if got.Edge.Kind != "blocks" {
+		t.Fatalf("default kind: edge.kind = %q, want blocks", got.Edge.Kind)
+	}
+	ctx := context.Background()
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM deps.dependencies WHERE id = $1`, got.Edge.ID) })
+}
+
+// TestD5_AddDependencyCycleDetected covers AC #1: forming a cycle
+// surfaces §7 CYCLE_DETECTED with data.cycle_path populated as a
+// typed []string. Seed chain a→b→c via direct SQL (the publisher path
+// is invisible to this harness anyway) and then call add_dependency
+// (c→a) which closes the cycle.
+//
+// The dual-encoding of cycle_path / cycle_path_list at the deps
+// layer (deps/deps.go:329-330) survives the gob round-trip across the
+// //encore:api boundary; errmap (errmap.go:227-231) prefers the typed
+// slice. We assert the JSON wire form carries a non-empty cycle_path
+// array.
+func TestD5_AddDependencyCycleDetected(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	a := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	b := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	c := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	// Pre-seed a→b and b→c via direct SQL so the chain exists for the
+	// cycle CTE to discover when we attempt to close it with c→a.
+	_ = seedEdgeDirect(t, a, b, "blocks")
+	_ = seedEdgeDirect(t, b, c, "blocks")
+
+	env := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": c,
+		"to_item_id":   a,
+		"kind":         "blocks",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected CYCLE_DETECTED; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "CYCLE_DETECTED" {
+		t.Fatalf("error.data.kind = %q, want CYCLE_DETECTED", data.Kind)
+	}
+	// cycle_path is a typed []string on the wire (errmap projects the
+	// dual-encoded Meta into a JSON array). json.Unmarshal lands it as
+	// []interface{}; assert at least one element so the path is real.
+	rawPath, ok := data.Details["cycle_path"]
+	if !ok {
+		t.Fatalf("error.data.details.cycle_path missing; details=%+v", data.Details)
+	}
+	pathSlice, ok := rawPath.([]interface{})
+	if !ok {
+		t.Fatalf("cycle_path type = %T, want []interface{} (JSON array); raw=%+v", rawPath, rawPath)
+	}
+	if len(pathSlice) == 0 {
+		t.Fatalf("cycle_path is empty; want at least one element")
+	}
+	// Sanity: from and to surface on the envelope per errmap.go:215-220.
+	if got, _ := data.Details["from"].(string); got != c {
+		t.Fatalf("error.data.details.from = %q, want %q", got, c)
+	}
+	if got, _ := data.Details["to"].(string); got != a {
+		t.Fatalf("error.data.details.to = %q, want %q", got, a)
+	}
+}
+
+// TestD5_AddDependencyCrossProjectRejected covers AC #2: from_item and
+// to_item in DIFFERENT projects in the same org are rejected with §7
+// VALIDATION data.field="to_item_id". The rejection lives in
+// deps.AddEdge (deps/deps.go:258-272) which sets Meta.field=
+// "to_item_id"; errmap projects it to the §7 envelope without changes.
+func TestD5_AddDependencyCrossProjectRejected(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	otherProject := seedSiblingProject(t, fx.OrgID)
+
+	fromInP1 := seedItemForEdgeInProject(t, fx.OrgID, fx.ProjectID)
+	toInP2 := seedItemForEdgeInProject(t, fx.OrgID, otherProject)
+
+	env := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": fromInP1,
+		"to_item_id":   toInP2,
+		"kind":         "blocks",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION on cross-project edge; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "to_item_id" {
+		t.Fatalf("error.data.details.field = %q, want \"to_item_id\"", got)
+	}
+}
+
+// TestD5_AddDependencyMissingFromItemID asserts the MCP-boundary
+// guard: empty from_item_id surfaces §7 VALIDATION with the matching
+// data.field. The handler's own pre-check is clearer than the
+// deps-layer 'missing' message (the deps layer would still reject,
+// but the MCP-level message is intentional per handler_create.go:80-86
+// pattern).
+//
+// Defense-in-depth: an EMPTY field (present but zero string) bypasses
+// the SDK's required-field check — the handler's guard is what makes
+// the error envelope precise.
+func TestD5_AddDependencyMissingFromItemID(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	env := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": "",
+		"to_item_id":   to,
+		"kind":         "blocks",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION on empty from_item_id; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "from_item_id" {
+		t.Fatalf("error.data.details.field = %q, want \"from_item_id\"", got)
+	}
+}
+
+// TestD5_AddDependencyMissingToItemID: symmetric guard for the
+// to_item_id field.
+func TestD5_AddDependencyMissingToItemID(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	env := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": from,
+		"to_item_id":   "",
+		"kind":         "blocks",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION on empty to_item_id; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "to_item_id" {
+		t.Fatalf("error.data.details.field = %q, want \"to_item_id\"", got)
+	}
+}
+
+// =============================================================================
+// remove_dependency
+// =============================================================================
+
+// TestD5_RemoveDependencyHappyPathByEdgeID exercises the §6.2 Tool 12
+// selection-by-edge_id path. Seed an edge via direct SQL (decoupled
+// from the publisher path), call remove_dependency with edge_id, and
+// assert structuredContent + DB read-back.
+func TestD5_RemoveDependencyHappyPathByEdgeID(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Done", true)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	edgeID := seedEdgeDirect(t, from, to, "blocks")
+
+	env := callTool(t, fx.RawKey, "remove_dependency", map[string]any{
+		"edge_id": edgeID,
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeRemoveOut(t, res.StructuredContent)
+
+	if !got.Removed {
+		t.Fatalf("removed = false, want true")
+	}
+
+	// DB read-back: edge is gone.
+	ctx := context.Background()
+	var count int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM deps.dependencies WHERE id = $1`, edgeID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count edges: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("edge still present after remove: count = %d, want 0", count)
+	}
+}
+
+// TestD5_RemoveDependencyHappyPathByComposite exercises the §6.2
+// Tool 12 selection-by-(from,to,kind) path. Equivalent to the
+// edge_id path but the input shape differs.
+func TestD5_RemoveDependencyHappyPathByComposite(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Done", true)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	_ = seedEdgeDirect(t, from, to, "blocks")
+
+	env := callTool(t, fx.RawKey, "remove_dependency", map[string]any{
+		"from_item_id": from,
+		"to_item_id":   to,
+		"kind":         "blocks",
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeRemoveOut(t, res.StructuredContent)
+	if !got.Removed {
+		t.Fatalf("removed = false, want true")
+	}
+
+	ctx := context.Background()
+	var count int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM deps.dependencies
+		 WHERE from_item = $1 AND to_item = $2 AND kind = 'blocks'`,
+		from, to,
+	).Scan(&count); err != nil {
+		t.Fatalf("count edges: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("edge still present after composite remove: count = %d, want 0", count)
+	}
+}
+
+// TestD5_RemoveDependencyToItemNowReady covers AC #3: the inline
+// is_ready recompute on the direct to_item flips correctly when the
+// removed edge was the LAST unsatisfied blocker.
+//
+// Fixture: item_a (Done, satisfied blocker) and item_blocker
+// (Backlog, unsatisfied blocker) both block item_b (Backlog,
+// is_ready=false). Removing the item_blocker → item_b edge leaves
+// only the satisfied a → b edge — item_b's is_ready flips to true.
+// to_item_now_ready in structuredContent reflects the single-hop
+// view per SPEC §6.2 Tool 12 lines 1578-1586.
+func TestD5_RemoveDependencyToItemNowReady(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	ctx := context.Background()
+
+	itemA := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Done", true)
+	itemBlocker := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	itemB := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	// Both A and blocker block B; A is Done (counts as satisfied),
+	// blocker is not (so B is_ready stays false).
+	_ = seedEdgeDirect(t, itemA, itemB, "blocks")
+	blockerEdge := seedEdgeDirect(t, itemBlocker, itemB, "blocks")
+
+	env := callTool(t, fx.RawKey, "remove_dependency", map[string]any{
+		"edge_id": blockerEdge,
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeRemoveOut(t, res.StructuredContent)
+	if !got.Removed {
+		t.Fatalf("removed = false, want true")
+	}
+	if !got.ToItemNowReady {
+		t.Fatalf("to_item_now_ready = false, want true (only satisfied blocker remains)")
+	}
+
+	// Direct SQL read-back: item_b.is_ready = true.
+	var isReady bool
+	if err := db.QueryRow(ctx,
+		`SELECT is_ready FROM workitems.items WHERE id = $1`, itemB,
+	).Scan(&isReady); err != nil {
+		t.Fatalf("query is_ready: %v", err)
+	}
+	if !isReady {
+		t.Fatalf("workitems.items[%s].is_ready = false, want true after Regime-A recompute", itemB)
+	}
+}
+
+// TestD5_RemoveDependencyWritesCascadeEvent covers AC #5: exactly one
+// deps.cascade_events row with kind='edge_removed' lands per logical
+// remove_dependency call. The inline INSERT inside deps.RemoveEdge
+// writes it (round-6 tension #1); the subscriber's attempted INSERT
+// collapses via ON CONFLICT (event_id, triggered_by_item_id) DO
+// NOTHING — exactly-one is the invariant.
+//
+// We assert on the directly-observable side-effect: read the
+// cascade_events table by triggered_by_item_id AFTER the call and
+// count rows with kind='edge_removed'. The subscriber path is
+// invisible from this harness (httptest goroutine — see
+// d3_tools_test.go:319-326 comment), so we are observing only the
+// inline insert; the no-op subscriber collapse would not add a row
+// anyway.
+func TestD5_RemoveDependencyWritesCascadeEvent(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	ctx := context.Background()
+
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Done", true)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	edgeID := seedEdgeDirect(t, from, to, "blocks")
+
+	env := callTool(t, fx.RawKey, "remove_dependency", map[string]any{
+		"edge_id": edgeID,
+	})
+	res := assertStructuredEchoesText(t, env)
+	_ = decodeRemoveOut(t, res.StructuredContent)
+
+	var count int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM deps.cascade_events
+		  WHERE triggered_by_item_id = $1 AND kind = 'edge_removed'`,
+		to,
+	).Scan(&count); err != nil {
+		t.Fatalf("count cascade_events: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("cascade_events kind='edge_removed' rows for to=%s: count = %d, want 1", to, count)
+	}
+	// Clean up the audit row so cross-test isolation is preserved.
+	t.Cleanup(func() {
+		_, _ = db.Exec(ctx,
+			`DELETE FROM deps.cascade_events WHERE triggered_by_item_id = $1 AND kind = 'edge_removed'`,
+			to,
+		)
+	})
+}
+
+// =============================================================================
+// audit rows
+// =============================================================================
+
+// TestD5_AuditRowsCarryToolName: each add_dependency + remove_dependency
+// dispatch writes one mcp.tool_calls row with the matching tool_name.
+// SPEC §8.1 — completes the audit coverage matrix alongside D-2, D-3,
+// and D-4.
+func TestD5_AuditRowsCarryToolName(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+
+	from := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+	to := seedItemForEdge(t, fx.OrgID, fx.ProjectID, "Backlog", false)
+
+	envAdd := callTool(t, fx.RawKey, "add_dependency", map[string]any{
+		"from_item_id": from,
+		"to_item_id":   to,
+		"kind":         "blocks",
+	})
+	res := assertStructuredEchoesText(t, envAdd)
+	addOut := decodeEdgeOut(t, res.StructuredContent)
+	ctx := context.Background()
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM deps.dependencies WHERE id = $1`, addOut.Edge.ID) })
+
+	_ = callTool(t, fx.RawKey, "remove_dependency", map[string]any{
+		"edge_id": addOut.Edge.ID,
+	})
+	// Clean the cascade_events row written by RemoveEdge.
+	t.Cleanup(func() {
+		_, _ = db.Exec(ctx,
+			`DELETE FROM deps.cascade_events WHERE triggered_by_item_id = $1 AND kind = 'edge_removed'`,
+			to,
+		)
+	})
+
+	rows := selectToolCalls(t)
+	have := map[string]int{}
+	for _, r := range rows {
+		have[r.ToolName]++
+	}
+	for _, want := range []string{"add_dependency", "remove_dependency"} {
+		if have[want] < 1 {
+			t.Fatalf("audit row for tool_name=%q: count=%d, want >=1; rows=%+v", want, have[want], rows)
+		}
+	}
+}


### PR DESCRIPTION
## unblock-tv8.20: D-5 MCP Tools 11–12 (add_dependency, remove_dependency)

Implement §6.2 Tools 11–12 as thin wire+identity-bridge+errmap wrappers around the existing `deps.AddEdge` / `deps.RemoveEdge` private RPCs. All business logic (cycle detection, cross-project rejection, inline `is_ready` recompute, audit row, post-commit `CascadeRequested` publish) stays in the deps layer per round-6 §6.3.0.

### What was done
- Created `handler_add_dependency.go` — derives `project_id` at the boundary via `workitems.Get(to_item_id)` (orchestrator DECISION 2026-05-18 DRIFT-2 option a) and forwards to `deps.AddEdge`.
- Created `handler_remove_dependency.go` — accepts `edge_id` XOR `(from_item_id, to_item_id, kind)` and forwards to `deps.RemoveEdge`. The inline audit row + post-commit publish reusing the same `event_id` (round-6 tension #1) are owned by the deps layer.
- Registered both handlers in `transport.go`'s `toolRegistrars`.
- Added `d5_tools_test.go` (10 tests) covering the full AC matrix.

### Files changed
- `apps/api/mcp/handler_add_dependency.go` (new)
- `apps/api/mcp/handler_remove_dependency.go` (new)
- `apps/api/mcp/transport.go` (modified — two registrar entries appended)
- `apps/api/shared/mcpaudittest/d5_tools_test.go` (new)

### Decisions
None — followed orchestrator DECISION 2026-05-18 verbatim (DRIFT-1 spec alignment, DRIFT-2 option a).

### Deviations
None — implemented as spec.

### AC coverage
- AC #1 (CYCLE_DETECTED with `cycle_path`) → `TestD5_AddDependencyCycleDetected`
- AC #2 (cross-project VALIDATION `field=to_item_id`) → `TestD5_AddDependencyCrossProjectRejected`
- AC #3 (inline `to_item_now_ready`) → `TestD5_RemoveDependencyToItemNowReady`
- AC #4 (post-commit publish reusing `event_id`) → covered by deps layer (tv8.11); MCP handler is a pass-through.
- AC #5 (exactly-one `cascade_events` row) → `TestD5_RemoveDependencyWritesCascadeEvent`

### Gates
`go fmt`, `go vet`, `encore test ./mcp/... ./deps/... ./shared/mcpaudittest/...`, and `encore check` all green.