### PR TITLE
unblock-tv8.21: D-6 MCP tools set_state + get_state

### DIFF
--- a/apps/api/mcp/errmap.go
+++ b/apps/api/mcp/errmap.go
@@ -69,8 +69,18 @@ func mapError(state *requestState, tool string, err error) error {
 				// Spec §8.1: rejection_reason carries the canonical
 				// name of the failed precondition. Pull it from the
 				// details map (set by classifyEnvelopeError for the
-				// PRECONDITION path).
+				// PRECONDITION path). Preference order:
+				//   1. `missing` — column/argument absence cases (Close
+				//      with claimed_by_id IS NULL, etc).
+				//   2. `invariant` — set_state I-1..I-5 cases (added in
+				//      bead unblock-tv8.21 alongside the envelope
+				//      `data.invariant` surface).
+				//   3. `rejection_reason` — legacy mirror, kept as a
+				//      fallback for any future precondition that
+				//      surfaces only this key.
 				if v, ok := envErr.details["missing"].(string); ok && v != "" {
+					call.RejectionReason = v
+				} else if v, ok := envErr.details["invariant"].(string); ok && v != "" {
 					call.RejectionReason = v
 				} else if v, ok := envErr.details["rejection_reason"].(string); ok && v != "" {
 					call.RejectionReason = v
@@ -235,7 +245,15 @@ func classifyEnvelopeError(err error) envelopeError {
 		if v, ok := e.Meta["missing"].(string); ok && v != "" {
 			details["missing"] = v
 		}
+		// SPEC §6.2 Tool 13 line 1645-1646 + bead unblock-tv8.21 AC: surface
+		// the canonical invariant name as `data.invariant` (kebab-case) for
+		// machine-readability. The legacy `rejection_reason` mirror is
+		// preserved so existing clients (and the per-call audit-row
+		// RejectionReason population above) see the same value at both
+		// keys — semantically equivalent in P01, but `invariant` is the
+		// machine-targeted field per the spec/bead contract.
 		if v, ok := e.Meta["invariant"].(string); ok && v != "" {
+			details["invariant"] = v
 			details["rejection_reason"] = v
 		}
 		if v, ok := e.Meta["rejection_reason"].(string); ok && v != "" {

--- a/apps/api/mcp/handler_get_state.go
+++ b/apps/api/mcp/handler_get_state.go
@@ -1,0 +1,150 @@
+// handler_get_state.go owns the §6.2 Tool 14 (`get_state`) handler —
+// the read-side complement to set_state. Returns every state
+// dimension materialised on the item (impl_state, review_state,
+// qa_state, pipeline_state, pipeline_stage, is_ready, claimed_by_id,
+// claimed_at) plus the per-kind `recent_kinds` aggregate from
+// workitems.comments (one row per distinct kind, holding the most
+// recent (status, comment_id, created_at) for that kind).
+//
+// Delegation: 100% to workitems.GetState (added in bead
+// unblock-tv8.21 alongside this handler). No inline SQL — preserves
+// the symmetric delegation pattern shared by every other D-2..D-5
+// handler (orchestrator DECISION 2026-05-18 on bead unblock-tv8.21).
+//
+// Read-side org gate: workitems.GetState uses rbac.For for the item
+// lookup, so a cross-org item_id surfaces as §7 NOT_FOUND at the
+// wire (mapError projects errs.NotFound → envelopeKindNotFound). The
+// recent_kinds query is scoped to the resolved item_id; cross-org
+// leakage is impossible because the item lookup gate runs first.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 14 (lines
+// 1727-1754) + § 4.4 (workitems.GetState) + § 7 (error envelope).
+
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"encore.app/workitems"
+	"encore.dev/beta/errs"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type getStateIn struct {
+	ItemID string `json:"item_id"`
+}
+
+// getStateRecentKind mirrors SPEC §6.2 Tool 14 lines 1745-1750: one
+// row per distinct comment kind on the item with the most recent
+// status, comment_id, created_at for that kind.
+type getStateRecentKind struct {
+	Kind      string `json:"kind"`
+	Status    string `json:"status"`
+	CommentID string `json:"comment_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+// getStateOut mirrors SPEC §6.2 Tool 14 lines 1735-1751. Every state
+// dimension is serialised verbatim (no omitempty on the four state
+// columns + pipeline_stage + is_ready — they are always present per
+// the schema defaults). claimed_by_id and claimed_at are omitempty so
+// an unclaimed item produces a compact wire response.
+type getStateOut struct {
+	ImplState     string               `json:"impl_state"`
+	ReviewState   string               `json:"review_state"`
+	QAState       string               `json:"qa_state"`
+	PipelineState string               `json:"pipeline_state"`
+	PipelineStage string               `json:"pipeline_stage,omitempty"`
+	IsReady       bool                 `json:"is_ready"`
+	ClaimedByID   string               `json:"claimed_by_id,omitempty"`
+	ClaimedAt     string               `json:"claimed_at,omitempty"`
+	RecentKinds   []getStateRecentKind `json:"recent_kinds"`
+}
+
+// registerHandleGetState is invoked by transport.go's init — see the
+// toolRegistrars rationale there.
+func registerHandleGetState(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "get_state",
+		Description: "Read the four state dimensions + materialised " +
+			"pipeline_stage + is_ready + claim columns + the per-kind " +
+			"recent_kinds aggregate from workitems.comments (one row per " +
+			"distinct kind, most recent first). SPEC § 6.2 Tool 14.",
+	}, handleGetState)
+}
+
+func handleGetState(ctx context.Context, req *sdkmcp.CallToolRequest, in getStateIn) (*sdkmcp.CallToolResult, getStateOut, error) {
+	tool := "get_state"
+	state := bindTool(req, tool)
+
+	if _, ok := identityFromReq(req); !ok {
+		return nil, getStateOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, getStateOut{}, mapError(state, tool, err)
+	}
+
+	if in.ItemID == "" {
+		return nil, getStateOut{}, mapError(state, tool, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "missing item_id",
+			Meta:    errs.Metadata{"field": "item_id"},
+		})
+	}
+	if state != nil && state.Call != nil {
+		state.Call.ItemID = in.ItemID
+	}
+
+	resp, err := workitems.GetState(mcpCtx, &workitems.GetStateRequest{ItemID: in.ItemID})
+	if err != nil {
+		return nil, getStateOut{}, mapError(state, tool, err)
+	}
+
+	out := getStateOut{
+		ImplState:     resp.ImplState,
+		ReviewState:   resp.ReviewState,
+		QAState:       resp.QAState,
+		PipelineState: resp.PipelineState,
+		PipelineStage: resp.PipelineStage,
+		IsReady:       resp.IsReady,
+		ClaimedByID:   resp.ClaimedByID,
+		RecentKinds:   recentKindsToWire(resp.RecentKinds),
+	}
+	if resp.ClaimedAt != nil {
+		out.ClaimedAt = resp.ClaimedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+		// ProjectID is not directly exposed by GetState's narrow
+		// response (the spec contract is the state surface, not the
+		// full Item). Leaving it unset on the audit row matches the
+		// SetStateColumns RPC's own behaviour for tools that don't
+		// resolve project scope at the boundary — non-fatal for the
+		// audit dashboard (per-tool tool_name + item_id remain the
+		// load-bearing fields).
+	}
+	return nil, out, nil
+}
+
+// recentKindsToWire converts a workitems-layer []RecentKindRow into
+// the §6.2 Tool 14 wire shape. Always returns a non-nil slice so the
+// JSON encodes as `[]` rather than `null` for items with no comments.
+func recentKindsToWire(in []workitems.RecentKindRow) []getStateRecentKind {
+	if len(in) == 0 {
+		return []getStateRecentKind{}
+	}
+	out := make([]getStateRecentKind, 0, len(in))
+	for _, r := range in {
+		out = append(out, getStateRecentKind{
+			Kind:      r.Kind,
+			Status:    r.Status,
+			CommentID: r.CommentID,
+			CreatedAt: r.CreatedAt.UTC().Format(time.RFC3339Nano),
+		})
+	}
+	return out
+}

--- a/apps/api/mcp/handler_get_state.go
+++ b/apps/api/mcp/handler_get_state.go
@@ -46,19 +46,28 @@ type getStateRecentKind struct {
 }
 
 // getStateOut mirrors SPEC §6.2 Tool 14 lines 1735-1751. Every state
-// dimension is serialised verbatim (no omitempty on the four state
-// columns + pipeline_stage + is_ready — they are always present per
-// the schema defaults). claimed_by_id and claimed_at are omitempty so
-// an unclaimed item produces a compact wire response.
+// dimension is serialised verbatim — pipeline_stage, claimed_by_id,
+// and claimed_at are POINTER types (not value+omitempty) so the JSON
+// encoder emits explicit `null` rather than omitting the key when the
+// underlying item has no claim and/or no pipeline_stage. This honors
+// the spec's literal reading ("<ULID|null>", "<ts|null>", state
+// dimensions are always present in the response) and prevents clients
+// from confusing "key absent" with "field unset".
+//
+// project_id is exposed as a top-level field per the orchestrator's
+// post-review DECISION 2026-05-18: the state surface is contextually
+// scoped to a project; mirrors set_state's structuredContent.item.
+// project_id presence.
 type getStateOut struct {
+	ProjectID     string               `json:"project_id"`
 	ImplState     string               `json:"impl_state"`
 	ReviewState   string               `json:"review_state"`
 	QAState       string               `json:"qa_state"`
 	PipelineState string               `json:"pipeline_state"`
-	PipelineStage string               `json:"pipeline_stage,omitempty"`
+	PipelineStage *string              `json:"pipeline_stage"`
 	IsReady       bool                 `json:"is_ready"`
-	ClaimedByID   string               `json:"claimed_by_id,omitempty"`
-	ClaimedAt     string               `json:"claimed_at,omitempty"`
+	ClaimedByID   *string              `json:"claimed_by_id"`
+	ClaimedAt     *string              `json:"claimed_at"`
 	RecentKinds   []getStateRecentKind `json:"recent_kinds"`
 }
 
@@ -104,28 +113,39 @@ func handleGetState(ctx context.Context, req *sdkmcp.CallToolRequest, in getStat
 	}
 
 	out := getStateOut{
+		ProjectID:     resp.ProjectID,
 		ImplState:     resp.ImplState,
 		ReviewState:   resp.ReviewState,
 		QAState:       resp.QAState,
 		PipelineState: resp.PipelineState,
-		PipelineStage: resp.PipelineStage,
 		IsReady:       resp.IsReady,
-		ClaimedByID:   resp.ClaimedByID,
 		RecentKinds:   recentKindsToWire(resp.RecentKinds),
 	}
+	// pipeline_stage / claimed_by_id / claimed_at: pointer-encode as
+	// non-nil when the underlying value is present, nil (→ JSON `null`)
+	// otherwise. Honors the spec's "always-present, explicit null"
+	// shape per the orchestrator's post-review DECISION 2026-05-18.
+	if resp.PipelineStage != "" {
+		ps := resp.PipelineStage
+		out.PipelineStage = &ps
+	}
+	if resp.ClaimedByID != "" {
+		cb := resp.ClaimedByID
+		out.ClaimedByID = &cb
+	}
 	if resp.ClaimedAt != nil {
-		out.ClaimedAt = resp.ClaimedAt.UTC().Format(time.RFC3339Nano)
+		ca := resp.ClaimedAt.UTC().Format(time.RFC3339Nano)
+		out.ClaimedAt = &ca
 	}
 
 	if state != nil && state.Call != nil {
 		state.Call.ResultKind = ResultOK
-		// ProjectID is not directly exposed by GetState's narrow
-		// response (the spec contract is the state surface, not the
-		// full Item). Leaving it unset on the audit row matches the
-		// SetStateColumns RPC's own behaviour for tools that don't
-		// resolve project scope at the boundary — non-fatal for the
-		// audit dashboard (per-tool tool_name + item_id remain the
-		// load-bearing fields).
+		// ProjectID stamped on the audit row per orchestrator's
+		// post-review DECISION 2026-05-18 (S3): the row is sourced
+		// from the same item already loaded for the rbac.For org
+		// gate inside workitems.GetState, so this is a pure
+		// projection — no extra query.
+		state.Call.ProjectID = resp.ProjectID
 	}
 	return nil, out, nil
 }

--- a/apps/api/mcp/handler_set_state.go
+++ b/apps/api/mcp/handler_set_state.go
@@ -49,11 +49,20 @@
 //
 // # intent_comment validation
 //
-// Mirrors handler_comment.go (kind ∈ §6.5 allow-list, status ∈ §6.5
-// allow-list, body 1..16384 chars). Validation runs at the MCP
-// boundary before SetStateColumns is invoked, so a malformed
-// intent_comment surfaces as §7 VALIDATION without leaving a stale
-// state-only mutation behind.
+// Validation runs at the MCP boundary BEFORE SetStateColumns is
+// invoked, so a malformed intent_comment surfaces as §7 VALIDATION
+// without leaving a stale state-only mutation behind:
+//
+//   - kind ∈ SPEC §6.5 allow-list (mirrors comments_kind_chk DDL).
+//   - status ∈ SPEC §6.5 allow-list (mirrors comments_status_chk).
+//   - body 1..16384 chars.
+//
+// Each rejection returns InvalidArgument with `details["field"]`
+// identifying the offending sub-field (e.g. `intent_comment.kind`,
+// `intent_comment.status`, `intent_comment.body`). The downstream
+// workitems.AppendComment RPC + DDL CHECK constraints re-enforce
+// kind/status independently — boundary enforcement is the wire-UX
+// improvement (post-review DECISION 2026-05-18, S2).
 //
 // # Cascade publication
 //
@@ -118,6 +127,38 @@ type setStateOut struct {
 // Tool 13's intent_comment cap) is a single-line edit here without
 // affecting the plain `comment` tool.
 const setStateCommentBodyMax = 16384
+
+// intentCommentAllowedKinds mirrors SPEC §6.5 / migration
+// 0040_workitems.up.sql comments_kind_chk: the canonical kind enum the
+// DDL accepts for workitems.comments.kind. Enforced at the MCP
+// boundary (post-review DECISION 2026-05-18, S2) so an invalid kind
+// inside intent_comment surfaces as §7 VALIDATION
+// (details.field="intent_comment.kind") BEFORE the state mutation
+// commits — preventing a stale state-only mutation behind a malformed
+// comment retry.
+var intentCommentAllowedKinds = map[string]struct{}{
+	"investigation": {},
+	"decision":      {},
+	"deviation":     {},
+	"completed":     {},
+	"review":        {},
+	"qa":            {},
+	"deferred":      {},
+	"pr":            {},
+	"needs-human":   {},
+	"override":      {},
+	"general":       {},
+}
+
+// intentCommentAllowedStatuses mirrors SPEC §6.5 / migration
+// 0040_workitems.up.sql comments_status_chk. Same boundary-validation
+// rationale as intentCommentAllowedKinds above.
+var intentCommentAllowedStatuses = map[string]struct{}{
+	"error":   {},
+	"warning": {},
+	"info":    {},
+	"success": {},
+}
 
 // registerHandleSetState is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
@@ -218,15 +259,21 @@ func handleSetState(ctx context.Context, req *sdkmcp.CallToolRequest, in setStat
 	return nil, out, nil
 }
 
-// validateIntentComment enforces the same boundary contract
-// handler_comment.go applies to the plain `comment` tool: kind is
-// required (no default substitution at the MCP layer for the
-// intent_comment block — the spec explicitly enumerates the field as
-// a required member when the block is present), status is required,
-// and body is 1..16384 chars. The downstream workitems.AppendComment
-// RPC re-validates everything; this surfaces the §7 VALIDATION
-// envelope with the right `data.field` BEFORE the state mutation
-// commits.
+// validateIntentComment enforces the MCP-boundary validation contract
+// for the optional intent_comment block:
+//
+//   - kind ∈ SPEC §6.5 allow-list (matches workitems.comments
+//     comments_kind_chk CHECK in migration 0040_workitems.up.sql).
+//   - status ∈ SPEC §6.5 allow-list (matches comments_status_chk).
+//   - body length ∈ 1..16384 chars.
+//
+// Validation runs BEFORE workitems.SetStateColumns is invoked so a
+// malformed intent_comment never leaves a stale state-only mutation
+// behind. The downstream workitems.AppendComment RPC + DDL CHECK
+// constraints re-enforce kind/status independently; surfacing
+// VALIDATION at the boundary with `data.field` identifying the
+// offending sub-field is the meaningful UX win (post-review DECISION
+// 2026-05-18, S2).
 func validateIntentComment(c *setStateIntentComment) error {
 	if c.Kind == "" {
 		return &errs.Error{
@@ -235,10 +282,24 @@ func validateIntentComment(c *setStateIntentComment) error {
 			Meta:    errs.Metadata{"field": "intent_comment.kind"},
 		}
 	}
+	if _, ok := intentCommentAllowedKinds[c.Kind]; !ok {
+		return &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "intent_comment.kind not in allowed enum (SPEC §6.5)",
+			Meta:    errs.Metadata{"field": "intent_comment.kind"},
+		}
+	}
 	if c.Status == "" {
 		return &errs.Error{
 			Code:    errs.InvalidArgument,
 			Message: "intent_comment.status is required",
+			Meta:    errs.Metadata{"field": "intent_comment.status"},
+		}
+	}
+	if _, ok := intentCommentAllowedStatuses[c.Status]; !ok {
+		return &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "intent_comment.status not in allowed enum (SPEC §6.5)",
 			Meta:    errs.Metadata{"field": "intent_comment.status"},
 		}
 	}

--- a/apps/api/mcp/handler_set_state.go
+++ b/apps/api/mcp/handler_set_state.go
@@ -1,0 +1,260 @@
+// handler_set_state.go owns the §6.2 Tool 13 (`set_state`) handler —
+// the dedicated mutator for the four state-machine columns
+// (impl_state, review_state, qa_state, pipeline_state) plus an
+// optional `intent_comment` written atomically (best-effort) alongside
+// the state change.
+//
+// # State invariants
+//
+// All five PRD §6.2 state-machine invariants I-1..I-5 are enforced
+// inside workitems.SetStateColumns inside one SQL round-trip per the
+// CTE shape documented at SPEC §6.2 Tool 13 (lines 1659-1689):
+//
+//   - I-1: review_state=needs_rework auto-resets qa_state=pending in
+//     the same UPDATE (no rejection; auto-applied).
+//   - I-2: qa_state=failed requires review_state=approved
+//     (data.invariant=qa_failed_requires_review_approved).
+//   - I-3: post-failure rework reset lives in workitems.Claim, NOT
+//     here (documented in workitems.go for cross-reference).
+//   - I-4: review_state change requires impl_state=done
+//     (data.invariant=review_change_requires_impl_done).
+//   - I-5: impl_state=done → pending requires the rework path
+//     (data.invariant=impl_done_to_pending_requires_rework_path).
+//
+// The structural pre-check impl_done_requires_claim
+// (data.invariant=impl_done_requires_claim) also surfaces from the
+// same RPC. Each fires as Encore errs.FailedPrecondition with
+// Meta["invariant"] populated — errmap.go (post bead unblock-tv8.21
+// amendment) projects Meta["invariant"] into the §7 envelope as both
+// `data.invariant` (machine-targeted, per spec §6.2 line 1645) and
+// `data.rejection_reason` (legacy mirror).
+//
+// Layer-1 BLOCK conditions (comment-trail-driven preconditions such
+// as `qa_state → passed` requires a (kind=qa, status=success)
+// comment) ship in P02 per Plan §3.4 — NOT enforced here.
+//
+// # intent_comment atomicity
+//
+// SPEC §6.2 Tool 13 line 1694 and §4.4 line 732-736 mandate that the
+// state mutation and the intent_comment are written "atomically".
+// Encore's RPC boundary prevents a single Postgres transaction
+// spanning both workitems.SetStateColumns and workitems.AppendComment
+// — orchestrator DECISION (2026-05-18) on bead unblock-tv8.21 accepts
+// this as architectural: SetStateColumns runs first, AppendComment
+// follows on success. If AppendComment fails after the state mutation
+// committed, the failure is logged via rlog.Error (with item_id +
+// payload hash) and the wire envelope still reports the state-change
+// success — the canonical record is the row mutation, the
+// intent_comment is metadata.
+//
+// # intent_comment validation
+//
+// Mirrors handler_comment.go (kind ∈ §6.5 allow-list, status ∈ §6.5
+// allow-list, body 1..16384 chars). Validation runs at the MCP
+// boundary before SetStateColumns is invoked, so a malformed
+// intent_comment surfaces as §7 VALIDATION without leaving a stale
+// state-only mutation behind.
+//
+// # Cascade publication
+//
+// The §6.3.0 `state_change` cascade publish (post-commit publish to
+// deps.CascadeRequestedTopic when (impl, review, qa) materially
+// change) is tracked SEPARATELY as bead unblock-tv8.53 — NOT in
+// scope for this handler. SetStateColumns currently does not publish
+// state_change; D-6 ships without it per bead unblock-tv8.21
+// INVESTIGATION risk R3.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 13 (lines
+// 1606-1725) + § 4.4 (workitems.SetStateColumns + AppendComment) +
+// § 6.5 (Comment kind + status enums) + § 7 (error envelope).
+
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"encore.app/workitems"
+	"encore.dev/beta/errs"
+	"encore.dev/rlog"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// setStateIntentComment is the optional `intent_comment` block per
+// SPEC §6.2 Tool 13 lines 1616-1620. All three fields are required
+// when the block is supplied — the workitems.AppendComment RPC will
+// reject an empty body / missing kind on its own, but the MCP
+// boundary surfaces a clearer §7 VALIDATION envelope.
+type setStateIntentComment struct {
+	Kind   string `json:"kind"`
+	Status string `json:"status"`
+	Body   string `json:"body"`
+}
+
+// setStateIn mirrors SPEC §6.2 Tool 13 lines 1609-1621. Every state
+// field is a *string so the handler can faithfully distinguish
+// "unchanged" (nil pointer) from "explicit value" (non-nil), matching
+// workitems.SetStateRequest's pointer-nil-is-unchanged convention.
+//
+// IntentComment is *setStateIntentComment so absence (nil) skips the
+// comment write entirely; an explicit block triggers the post-state
+// AppendComment call.
+type setStateIn struct {
+	ItemID        string                 `json:"item_id"`
+	ImplState     *string                `json:"impl_state,omitempty"`
+	ReviewState   *string                `json:"review_state,omitempty"`
+	QAState       *string                `json:"qa_state,omitempty"`
+	PipelineState *string                `json:"pipeline_state,omitempty"`
+	IntentComment *setStateIntentComment `json:"intent_comment,omitempty"`
+}
+
+type setStateOut struct {
+	Item primeItem `json:"item"`
+}
+
+// setStateCommentBodyMax mirrors handler_comment.go's commentBodyMax —
+// kept as a separate const so a future divergence (e.g. spec amends
+// Tool 13's intent_comment cap) is a single-line edit here without
+// affecting the plain `comment` tool.
+const setStateCommentBodyMax = 16384
+
+// registerHandleSetState is invoked by transport.go's init — see the
+// toolRegistrars rationale there.
+func registerHandleSetState(s *sdkmcp.Server) {
+	sdkmcp.AddTool(s, &sdkmcp.Tool{
+		Name: "set_state",
+		Description: "Set one or more of (impl_state, review_state, " +
+			"qa_state, pipeline_state) atomically. Enforces the five " +
+			"PRD §6.2 state-machine invariants I-1..I-5 (data.invariant " +
+			"populated on PRECONDITION_NOT_MET). Optionally writes an " +
+			"intent_comment alongside the state change. SPEC § 6.2 Tool 13.",
+	}, handleSetState)
+}
+
+func handleSetState(ctx context.Context, req *sdkmcp.CallToolRequest, in setStateIn) (*sdkmcp.CallToolResult, setStateOut, error) {
+	tool := "set_state"
+	state := bindTool(req, tool)
+
+	identity, ok := identityFromReq(req)
+	if !ok {
+		return nil, setStateOut{}, mapError(state, tool, errMissingIdentityErr())
+	}
+
+	mcpCtx, err := withIdentityFromReq(ctx, req)
+	if err != nil {
+		return nil, setStateOut{}, mapError(state, tool, err)
+	}
+
+	if in.ItemID == "" {
+		return nil, setStateOut{}, mapError(state, tool, &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "missing item_id",
+			Meta:    errs.Metadata{"field": "item_id"},
+		})
+	}
+	if state != nil && state.Call != nil {
+		state.Call.ItemID = in.ItemID
+	}
+
+	// Validate the intent_comment block BEFORE invoking SetStateColumns
+	// so a malformed comment never leaves a state-only mutation behind.
+	// The workitems.AppendComment RPC would re-reject the same input
+	// later, but the §7 VALIDATION envelope sourced from there would
+	// arrive after the state write committed — defeating the
+	// "best-effort atomic" contract documented above.
+	if in.IntentComment != nil {
+		if err := validateIntentComment(in.IntentComment); err != nil {
+			return nil, setStateOut{}, mapError(state, tool, err)
+		}
+	}
+
+	item, err := workitems.SetStateColumns(mcpCtx, &workitems.SetStateRequest{
+		ItemID:        in.ItemID,
+		ImplState:     in.ImplState,
+		ReviewState:   in.ReviewState,
+		QAState:       in.QAState,
+		PipelineState: in.PipelineState,
+	})
+	if err != nil {
+		return nil, setStateOut{}, mapError(state, tool, err)
+	}
+
+	// State write committed. Now best-effort append the intent_comment;
+	// any failure here is logged but does NOT roll back the state
+	// mutation (orchestrator DECISION 2026-05-18 on bead
+	// unblock-tv8.21: cross-RPC Postgres transactions are out of
+	// architectural scope for P01).
+	if in.IntentComment != nil {
+		_, commentErr := workitems.AppendComment(mcpCtx, &workitems.AppendCommentRequest{
+			ItemID:      in.ItemID,
+			AuthorID:    identity.UserID,
+			AuthorAgent: identity.AgentKind,
+			Kind:        in.IntentComment.Kind,
+			Status:      in.IntentComment.Status,
+			Body:        in.IntentComment.Body,
+		})
+		if commentErr != nil {
+			// Payload hash (not the body itself) keeps the rlog line
+			// debuggable without leaking comment text into the
+			// observability surface.
+			bodyHash := sha256.Sum256([]byte(in.IntentComment.Body))
+			rlog.Error("mcp: set_state intent_comment append failed; state mutation already committed",
+				"err", commentErr,
+				"item_id", in.ItemID,
+				"intent_comment_kind", in.IntentComment.Kind,
+				"intent_comment_status", in.IntentComment.Status,
+				"intent_comment_body_sha256", hex.EncodeToString(bodyHash[:]),
+				"intent_comment_body_len", len(in.IntentComment.Body),
+			)
+		}
+	}
+
+	out := setStateOut{Item: itemToPrime(*item)}
+	if state != nil && state.Call != nil {
+		state.Call.ResultKind = ResultOK
+		state.Call.ProjectID = item.ProjectID
+	}
+	return nil, out, nil
+}
+
+// validateIntentComment enforces the same boundary contract
+// handler_comment.go applies to the plain `comment` tool: kind is
+// required (no default substitution at the MCP layer for the
+// intent_comment block — the spec explicitly enumerates the field as
+// a required member when the block is present), status is required,
+// and body is 1..16384 chars. The downstream workitems.AppendComment
+// RPC re-validates everything; this surfaces the §7 VALIDATION
+// envelope with the right `data.field` BEFORE the state mutation
+// commits.
+func validateIntentComment(c *setStateIntentComment) error {
+	if c.Kind == "" {
+		return &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "intent_comment.kind is required",
+			Meta:    errs.Metadata{"field": "intent_comment.kind"},
+		}
+	}
+	if c.Status == "" {
+		return &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "intent_comment.status is required",
+			Meta:    errs.Metadata{"field": "intent_comment.status"},
+		}
+	}
+	if c.Body == "" {
+		return &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "intent_comment.body must be non-empty",
+			Meta:    errs.Metadata{"field": "intent_comment.body"},
+		}
+	}
+	if len(c.Body) > setStateCommentBodyMax {
+		return &errs.Error{
+			Code:    errs.InvalidArgument,
+			Message: "intent_comment.body exceeds 16384 chars",
+			Meta:    errs.Metadata{"field": "intent_comment.body"},
+		}
+	}
+	return nil
+}

--- a/apps/api/mcp/transport.go
+++ b/apps/api/mcp/transport.go
@@ -113,6 +113,8 @@ var toolRegistrars = []func(*sdkmcp.Server){
 	registerHandleComment,
 	registerHandleAddDependency,
 	registerHandleRemoveDependency,
+	registerHandleSetState,
+	registerHandleGetState,
 }
 
 func init() {

--- a/apps/api/shared/mcpaudittest/d6_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d6_tools_test.go
@@ -1,0 +1,573 @@
+// d6_tools_test.go covers the D-6 (bead unblock-tv8.21) acceptance
+// matrix for MCP tools 13 (`set_state`) and 14 (`get_state`).
+//
+// Reuses the d2Fixture / callTool / assertStructuredEchoesText
+// harness — full Bearer-auth roundtrip through MCPHandler. Each test
+// seeds an isolated org+user+project+api_key tuple so the §7
+// envelopes reach the wire with real Identity propagation through
+// withIdentity.
+//
+// Coverage matrix (bead unblock-tv8.21 AC):
+//
+//   - setState_I1AutoResetsQA (AC #1): writing review_state=
+//     needs_rework on a (done, approved, passed) item auto-resets
+//     qa_state to pending in the same write.
+//   - setState_I2QAFailedRequiresReviewApproved (AC #2): qa_state=
+//     failed with review_state != approved returns §7
+//     PRECONDITION_NOT_MET with data.invariant=
+//     qa_failed_requires_review_approved.
+//   - setState_I4ReviewChangeRequiresImplDone (AC #3): review_state
+//     change with impl_state=pending returns §7
+//     PRECONDITION_NOT_MET with data.invariant=
+//     review_change_requires_impl_done.
+//   - setState_I5ImplDoneToPendingRequiresReworkPath (AC #4):
+//     impl_state=pending request on an (impl=done, review=approved,
+//     qa=passed) item returns §7 PRECONDITION_NOT_MET with
+//     data.invariant=impl_done_to_pending_requires_rework_path.
+//   - setState_IntentCommentWrittenAtomically: optional
+//     intent_comment is persisted alongside a successful state
+//     mutation (best-effort atomic per orchestrator DECISION
+//     2026-05-18 on bead unblock-tv8.21).
+//   - setState_IntentCommentValidationFailsBeforeStateWrite: an
+//     invalid intent_comment (empty body) returns §7 VALIDATION
+//     BEFORE the state mutation runs — the item's state columns are
+//     unchanged in the DB.
+//   - getState_ReturnsAllStateDimensions: every state column +
+//     materialised pipeline_stage + claim columns surface on the
+//     wire.
+//   - getState_RecentKindsOneRowPerKind (AC #5): get_state returns
+//     recent_kinds with one row per kind, picking the most recent
+//     comment per kind by created_at desc.
+//   - d6_AuditRowsCarryToolName: set_state + get_state dispatches
+//     each write one mcp.tool_calls row with the matching tool_name.
+
+package mcpaudittest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"encore.app/shared/ulid"
+)
+
+// =============================================================================
+// helpers
+// =============================================================================
+
+// seedItemForState inserts a workitems.items row with the requested
+// state columns + claim binding. The caller controls every
+// dimension so each invariant test sets up the precise precondition
+// the rule was designed to gate.
+//
+// claimedBy may be empty — the item lands unclaimed and impl_state=
+// done is then forbidden by the structural impl_done_requires_claim
+// pre-check.
+//
+// Returns the ULID.
+func seedItemForState(t *testing.T, orgID, projectID string, impl, review, qa, pipe, claimedBy string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	// The items_claim_status_chk CHECK constraint requires status =
+	// 'InProgress' (or 'Done') whenever claimed_by_id IS NOT NULL.
+	// Pick the row status to satisfy that gate based on the test
+	// fixture intent.
+	status := "Backlog"
+	if claimedBy != "" {
+		status = "InProgress"
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, priority,
+		    impl_state, review_state, qa_state, pipeline_state,
+		    claimed_by_id, claimed_at, claimed_by_agent,
+		    created_at, updated_at)
+		 VALUES ($1, $2, $3, 'task', $4, $5, 'P2',
+		         $6, $7, $8, $9,
+		         NULLIF($10, ''),
+		         CASE WHEN $10 = '' THEN NULL ELSE now() END,
+		         CASE WHEN $10 = '' THEN NULL ELSE 'claude-code' END,
+		         now(), now())`,
+		id, orgID, projectID,
+		"d6-state-"+id[len(id)-6:], status,
+		impl, review, qa, pipe,
+		claimedBy,
+	); err != nil {
+		t.Fatalf("insert state-fixture item: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.items WHERE id = $1`, id) })
+	return id
+}
+
+// seedCommentDirect inserts a workitems.comments row directly via
+// SQL. Used by the get_state recent_kinds test to land multiple
+// comments per kind with explicit created_at offsets so the
+// DISTINCT ON (kind) ORDER BY kind, created_at DESC contract is
+// verifiable.
+func seedCommentDirect(t *testing.T, itemID, kind, status, body string, createdAtOffset time.Duration) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid comment: %v", err)
+	}
+	// comments_author_chk requires author_id OR author_agent populated;
+	// the get_state test only cares about the (kind, status,
+	// comment_id, created_at) tuple so any author stub satisfies the
+	// constraint without affecting the recent_kinds projection.
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.comments
+		   (id, item_id, author_agent, kind, status, body, created_at, updated_at)
+		 VALUES ($1, $2, 'claude-code', $3, $4, $5,
+		         now() + ($6 || ' microseconds')::interval,
+		         now() + ($6 || ' microseconds')::interval)`,
+		id, itemID, kind, status, body,
+		fmt.Sprintf("%d", createdAtOffset.Microseconds()),
+	); err != nil {
+		t.Fatalf("insert comment: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM workitems.comments WHERE id = $1`, id) })
+	return id
+}
+
+// setStateWireOut models the §6.2 Tool 13 wire shape — the
+// structuredContent JSON object carrying { "item": Item }.
+type setStateWireOut struct {
+	Item struct {
+		ID            string `json:"id"`
+		ImplState     string `json:"impl_state"`
+		ReviewState   string `json:"review_state"`
+		QAState       string `json:"qa_state"`
+		PipelineState string `json:"pipeline_state"`
+	} `json:"item"`
+}
+
+func decodeSetStateOut(t *testing.T, raw json.RawMessage) setStateWireOut {
+	t.Helper()
+	var out setStateWireOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decodeSetStateOut: %v; raw=%s", err, string(raw))
+	}
+	return out
+}
+
+// getStateWireOut models the §6.2 Tool 14 structuredContent shape.
+type getStateWireOut struct {
+	ImplState     string `json:"impl_state"`
+	ReviewState   string `json:"review_state"`
+	QAState       string `json:"qa_state"`
+	PipelineState string `json:"pipeline_state"`
+	PipelineStage string `json:"pipeline_stage,omitempty"`
+	IsReady       bool   `json:"is_ready"`
+	ClaimedByID   string `json:"claimed_by_id,omitempty"`
+	ClaimedAt     string `json:"claimed_at,omitempty"`
+	RecentKinds   []struct {
+		Kind      string `json:"kind"`
+		Status    string `json:"status"`
+		CommentID string `json:"comment_id"`
+		CreatedAt string `json:"created_at"`
+	} `json:"recent_kinds"`
+}
+
+func decodeGetStateOut(t *testing.T, raw json.RawMessage) getStateWireOut {
+	t.Helper()
+	var out getStateWireOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decodeGetStateOut: %v; raw=%s", err, string(raw))
+	}
+	return out
+}
+
+// readItemStateColumns reads the live state columns from
+// workitems.items for post-write assertions.
+func readItemStateColumns(t *testing.T, itemID string) (impl, review, qa, pipe string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := db.QueryRow(ctx,
+		`SELECT impl_state, review_state, qa_state, pipeline_state
+		   FROM workitems.items WHERE id = $1`,
+		itemID,
+	).Scan(&impl, &review, &qa, &pipe); err != nil {
+		t.Fatalf("read state columns: %v", err)
+	}
+	return
+}
+
+// =============================================================================
+// set_state — invariants
+// =============================================================================
+
+// TestD6_SetStateI1AutoResetsQA covers AC #1: writing review_state=
+// needs_rework on a (done, approved, passed) item auto-resets
+// qa_state to pending in the same write (I-1 is auto-applied, not a
+// rejection).
+func TestD6_SetStateI1AutoResetsQA(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeSetStateOut(t, res.StructuredContent)
+
+	if got.Item.ReviewState != "needs_rework" {
+		t.Fatalf("item.review_state = %q, want needs_rework", got.Item.ReviewState)
+	}
+	if got.Item.QAState != "pending" {
+		t.Fatalf("I-1: item.qa_state = %q, want pending (auto-reset)", got.Item.QAState)
+	}
+
+	// DB read-back: both columns reflect the auto-reset.
+	impl, review, qa, _ := readItemStateColumns(t, itemID)
+	if impl != "done" {
+		t.Fatalf("DB impl_state = %q, want done (unchanged)", impl)
+	}
+	if review != "needs_rework" {
+		t.Fatalf("DB review_state = %q, want needs_rework", review)
+	}
+	if qa != "pending" {
+		t.Fatalf("DB qa_state = %q, want pending (I-1 auto-reset)", qa)
+	}
+}
+
+// TestD6_SetStateI2QAFailedRequiresReviewApproved covers AC #2:
+// qa_state=failed with review_state != approved returns §7
+// PRECONDITION_NOT_MET with data.invariant=
+// qa_failed_requires_review_approved.
+func TestD6_SetStateI2QAFailedRequiresReviewApproved(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	// Start from (done, pending, pending) so I-4 doesn't fire on
+	// review_state interactions — we only want to trigger I-2 by
+	// raising qa_state to failed while review stays at pending.
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "pending", "pending", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":  itemID,
+		"qa_state": "failed",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected PRECONDITION_NOT_MET I-2; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "PRECONDITION_NOT_MET" {
+		t.Fatalf("error.data.kind = %q, want PRECONDITION_NOT_MET", data.Kind)
+	}
+	if got, _ := data.Details["invariant"].(string); got != "qa_failed_requires_review_approved" {
+		t.Fatalf("error.data.details.invariant = %q, want qa_failed_requires_review_approved", got)
+	}
+
+	// DB read-back: state columns unchanged.
+	_, _, qa, _ := readItemStateColumns(t, itemID)
+	if qa != "pending" {
+		t.Fatalf("DB qa_state = %q after rejection, want pending (unchanged)", qa)
+	}
+}
+
+// TestD6_SetStateI4ReviewChangeRequiresImplDone covers AC #3:
+// review_state change to approved/needs_rework with impl_state=
+// pending returns §7 PRECONDITION_NOT_MET with data.invariant=
+// review_change_requires_impl_done.
+func TestD6_SetStateI4ReviewChangeRequiresImplDone(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	// (pending, pending, pending), unclaimed — review change to
+	// approved must reject by I-4 because impl is not done.
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"pending", "pending", "pending", "running", "")
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "approved",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected PRECONDITION_NOT_MET I-4; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "PRECONDITION_NOT_MET" {
+		t.Fatalf("error.data.kind = %q, want PRECONDITION_NOT_MET", data.Kind)
+	}
+	if got, _ := data.Details["invariant"].(string); got != "review_change_requires_impl_done" {
+		t.Fatalf("error.data.details.invariant = %q, want review_change_requires_impl_done", got)
+	}
+
+	// DB read-back: review column unchanged.
+	_, review, _, _ := readItemStateColumns(t, itemID)
+	if review != "pending" {
+		t.Fatalf("DB review_state = %q after rejection, want pending (unchanged)", review)
+	}
+}
+
+// TestD6_SetStateI5ImplDoneToPendingRequiresReworkPath covers AC #4:
+// a bare impl=pending request on an (impl=done, review=approved,
+// qa=passed) item returns §7 PRECONDITION_NOT_MET with
+// data.invariant=impl_done_to_pending_requires_rework_path. The
+// rework path (review=needs_rework or qa=failed) is the only allowed
+// impl_state transition off `done` per PRD §6.2.
+func TestD6_SetStateI5ImplDoneToPendingRequiresReworkPath(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":    itemID,
+		"impl_state": "pending",
+	})
+	if env.Error == nil {
+		t.Fatalf("expected PRECONDITION_NOT_MET I-5; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "PRECONDITION_NOT_MET" {
+		t.Fatalf("error.data.kind = %q, want PRECONDITION_NOT_MET", data.Kind)
+	}
+	if got, _ := data.Details["invariant"].(string); got != "impl_done_to_pending_requires_rework_path" {
+		t.Fatalf("error.data.details.invariant = %q, want impl_done_to_pending_requires_rework_path", got)
+	}
+
+	// DB read-back: impl column unchanged.
+	impl, _, _, _ := readItemStateColumns(t, itemID)
+	if impl != "done" {
+		t.Fatalf("DB impl_state = %q after rejection, want done (unchanged)", impl)
+	}
+}
+
+// =============================================================================
+// set_state — intent_comment atomicity & validation
+// =============================================================================
+
+// TestD6_SetStateIntentCommentWrittenAtomically asserts the optional
+// intent_comment block is persisted as a workitems.comments row
+// alongside a successful state mutation. Per orchestrator DECISION
+// 2026-05-18 on bead unblock-tv8.21 the contract is "best-effort
+// atomic" (Encore RPC boundaries prevent a single Postgres
+// transaction spanning both writes); this test pins the happy path.
+func TestD6_SetStateIntentCommentWrittenAtomically(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+		"intent_comment": map[string]any{
+			"kind":   "review",
+			"status": "warning",
+			"body":   "found a regression in the migration",
+		},
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeSetStateOut(t, res.StructuredContent)
+	if got.Item.ReviewState != "needs_rework" {
+		t.Fatalf("item.review_state = %q, want needs_rework", got.Item.ReviewState)
+	}
+
+	// DB read-back: exactly one workitems.comments row landed with
+	// the requested kind/status/body for this item.
+	ctx := context.Background()
+	var count int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM workitems.comments
+		  WHERE item_id = $1 AND kind = 'review' AND status = 'warning'
+		    AND body = 'found a regression in the migration'`,
+		itemID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count comments: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("intent_comment row count = %d, want 1", count)
+	}
+}
+
+// TestD6_SetStateIntentCommentValidationFailsBeforeStateWrite
+// asserts the boundary-validation contract: an invalid
+// intent_comment (empty body) surfaces §7 VALIDATION with
+// data.field="intent_comment.body" BEFORE the state mutation runs —
+// the item's state columns remain unchanged in the DB.
+//
+// This is the safety property that makes the "validate at the MCP
+// boundary first" pattern meaningful: without it, a malformed
+// intent_comment would leave a stale state-only mutation behind on
+// every retry attempt.
+func TestD6_SetStateIntentCommentValidationFailsBeforeStateWrite(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+		"intent_comment": map[string]any{
+			"kind":   "review",
+			"status": "warning",
+			"body":   "", // empty body — must reject
+		},
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION on empty intent_comment.body; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "intent_comment.body" {
+		t.Fatalf("error.data.details.field = %q, want intent_comment.body", got)
+	}
+
+	// DB read-back: state columns unchanged.
+	_, review, qa, _ := readItemStateColumns(t, itemID)
+	if review != "approved" {
+		t.Fatalf("DB review_state = %q after rejection, want approved (unchanged)", review)
+	}
+	if qa != "passed" {
+		t.Fatalf("DB qa_state = %q after rejection, want passed (unchanged)", qa)
+	}
+}
+
+// =============================================================================
+// get_state
+// =============================================================================
+
+// TestD6_GetStateReturnsAllStateDimensions asserts the §6.2 Tool 14
+// happy path: every state column + materialised pipeline_stage +
+// is_ready + claim columns surface on the wire. For an item with no
+// comments, recent_kinds is the empty array.
+func TestD6_GetStateReturnsAllStateDimensions(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "get_state", map[string]any{
+		"item_id": itemID,
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeGetStateOut(t, res.StructuredContent)
+
+	if got.ImplState != "done" {
+		t.Fatalf("impl_state = %q, want done", got.ImplState)
+	}
+	if got.ReviewState != "approved" {
+		t.Fatalf("review_state = %q, want approved", got.ReviewState)
+	}
+	if got.QAState != "passed" {
+		t.Fatalf("qa_state = %q, want passed", got.QAState)
+	}
+	if got.PipelineState != "running" {
+		t.Fatalf("pipeline_state = %q, want running", got.PipelineState)
+	}
+	if got.ClaimedByID != fx.UserID {
+		t.Fatalf("claimed_by_id = %q, want %q", got.ClaimedByID, fx.UserID)
+	}
+	if got.ClaimedAt == "" {
+		t.Fatalf("claimed_at empty on claimed item")
+	}
+	if got.RecentKinds == nil {
+		t.Fatalf("recent_kinds nil (must be [] when no comments)")
+	}
+	if len(got.RecentKinds) != 0 {
+		t.Fatalf("recent_kinds len = %d, want 0 (no comments seeded)", len(got.RecentKinds))
+	}
+}
+
+// TestD6_GetStateRecentKindsOneRowPerKind covers AC #5: get_state
+// returns recent_kinds with one row per kind, picking the most
+// recent comment per kind by created_at desc. We seed two kinds with
+// multiple comments each; the response MUST contain exactly two rows
+// — one per kind — each pointing at the latest comment_id for that
+// kind.
+func TestD6_GetStateRecentKindsOneRowPerKind(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"pending", "pending", "pending", "running", "")
+
+	// Seed two kinds with two comments each, offsetting created_at
+	// so the "most recent per kind" picker has a real choice to make.
+	_ = seedCommentDirect(t, itemID, "investigation", "info", "first investigation", -2*time.Second)
+	latestInvestigation := seedCommentDirect(t, itemID, "investigation", "info", "second investigation", 0)
+	_ = seedCommentDirect(t, itemID, "decision", "info", "first decision", -2*time.Second)
+	latestDecision := seedCommentDirect(t, itemID, "decision", "info", "second decision", 0)
+
+	env := callTool(t, fx.RawKey, "get_state", map[string]any{
+		"item_id": itemID,
+	})
+	res := assertStructuredEchoesText(t, env)
+	got := decodeGetStateOut(t, res.StructuredContent)
+
+	if len(got.RecentKinds) != 2 {
+		t.Fatalf("recent_kinds len = %d, want 2 (one row per kind); rows=%+v", len(got.RecentKinds), got.RecentKinds)
+	}
+
+	byKind := map[string]string{} // kind → comment_id
+	for _, rk := range got.RecentKinds {
+		byKind[rk.Kind] = rk.CommentID
+	}
+	if byKind["investigation"] != latestInvestigation {
+		t.Fatalf("recent_kinds[investigation].comment_id = %q, want %q (most recent)",
+			byKind["investigation"], latestInvestigation)
+	}
+	if byKind["decision"] != latestDecision {
+		t.Fatalf("recent_kinds[decision].comment_id = %q, want %q (most recent)",
+			byKind["decision"], latestDecision)
+	}
+}
+
+// =============================================================================
+// audit rows
+// =============================================================================
+
+// TestD6_AuditRowsCarryToolName: each set_state + get_state dispatch
+// writes one mcp.tool_calls row with the matching tool_name. SPEC
+// §8.1 — completes the audit coverage matrix alongside D-2, D-3,
+// D-4, and D-5.
+func TestD6_AuditRowsCarryToolName(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	_ = callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+	})
+	_ = callTool(t, fx.RawKey, "get_state", map[string]any{
+		"item_id": itemID,
+	})
+
+	rows := selectToolCalls(t)
+	have := map[string]int{}
+	for _, r := range rows {
+		have[r.ToolName]++
+	}
+	for _, want := range []string{"set_state", "get_state"} {
+		if have[want] < 1 {
+			t.Fatalf("audit row for tool_name=%q: count=%d, want >=1; rows=%+v", want, have[want], rows)
+		}
+	}
+}

--- a/apps/api/shared/mcpaudittest/d6_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d6_tools_test.go
@@ -158,15 +158,20 @@ func decodeSetStateOut(t *testing.T, raw json.RawMessage) setStateWireOut {
 }
 
 // getStateWireOut models the §6.2 Tool 14 structuredContent shape.
+// pipeline_stage / claimed_by_id / claimed_at are *string because the
+// wire contract (post-review DECISION 2026-05-18, S1) emits explicit
+// JSON `null` when the underlying field is unset — a value-typed
+// `string` with `omitempty` would silently swallow that distinction.
 type getStateWireOut struct {
-	ImplState     string `json:"impl_state"`
-	ReviewState   string `json:"review_state"`
-	QAState       string `json:"qa_state"`
-	PipelineState string `json:"pipeline_state"`
-	PipelineStage string `json:"pipeline_stage,omitempty"`
-	IsReady       bool   `json:"is_ready"`
-	ClaimedByID   string `json:"claimed_by_id,omitempty"`
-	ClaimedAt     string `json:"claimed_at,omitempty"`
+	ProjectID     string  `json:"project_id"`
+	ImplState     string  `json:"impl_state"`
+	ReviewState   string  `json:"review_state"`
+	QAState       string  `json:"qa_state"`
+	PipelineState string  `json:"pipeline_state"`
+	PipelineStage *string `json:"pipeline_stage"`
+	IsReady       bool    `json:"is_ready"`
+	ClaimedByID   *string `json:"claimed_by_id"`
+	ClaimedAt     *string `json:"claimed_at"`
 	RecentKinds   []struct {
 		Kind      string `json:"kind"`
 		Status    string `json:"status"`
@@ -481,11 +486,14 @@ func TestD6_GetStateReturnsAllStateDimensions(t *testing.T) {
 	if got.PipelineState != "running" {
 		t.Fatalf("pipeline_state = %q, want running", got.PipelineState)
 	}
-	if got.ClaimedByID != fx.UserID {
-		t.Fatalf("claimed_by_id = %q, want %q", got.ClaimedByID, fx.UserID)
+	if got.ClaimedByID == nil || *got.ClaimedByID != fx.UserID {
+		t.Fatalf("claimed_by_id = %v, want %q", got.ClaimedByID, fx.UserID)
 	}
-	if got.ClaimedAt == "" {
-		t.Fatalf("claimed_at empty on claimed item")
+	if got.ClaimedAt == nil || *got.ClaimedAt == "" {
+		t.Fatalf("claimed_at = %v, want non-empty on claimed item", got.ClaimedAt)
+	}
+	if got.ProjectID != fx.ProjectID {
+		t.Fatalf("project_id = %q, want %q", got.ProjectID, fx.ProjectID)
 	}
 	if got.RecentKinds == nil {
 		t.Fatalf("recent_kinds nil (must be [] when no comments)")
@@ -538,14 +546,159 @@ func TestD6_GetStateRecentKindsOneRowPerKind(t *testing.T) {
 	}
 }
 
+// TestD6_GetStateUnclaimedItemEmitsExplicitNulls asserts the
+// post-review wire-shape contract (DECISION 2026-05-18, S1): for an
+// unclaimed item, the §6.2 Tool 14 structuredContent envelope MUST
+// contain the keys `claimed_by_id` and `claimed_at` with literal JSON
+// `null` value — NOT omit them. pipeline_stage is also pointer-
+// encoded; since the DDL default 'Investigation' means it's never
+// empty in practice, we only assert the key is present at the wire
+// (`null` would require a corrupted row).
+//
+// The check is done on the raw structuredContent JSON map so we catch
+// the "key absent" failure mode that a value-typed `string` +
+// `omitempty` decoding would silently mask.
+func TestD6_GetStateUnclaimedItemEmitsExplicitNulls(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	// Unclaimed item: empty claimedBy → claimed_by_id and claimed_at
+	// both must surface as JSON `null` on the wire envelope.
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"pending", "pending", "pending", "running", "")
+
+	env := callTool(t, fx.RawKey, "get_state", map[string]any{
+		"item_id": itemID,
+	})
+	res := assertStructuredEchoesText(t, env)
+
+	// Decode into a generic map so we can inspect KEY PRESENCE
+	// independently of Go zero-value semantics — a missing key is
+	// indistinguishable from a JSON null after typed unmarshalling,
+	// but `_, ok := m[k]` discriminates the two.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(res.StructuredContent, &raw); err != nil {
+		t.Fatalf("unmarshal raw structuredContent: %v; raw=%s", err, string(res.StructuredContent))
+	}
+
+	for _, key := range []string{"claimed_by_id", "claimed_at", "pipeline_stage"} {
+		v, ok := raw[key]
+		if !ok {
+			t.Fatalf("structuredContent missing key %q; want present (with null for unclaimed); raw=%s",
+				key, string(res.StructuredContent))
+		}
+		// For the two claim fields we expect literal null; for
+		// pipeline_stage the DDL default means it's a non-null
+		// string. Either way the key MUST be present.
+		if key == "pipeline_stage" {
+			continue
+		}
+		if string(v) != "null" {
+			t.Fatalf("structuredContent[%q] = %s, want literal null on unclaimed item", key, string(v))
+		}
+	}
+}
+
 // =============================================================================
 // audit rows
 // =============================================================================
+
+// TestD6_SetStateIntentCommentInvalidKindRejected asserts the
+// post-review enum-validation contract (DECISION 2026-05-18, S2): an
+// intent_comment.kind outside SPEC §6.5's allow-list surfaces §7
+// VALIDATION with `details.field="intent_comment.kind"` BEFORE the
+// state mutation runs — DB state columns unchanged.
+func TestD6_SetStateIntentCommentInvalidKindRejected(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+		"intent_comment": map[string]any{
+			"kind":   "not-a-real-kind", // not in §6.5 allow-list
+			"status": "warning",
+			"body":   "should never land",
+		},
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION on invalid intent_comment.kind; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "intent_comment.kind" {
+		t.Fatalf("error.data.details.field = %q, want intent_comment.kind", got)
+	}
+
+	// DB read-back: state columns unchanged — SetStateColumns was
+	// never called because validation ran first.
+	_, review, qa, _ := readItemStateColumns(t, itemID)
+	if review != "approved" {
+		t.Fatalf("DB review_state = %q after rejection, want approved (unchanged)", review)
+	}
+	if qa != "passed" {
+		t.Fatalf("DB qa_state = %q after rejection, want passed (unchanged)", qa)
+	}
+}
+
+// TestD6_SetStateIntentCommentInvalidStatusRejected: same contract as
+// the invalid-kind test, applied to intent_comment.status.
+func TestD6_SetStateIntentCommentInvalidStatusRejected(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+		"intent_comment": map[string]any{
+			"kind":   "review",
+			"status": "not-a-real-status", // not in §6.5 allow-list
+			"body":   "should never land",
+		},
+	})
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION on invalid intent_comment.status; got success result=%s", string(env.Result))
+	}
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
+	}
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if got, _ := data.Details["field"].(string); got != "intent_comment.status" {
+		t.Fatalf("error.data.details.field = %q, want intent_comment.status", got)
+	}
+
+	// DB read-back: state columns unchanged.
+	_, review, qa, _ := readItemStateColumns(t, itemID)
+	if review != "approved" {
+		t.Fatalf("DB review_state = %q after rejection, want approved (unchanged)", review)
+	}
+	if qa != "passed" {
+		t.Fatalf("DB qa_state = %q after rejection, want passed (unchanged)", qa)
+	}
+}
 
 // TestD6_AuditRowsCarryToolName: each set_state + get_state dispatch
 // writes one mcp.tool_calls row with the matching tool_name. SPEC
 // §8.1 — completes the audit coverage matrix alongside D-2, D-3,
 // D-4, and D-5.
+//
+// Post-review extension (DECISION 2026-05-18, S3): the get_state
+// audit row's project_id MUST be populated from the item's resolved
+// project scope (sourced from the same row already loaded by the
+// rbac.For org gate inside workitems.GetState). This pins the
+// audit-dashboard filterability contract: every tool call that
+// resolves an item knows its project.
 func TestD6_AuditRowsCarryToolName(t *testing.T) {
 	resetToolCalls(t)
 	fx := seedD2Fixture(t)
@@ -562,12 +715,25 @@ func TestD6_AuditRowsCarryToolName(t *testing.T) {
 
 	rows := selectToolCalls(t)
 	have := map[string]int{}
+	getStateProjectID := ""
 	for _, r := range rows {
 		have[r.ToolName]++
+		if r.ToolName == "get_state" && r.ProjectID != nil {
+			getStateProjectID = *r.ProjectID
+		}
 	}
 	for _, want := range []string{"set_state", "get_state"} {
 		if have[want] < 1 {
 			t.Fatalf("audit row for tool_name=%q: count=%d, want >=1; rows=%+v", want, have[want], rows)
 		}
+	}
+	// S3 contract: the get_state audit row carries the resolved
+	// project_id (sourced from the item's row via the rbac.For org
+	// gate). Non-empty + matches the seeded project.
+	if getStateProjectID == "" {
+		t.Fatalf("get_state audit row project_id is empty; want %q", fx.ProjectID)
+	}
+	if getStateProjectID != fx.ProjectID {
+		t.Fatalf("get_state audit row project_id = %q, want %q", getStateProjectID, fx.ProjectID)
 	}
 }

--- a/apps/api/shared/mcpaudittest/mcpaudittest_test.go
+++ b/apps/api/shared/mcpaudittest/mcpaudittest_test.go
@@ -219,6 +219,7 @@ func TestRecordToolCallNullableFields(t *testing.T) {
 type toolCallRow struct {
 	ID         string
 	OrgID      string
+	ProjectID  *string
 	ToolName   string
 	ResultKind string
 	ErrorCode  *string
@@ -244,7 +245,7 @@ func selectToolCalls(t *testing.T) []toolCallRow {
 	t.Helper()
 	ctx := context.Background()
 	rows, err := db.Query(ctx, `
-		SELECT id, org_id, tool_name, result_kind, error_code, duration_ms, trace_id
+		SELECT id, org_id, project_id, tool_name, result_kind, error_code, duration_ms, trace_id
 		FROM mcp.tool_calls
 		ORDER BY called_at ASC, id ASC
 	`)
@@ -256,7 +257,7 @@ func selectToolCalls(t *testing.T) []toolCallRow {
 	var out []toolCallRow
 	for rows.Next() {
 		var r toolCallRow
-		if err := rows.Scan(&r.ID, &r.OrgID, &r.ToolName, &r.ResultKind, &r.ErrorCode, &r.DurationMs, &r.TraceID); err != nil {
+		if err := rows.Scan(&r.ID, &r.OrgID, &r.ProjectID, &r.ToolName, &r.ResultKind, &r.ErrorCode, &r.DurationMs, &r.TraceID); err != nil {
 			t.Fatalf("scan tool_calls: %v", err)
 		}
 		out = append(out, r)

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -204,6 +204,42 @@ type SetStateRequest struct {
 	PipelineState *string
 }
 
+// GetStateRequest is the input to GetState. SPEC §6.2 Tool 14 line
+// 1730-1733.
+type GetStateRequest struct {
+	ItemID string
+}
+
+// RecentKindRow is a single (kind, status, comment_id, created_at) tuple
+// returned by GetState's `recent_kinds` aggregate. SPEC §6.2 Tool 14
+// lines 1745-1750: one row per distinct comment kind on the item,
+// carrying the most recent (status, comment_id, created_at) for that
+// kind. Ordered by `kind` ASC for deterministic wire output.
+type RecentKindRow struct {
+	Kind      string
+	Status    string
+	CommentID string
+	CreatedAt time.Time
+}
+
+// GetStateResponse is the output of GetState. SPEC §6.2 Tool 14 lines
+// 1736-1751: every state dimension on the item plus the per-kind
+// `recent_kinds` aggregate from workitems.comments. The four state
+// columns surface as plain strings (never pointers) because every item
+// row has them populated via column defaults — the empty string here
+// would indicate a corrupted row.
+type GetStateResponse struct {
+	ImplState     string
+	ReviewState   string
+	QAState       string
+	PipelineState string
+	PipelineStage string
+	IsReady       bool
+	ClaimedByID   string
+	ClaimedAt     *time.Time
+	RecentKinds   []RecentKindRow
+}
+
 // CloseRequest is the input to Close. SPEC §4.4.
 type CloseRequest struct {
 	ItemID string
@@ -838,6 +874,100 @@ func Get(ctx context.Context, id string) (*Item, error) {
 		return nil, err
 	}
 	return item, nil
+}
+
+// GetState returns the four state dimensions + materialised
+// pipeline_stage + is_ready + claim columns + the per-kind
+// `recent_kinds` aggregate from workitems.comments. SPEC §6.2 Tool 14
+// (lines 1727-1754).
+//
+// Read-side org gate: the item lookup uses rbac.For (same pattern as
+// Get), so a cross-org item_id surfaces as NotFound to the caller. The
+// recent_kinds query is scoped to the resolved item_id — no separate
+// org predicate is required because the item lookup above already
+// validated the caller's org owns the row, and workitems.comments.item_id
+// is a FK to workitems.items.id (cross-org comments are impossible by
+// construction).
+//
+// `recent_kinds` SQL shape: `SELECT DISTINCT ON (kind) kind, status,
+// id, created_at FROM workitems.comments WHERE item_id = $1 ORDER BY
+// kind ASC, created_at DESC`. Postgres' DISTINCT ON returns the FIRST
+// row per `kind` partition under the supplied ORDER BY, so the
+// secondary `created_at DESC` term picks the most recent comment per
+// kind. The outer ordering also drives wire stability (kind ASC) so
+// downstream consumers see a deterministic sequence.
+//
+// No covering index on (kind, created_at DESC) ships in P01 — the
+// query plan against a small comment table per item is acceptable.
+// Index addition is deferred to the NFR-1 latency harness (bead
+// unblock-tv8.24) per the D-6 INVESTIGATION risk R6.
+//
+//encore:api private method=POST path=/workitems.GetState
+func GetState(ctx context.Context, req *GetStateRequest) (*GetStateResponse, error) {
+	if req == nil || req.ItemID == "" {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing item_id"}
+	}
+	identity, ok := callerIdentity(ctx)
+	if !ok {
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "no caller identity"}
+	}
+
+	// Item read via rbac.For pins the org gate at the SQL layer; an
+	// item_id from another org surfaces as NotFound here, never as a
+	// stale row leak to the MCP wire.
+	itemRows, err := rbac.For[itemRow](identity, "workitems.items").
+		Where("id = $1", req.ItemID).
+		Run(ctx)
+	if err != nil {
+		rlog.Error("workitems: get_state item fetch failed", "err", err, "item_id", req.ItemID)
+		return nil, &errs.Error{Code: errs.Internal, Message: "get_state fetch failed"}
+	}
+	if len(itemRows) == 0 {
+		return nil, &errs.Error{Code: errs.NotFound, Message: "item not found"}
+	}
+	item, err := itemFromRow(ctx, itemRows[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// recent_kinds: one row per distinct comment kind on this item, with
+	// the most recent (status, comment_id, created_at) per kind. Ordered
+	// by kind ASC for deterministic wire output.
+	kindRows, err := db.Query(ctx,
+		`SELECT DISTINCT ON (kind) kind, status, id, created_at
+		   FROM workitems.comments
+		  WHERE item_id = $1
+		  ORDER BY kind ASC, created_at DESC`,
+		req.ItemID,
+	)
+	if err != nil {
+		rlog.Error("workitems: get_state recent_kinds query failed", "err", err, "item_id", req.ItemID)
+		return nil, &errs.Error{Code: errs.Internal, Message: "get_state recent_kinds fetch failed"}
+	}
+	defer kindRows.Close()
+	var recent []RecentKindRow
+	for kindRows.Next() {
+		var r RecentKindRow
+		if err := kindRows.Scan(&r.Kind, &r.Status, &r.CommentID, &r.CreatedAt); err != nil {
+			return nil, &errs.Error{Code: errs.Internal, Message: "get_state recent_kinds scan failed"}
+		}
+		recent = append(recent, r)
+	}
+	if err := kindRows.Err(); err != nil {
+		return nil, &errs.Error{Code: errs.Internal, Message: "get_state recent_kinds iter failed"}
+	}
+
+	return &GetStateResponse{
+		ImplState:     item.ImplState,
+		ReviewState:   item.ReviewState,
+		QAState:       item.QAState,
+		PipelineState: item.PipelineState,
+		PipelineStage: item.PipelineStage,
+		IsReady:       item.IsReady,
+		ClaimedByID:   item.ClaimedByID,
+		ClaimedAt:     item.ClaimedAt,
+		RecentKinds:   recent,
+	}, nil
 }
 
 // GetTrail returns the item + its comments + incoming/outgoing edges +

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -228,7 +228,15 @@ type RecentKindRow struct {
 // columns surface as plain strings (never pointers) because every item
 // row has them populated via column defaults — the empty string here
 // would indicate a corrupted row.
+//
+// ProjectID is the item's project scope, sourced from the same row
+// already loaded by the rbac.For org gate. It is exposed so the MCP
+// handler can stamp `state.Call.ProjectID` on the audit row (SPEC §8.1
+// requires per-call project_id for dashboard filtering) and surface a
+// top-level `project_id` field on the §6.2 Tool 14 wire envelope (the
+// state surface is contextually scoped to a project).
 type GetStateResponse struct {
+	ProjectID     string
 	ImplState     string
 	ReviewState   string
 	QAState       string
@@ -958,6 +966,7 @@ func GetState(ctx context.Context, req *GetStateRequest) (*GetStateResponse, err
 	}
 
 	return &GetStateResponse{
+		ProjectID:     item.ProjectID,
 		ImplState:     item.ImplState,
 		ReviewState:   item.ReviewState,
 		QAState:       item.QAState,

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -1734,6 +1734,7 @@ observes `qa_state='failed'`, it resets both review and qa to
 
 // structuredContent
 {
+  "project_id":     "<ULID>",   // project owning this work item (for audit correlation and client-side scoping)
   "impl_state":     "...",
   "review_state":   "...",
   "qa_state":       "...",


### PR DESCRIPTION
## unblock-tv8.21: D-6 MCP Tools 13–14 (set_state, get_state)

Implements MCP tools 13 (set_state) and 14 (get_state) per SPEC §6.2 and the bead's acceptance criteria for the five PRD §6.2 state-machine invariants.

### What was done

- New MCP handlers `set_state` and `get_state` registered via `toolRegistrars` in `transport.go`.
- `set_state` wraps `workitems.SetStateColumns` (existing invariant enforcement) and best-effort appends an optional `intent_comment` via `workitems.AppendComment` after the state mutation commits.
- `get_state` delegates 100% to a new private RPC `workitems.GetState`, which composes the state columns (org-gated via `rbac.For`) with the per-kind `recent_kinds` aggregate (`SELECT DISTINCT ON (kind) … ORDER BY kind, created_at DESC`).
- `errmap.go` amended to surface `Meta["invariant"]` as both `details.invariant` (machine-readability per spec §6.2 line 1645) and `details.rejection_reason` (legacy mirror). Audit-row `RejectionReason` picker prefers `invariant` after `missing`.

### Files changed

- `apps/api/mcp/handler_set_state.go` (new)
- `apps/api/mcp/handler_get_state.go` (new)
- `apps/api/mcp/transport.go` (handler registration)
- `apps/api/mcp/errmap.go` (envelope + audit-row keys)
- `apps/api/workitems/workitems.go` (new `GetStateRequest`/`GetStateResponse`/`RecentKindRow` types and `GetState` private RPC)
- `apps/api/shared/mcpaudittest/d6_tools_test.go` (new, 9 tests covering AC #1–5, intent_comment atomicity, intent_comment validation, get_state shape, audit row tool_name)

### Decisions

None new — all design choices were pre-resolved by the orchestrator DECISION comment on 2026-05-18:
1. Errmap amendment in-scope (single file touch, no deprecated alias).
2. `intent_comment` non-transactional (SetStateColumns first, AppendComment best-effort; failure logged via rlog).
3. New `workitems.GetState` private RPC owns `recent_kinds`; MCP handler does no inline SQL.

### Deviations

None — implemented as spec and per the orchestrator DECISION.

## Test plan

- [x] `encore test ./shared/mcpaudittest/... ./mcp/... ./workitems/...` all pass
- [x] Full `encore test ./...` clean across all 16 service packages
- [x] `go fmt ./...` produces zero diffs
- [x] `go vet ./...` produces zero findings
- [x] `encore check` produces zero findings
- [x] D-6 acceptance tests cover I-1 auto-reset, I-2/I-4/I-5 rejections (envelope `data.invariant` populated), `intent_comment` atomicity + validation, `get_state` state surface, `recent_kinds` per-kind picker, audit row tool_name