### PR TITLE
unblock-tv8.15: C-6 RBAC suite extensions for workitems and deps

### DIFF
--- a/apps/api/shared/rbactest/matrix.go
+++ b/apps/api/shared/rbactest/matrix.go
@@ -117,8 +117,11 @@ type TableSpec struct {
 // AuthOrgTables is the closed set of auth + org + workitems + deps
 // schema tables the B-3 (unblock-tv8.9) + C-6 (unblock-tv8.15) sweeps
 // cover. E-3 / unblock-tv8.25 appends the remaining
-// deps.cascade_events + mcp.* + memory.* + boards.* entries. The
-// slice is exported and additive so the final bead only adds lines.
+// deps.cascade_events + mcp.* + memory.* + boards.* entries.
+// KindAuthorizeOnly additions are pure append-only on this slice;
+// KindOrgScoped additions also require a paired typed row struct
+// plus a new case in rbactest_test.go's selectScopedOrgIDs switch
+// mirroring the table's column shape.
 //
 // Classification rationale (verified against migrations
 // apps/api/db/migrations/0020_auth.up.sql lines 11-66,

--- a/apps/api/shared/rbactest/matrix.go
+++ b/apps/api/shared/rbactest/matrix.go
@@ -114,15 +114,16 @@ type TableSpec struct {
 	Kind TableKind
 }
 
-// AuthOrgTables is the closed set of P01 auth + org schema tables this
-// bead (B-3 / unblock-tv8.9) sweeps. C-6 / unblock-tv8.15 appends
-// workitems.* + deps.* entries; E-3 / unblock-tv8.25 appends mcp.* +
-// memory.* + boards.* entries. The slice is exported and additive so
-// the two follow-up beads only add lines.
+// AuthOrgTables is the closed set of auth + org + workitems + deps
+// schema tables the B-3 (unblock-tv8.9) + C-6 (unblock-tv8.15) sweeps
+// cover. E-3 / unblock-tv8.25 appends the remaining
+// deps.cascade_events + mcp.* + memory.* + boards.* entries. The
+// slice is exported and additive so the final bead only adds lines.
 //
 // Classification rationale (verified against migrations
-// apps/api/db/migrations/0020_auth.up.sql lines 11-66 and
-// 0030_org.up.sql lines 7-62):
+// apps/api/db/migrations/0020_auth.up.sql lines 11-66,
+// 0030_org.up.sql lines 7-62, 0040_workitems.up.sql lines 46-225,
+// and 0050_deps.up.sql lines 13-26):
 //
 //   - auth.users / auth.oauth_tokens / auth.sessions — no org_id column;
 //     rbac.For would emit `<table>.org_id = $1` which Postgres rejects
@@ -135,6 +136,21 @@ type TableSpec struct {
 //     org_id). Same Authorize-gate treatment.
 //   - org.projects — has org_id column; rbac.For-scoped.
 //   - org.members — has org_id column; rbac.For-scoped.
+//   - workitems.items — has org_id column AND is reached through both
+//     surfaces: rbac.For for row-leak reads (workitems.go:870, 926,
+//     996, 1569, 1753) AND org.Authorize for write/delete gating
+//     (deps.AddEdge, workitems.SetStateColumns). The matrix carries
+//     TWO TableSpec entries on the same Name: one KindOrgScoped (read
+//     row-leak only) and one KindAuthorizeOnly (read/write/delete
+//     policy decision). SPEC §10.1 line 2356-2361 names exactly this
+//     dual treatment.
+//   - workitems.comments — no org_id column (scoped via parent
+//     items.org_id; workitems.go:1010-1020). Authorize-only gate.
+//   - workitems.trail — virtual resource (no SQL table; resource
+//     identifier at apps/api/org/org.go:111 gating workitems.GetTrail).
+//     Authorize-only.
+//   - deps.dependencies — no org_id column (gated at the MCP layer via
+//     org.Authorize; deps.go:18-25 header doc). Authorize-only.
 var AuthOrgTables = []TableSpec{
 	{Name: "auth.users", Kind: KindAuthorizeOnly},
 	{Name: "auth.oauth_tokens", Kind: KindAuthorizeOnly},
@@ -143,6 +159,12 @@ var AuthOrgTables = []TableSpec{
 	{Name: "org.project_members", Kind: KindAuthorizeOnly},
 	{Name: "org.projects", Kind: KindOrgScoped},
 	{Name: "org.members", Kind: KindOrgScoped},
+	// C-6 (unblock-tv8.15): workitems + deps surfaces.
+	{Name: "workitems.items", Kind: KindOrgScoped},
+	{Name: "workitems.items", Kind: KindAuthorizeOnly},
+	{Name: "workitems.comments", Kind: KindAuthorizeOnly},
+	{Name: "workitems.trail", Kind: KindAuthorizeOnly},
+	{Name: "deps.dependencies", Kind: KindAuthorizeOnly},
 }
 
 // agentPermittedResources mirrors the org.agentReadWriteResources map

--- a/apps/api/shared/rbactest/rbactest_test.go
+++ b/apps/api/shared/rbactest/rbactest_test.go
@@ -167,14 +167,29 @@ func expectAuthorizeOK(role, resource, action string) bool {
 // shapes. The subtest tree is deliberately deep so a CI failure
 // reads as a navigable path.
 //
-// Tuple count under B-3 (auth + org schemas):
+// Tuple count under B-3 + C-6 (auth + org + workitems + deps
+// schemas):
 //   - org axes:      2 * 2 = 4 (caller × target)
 //   - role axis:     5
-//   - tables:        7 (5 KindAuthorizeOnly + 2 KindOrgScoped)
+//   - tables:        12 entries in AuthOrgTables (9 KindAuthorizeOnly +
+//     3 KindOrgScoped). Note: workitems.items appears TWICE — once
+//     under each kind — because the production code reaches the
+//     table through BOTH surfaces (rbac.For for read row-leak;
+//     org.Authorize for write/delete policy gating). SPEC §10.1 line
+//     2356-2361 names the dual treatment explicitly.
 //   - actions:       3 (read/write/delete) for KindAuthorizeOnly,
 //     1 (read only) for KindOrgScoped
 //
-// = 4 * 5 * (5*3 + 2*1) = 4 * 5 * 17 = 340 subtests.
+// = 4 * 5 * (9*3 + 3*1) = 4 * 5 * 30 = 600 subtests.
+//
+// Naming note: workitems.items appears under both kinds, so for that
+// table the read-action subtest exists in two shapes. The OrgScoped
+// read asserts row-level leak (rbac.For); the AuthorizeOnly read
+// asserts the policy-decision (org.Authorize). The subtest names
+// collide on action=read; Go's testing package auto-disambiguates
+// duplicates with a "#01" suffix on the second occurrence. Both
+// assertions remain independent — they exercise different code
+// paths against the same table.
 func TestRBACMatrix(t *testing.T) {
 	if fixture == nil {
 		t.Fatalf("rbactest: fixture is nil; SeedFixture must run from TestMain before this test fires")
@@ -393,6 +408,61 @@ type orgMembersRow struct {
 	CreatedAt time.Time
 }
 
+// workitemsItemsRow mirrors workitems.items column order verbatim
+// per migration 0040_workitems.up.sql lines 46-135 + the trailing
+// `fts` tsvector column added by ALTER TABLE at lines 151-155
+// (28 fields total). rbac.For emits `SELECT *` and scans by ordinal
+// (apps/api/shared/rbac/rbac.go line 413), so the field count and
+// declaration order MUST match the schema's column declaration
+// order EXACTLY — including the trailing fts column. Field shapes
+// (text vs *text vs time.Time vs *time.Time vs []byte) match
+// apps/api/workitems/helpers.go's itemRow type verbatim; the type
+// is re-declared here (not imported) so a drift between the suite
+// and the production scanner surfaces as a test failure instead of
+// a silent compile-time sync.
+//
+// The suite reads only OrgID off this struct for the row-leak
+// assertion; the other fields exist purely to keep the column
+// count aligned with the rbac builder's reflection scanner.
+type workitemsItemsRow struct {
+	ID                  string
+	OrgID               string
+	ProjectID           *string
+	MilestoneID         *string
+	ParentID            *string
+	DiscoveredFromID    *string
+	Type                string
+	Title               string
+	Body                string
+	Status              string
+	Priority            string
+	PipelineStage       string
+	AgentKind           *string
+	ImplState           string
+	ReviewState         string
+	QAState             string
+	PipelineState       string
+	Severity            *string
+	KindOfFinding       *string
+	ClaimedByID         *string
+	ClaimedByAgent      *string
+	ClaimedAt           *time.Time
+	IsReady             bool
+	MilestoneAssignedAt *time.Time
+	MilestoneAssignedBy *string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	ClosedAt            *time.Time
+	// FTS is the generated tsvector column appended by ALTER TABLE
+	// in 0040_workitems.up.sql line 151-155. pgx v5.7 has no
+	// registered tsvector type, so the driver delivers the text
+	// representation as a raw byte slice. The field is unused
+	// downstream — it exists only to keep ordinal positions aligned
+	// with the migration so rbac.For's reflection scanner does not
+	// error on column count.
+	FTS []byte
+}
+
 // selectScopedOrgIDs issues a rbac.For[T] read against the named
 // table and returns the org_id of every row the caller sees. The
 // per-table T shape is selected by the switch below; the only
@@ -412,6 +482,17 @@ func selectScopedOrgIDs(ctx context.Context, id auth.Identity, table string) ([]
 
 	case "org.members":
 		rows, err := rbac.For[orgMembersRow](id, "org.members").Run(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.OrgID)
+		}
+		return out, nil
+
+	case "workitems.items":
+		rows, err := rbac.For[workitemsItemsRow](id, "workitems.items").Run(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/apps/api/shared/rbactest/seed.go
+++ b/apps/api/shared/rbactest/seed.go
@@ -87,6 +87,21 @@ type Fixture struct {
 	// validated end-to-end and the C-6/E-3 extensions inherit a
 	// non-empty mcp.api_keys table.
 	APIKeyRows map[string]string
+
+	// Items maps the OrgA / OrgB label to the persisted ULID for the
+	// canonical workitems.items row seeded under each org. Used by
+	// C-6 (unblock-tv8.15) as KindOrgScoped row-leak bait for
+	// workitems.items (rbac.For path) and as the parent of the
+	// workitems.comments row below.
+	Items map[string]string
+
+	// Comments maps the OrgA / OrgB label to the persisted ULID for
+	// the canonical workitems.comments row seeded under each org.
+	// The comments table has no org_id column; its cross-tenant gate
+	// is org.Authorize on the parent item's org. Seeded so the FK
+	// chain (comments.item_id → items.id → items.org_id) is
+	// exercised end-to-end.
+	Comments map[string]string
 }
 
 // userKey is the composite key for Fixture.Users. Declared as a
@@ -116,6 +131,8 @@ func SeedFixture(ctx context.Context, db *sqldb.Database) (*Fixture, error) {
 		Users:      make(map[userKey]string, 8),
 		Projects:   make(map[string]string, 2),
 		APIKeyRows: make(map[string]string, 2),
+		Items:      make(map[string]string, 2),
+		Comments:   make(map[string]string, 2),
 	}
 
 	// Per-side seeding. Both sides get the identical row complement;
@@ -263,6 +280,56 @@ func seedSide(ctx context.Context, db *sqldb.Database, fx *Fixture, orgLabel str
 		return fmt.Errorf("insert org.project_members: %w", err)
 	}
 
+	// 4a. workitems.items row (C-6 / unblock-tv8.15). Seeds the
+	//     KindOrgScoped row-leak bait for workitems.items reads
+	//     through rbac.For AND the parent row for the
+	//     workitems.comments seed below. Constraints:
+	//       - type='task' keeps items_finding_required_fields_chk
+	//         vacuous (severity/kind_of_finding/discovered_from_id/
+	//         parent_id all NULL is legal for non-findings).
+	//       - status='Backlog' + claimed_by_id NULL + claimed_at NULL
+	//         satisfies items_claim_status_chk's first leg.
+	//       - is_ready=false is the schema DEFAULT; written explicit
+	//         here so a future ALTER never silently flips the seed.
+	itemID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("item ulid: %w", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, is_ready)
+		 VALUES ($1, $2, $3, 'task', $4, 'Backlog', false)`,
+		itemID, orgID, projectID, fmt.Sprintf("rbactest item %s", orgLabel),
+	); err != nil {
+		return fmt.Errorf("insert workitems.items: %w", err)
+	}
+	fx.Items[orgLabel] = itemID
+
+	// 4b. workitems.comments row (C-6 / unblock-tv8.15). The
+	//     comments table has no org_id column — its cross-tenant
+	//     gate is org.Authorize on the parent item's org. Seeded
+	//     primarily so the FK chain
+	//     (comments.item_id → items.id → items.org_id) is exercised
+	//     end-to-end and future C-6 KindOrgScoped extensions (if
+	//     workitems.comments ever grows an org_id column) inherit a
+	//     non-empty fixture. Constraints:
+	//       - kind='general' is in the comments_kind_chk allow-list.
+	//       - author_id NOT NULL satisfies comments_author_chk.
+	commentID, err := ulid.New()
+	if err != nil {
+		return fmt.Errorf("comment ulid: %w", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO workitems.comments
+		   (id, item_id, author_id, kind, body)
+		 VALUES ($1, $2, $3, 'general', $4)`,
+		commentID, itemID, ownerID,
+		fmt.Sprintf("rbactest comment %s", orgLabel),
+	); err != nil {
+		return fmt.Errorf("insert workitems.comments: %w", err)
+	}
+	fx.Comments[orgLabel] = commentID
+
 	// 5. mcp.api_keys row foreshadowing the C-6 / E-3 extension. Not
 	//    asserted on in B-3; seed only so the FK chain is exercised
 	//    and the follow-up beads inherit a non-empty table.
@@ -296,10 +363,12 @@ func seedSide(ctx context.Context, db *sqldb.Database, fx *Fixture, orgLabel str
 // Teardown removes every row this Fixture installed. Called from
 // TestMain on the way out. The org.organizations rows cascade-delete
 // everything reachable (members, projects, project_members,
-// api_keys, tool_calls, …) per the schema's ON DELETE CASCADE
-// chain. auth.users / auth.oauth_tokens / auth.sessions are NOT
-// reachable via the org_id cascade — they are deleted separately,
-// keyed by the ids the fixture installed.
+// api_keys, tool_calls, workitems.items via items.org_id +
+// items.project_id, workitems.comments via comments.item_id, …)
+// per the schema's ON DELETE CASCADE chain. auth.users /
+// auth.oauth_tokens / auth.sessions are NOT reachable via the
+// org_id cascade — they are deleted separately, keyed by the ids
+// the fixture installed.
 //
 // Teardown is best-effort: failures are reported but do not abort.
 // The unique-by-ULID safety net in SeedFixture ensures a partial


### PR DESCRIPTION
## unblock-tv8.15: C-6 RBAC suite extensions for workitems and deps schemas

Extends the `apps/api/shared/rbactest/` exhaustive RBAC regression
suite from B-3's auth+org coverage to the C-group schemas per SPEC
§10.1. Zero cross-tenant leaks across every new (caller-org,
target-org, role, table, action) tuple.

### What was done

- `matrix.go`: appended five `TableSpec` rows to `AuthOrgTables` —
  `workitems.items` (both `KindOrgScoped` and `KindAuthorizeOnly`,
  dual-shape per the matrix.go doc-comment and SPEC §10.1 line
  2356-2361), `workitems.comments`, `workitems.trail`,
  `deps.dependencies` (all KindAuthorizeOnly).
- `seed.go`: extended `Fixture` with `Items` and `Comments` maps and
  seeded one `workitems.items` row (type='task', status='Backlog' to
  keep `items_finding_required_fields_chk` and
  `items_claim_status_chk` vacuous) plus one `workitems.comments` row
  (kind='general', author_id=owner) per side.
- `rbactest_test.go`: added `workitemsItemsRow` (28 fields including
  trailing FTS `[]byte` to match `rbac.For`'s SELECT * reflection
  scanner), extended `selectScopedOrgIDs` switch, updated the
  tuple-count doc-comment from 340 to 600.

### Files changed

- `apps/api/shared/rbactest/matrix.go`
- `apps/api/shared/rbactest/seed.go`
- `apps/api/shared/rbactest/rbactest_test.go`

### Decisions

- **workitems.items dual shape**: added two `TableSpec` entries on the
  same `Name` (one `KindOrgScoped` for rbac.For row-leak; one
  `KindAuthorizeOnly` for read/write/delete policy decision). This is
  what DRIFT-2 in the investigation comment anticipated and what the
  existing matrix.go:84-86 doc-comment names directly. The
  consequence: `action=read` subtest names for workitems.items appear
  twice; Go's `t.Run` auto-disambiguates the second occurrence with a
  `#01` suffix.

### Deviations

None — implemented as spec.

### Verification

- `encore test ./apps/api/shared/rbactest/... -run TestRBACMatrix
  -count=1 -v` — 600 PASS, zero FAIL.
- `encore check` — clean.
- `go fmt ./...` + `go vet ./shared/rbactest/...` — clean.