### PR TITLE
unblock-tv8.50: tenant-gate cascade BFS and derivation reads

### DIFF
--- a/apps/api/deps/cascade_subscriber.go
+++ b/apps/api/deps/cascade_subscriber.go
@@ -137,7 +137,16 @@ func handleCascadeRequested(ctx context.Context, msg *CascadeRequested) error {
 	//    collecting affected ids. The seed itself is INCLUDED so its
 	//    own pipeline_stage is recomputed (a status='Done' flip can
 	//    move the triggered item's pipeline_stage to 'Done').
-	affected, err := bfsForwardBlocksClosure(ctx, msg.TriggeredByItemID)
+	//
+	//    Tenant defence-in-depth (unblock-tv8.50): the BFS is gated on
+	//    msg.OrgID and msg.ProjectID via a JOIN against workitems.items
+	//    in both the anchor and the recursive step. Cross-tenant edges
+	//    are already rejected upstream by deps.AddEdge (deps.go §6.5),
+	//    so in practice the walk stays within one tenant; the JOIN
+	//    enforces the property structurally so a future regression in
+	//    the writer path or a direct DDL bypass cannot leak a cascade
+	//    across orgs/projects.
+	affected, err := bfsForwardBlocksClosure(ctx, msg.TriggeredByItemID, msg.OrgID, msg.ProjectID)
 	if err != nil {
 		rlog.Error("deps: cascade subscriber BFS failed",
 			"err", err, "reason", msg.Reason,
@@ -147,8 +156,11 @@ func handleCascadeRequested(ctx context.Context, msg *CascadeRequested) error {
 
 	// 2. Recompute pipeline_stage per §5.7.1 for every affected item.
 	//    Idempotent UPDATE: WHERE pipeline_stage <> $new short-circuits
-	//    a no-op write on re-delivery.
-	if err := recomputePipelineStageForAffected(ctx, affected); err != nil {
+	//    a no-op write on re-delivery. The derivation reads are also
+	//    tenant-gated (unblock-tv8.50) — symmetric defence-in-depth so a
+	//    tampered `affected` set (e.g. a tenant-bypassing id injected
+	//    between BFS and derivation read) cannot pull another org's row.
+	if err := recomputePipelineStageForAffected(ctx, affected, msg.OrgID, msg.ProjectID); err != nil {
 		rlog.Error("deps: cascade subscriber pipeline_stage recompute failed",
 			"err", err, "reason", msg.Reason,
 			"event_id", msg.EventID, "triggered_by", msg.TriggeredByItemID)
@@ -196,23 +208,59 @@ func handleCascadeRequested(ctx context.Context, msg *CascadeRequested) error {
 // — Postgres's `WHERE r.depth < $N` terminates the recursion at the
 // declared cap. The subscriber emits a Warn on truncation and proceeds
 // with the bounded prefix (the cap is locked at 256 per RP01-3).
-func bfsForwardBlocksClosure(ctx context.Context, seedID string) ([]string, error) {
+//
+// Tenant predicate (unblock-tv8.50 / defence-in-depth): both the
+// anchor and the recursive step JOIN workitems.items and gate on
+// (i.org_id = orgID AND ($projectID = ” OR i.project_id = projectID)).
+// Cross-tenant rows in deps.dependencies are impossible today because
+// deps.AddEdge (§6.5) rejects them upstream, but a future writer-path
+// regression or a direct DDL bypass would otherwise leak a cascade
+// across orgs/projects via the recursive walk. The JOIN closes that
+// gap structurally — its cost is one items_pk index probe per edge
+// row, well inside the AR-8 (256) depth cap and Law 7's < 2s envelope.
+//
+// The deps.dependencies schema has no org_id / project_id columns
+// (see apps/api/db/migrations/0050_deps.up.sql), so tenant filtering
+// MUST be expressed via JOIN against workitems.items. The same
+// shape is used by deps.recomputeReady (recompute.go:50-69).
+//
+// projectID may be empty: workitems.items.project_id is nullable
+// (org-scoped items are permitted by §9.4.2). The `$N = ” OR
+// project_id = $N` shape mirrors deps.go:767-768 (CascadeEvents read
+// path) — when projectID is empty the predicate degrades to org_id
+// alone, when non-empty it narrows to that project.
+//
+// If the publisher's (orgID, projectID) disagrees with the seed's
+// actual row, the anchor SELECT returns no rows, the recursive step
+// has no seed to walk from, and the function returns an empty slice.
+// The audit row INSERT in insertCascadeEventRow still writes with
+// msg.OrgID as authoritative — the audit captures what was REQUESTED,
+// not what was REACHABLE. This is intentional: the publisher's claim
+// must remain visible in the audit even when the walk yields nothing.
+func bfsForwardBlocksClosure(ctx context.Context, seedID, orgID, projectID string) ([]string, error) {
 	// Read up to cascadeBFSMaxDepth+1 rows so we can detect cap hits
 	// — when the result count exceeds the cap, we know the walk
 	// terminated on depth rather than exhaustion of the graph.
 	rows, err := db.Query(ctx,
 		`WITH RECURSIVE reachable(id, depth) AS (
-		         SELECT $1::text, 0
+		         SELECT i.id, 0
+		           FROM workitems.items i
+		          WHERE i.id = $1
+		            AND i.org_id = $3
+		            AND ($4 = '' OR i.project_id = $4)
 		         UNION ALL
 		         SELECT d.to_item, r.depth + 1
 		           FROM deps.dependencies d
 		           JOIN reachable r ON d.from_item = r.id
+		           JOIN workitems.items i ON i.id = d.to_item
 		          WHERE d.kind = 'blocks'
 		            AND r.depth < $2
+		            AND i.org_id = $3
+		            AND ($4 = '' OR i.project_id = $4)
 		       )
 		       SELECT DISTINCT id FROM reachable
 		       ORDER BY id`,
-		seedID, cascadeBFSMaxDepth,
+		seedID, cascadeBFSMaxDepth, orgID, projectID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("bfs query: %w", err)
@@ -267,24 +315,39 @@ type itemDerivationInputs struct {
 // bounded at 256. The per-item UPDATE includes the value-equality
 // guard so repeated delivery converges to the same row state.
 //
+// Tenant predicate (unblock-tv8.50 / defence-in-depth): both reads are
+// gated by (org_id = orgID AND ($projectID = ” OR project_id =
+// projectID)). Today the BFS already filters the input set by the same
+// predicate, so the predicate here is redundant in the happy path —
+// but it is essential for symmetric defence-in-depth: a tampered
+// `affected` slice (a tenant-bypassing id injected between BFS and
+// derivation read by future code, or a debug-path call that bypasses
+// the BFS) cannot pull another org's row. workitems.comments has no
+// org_id column, so the predicate is enforced via a sub-SELECT against
+// workitems.items keyed on item_id. The per-item UPDATE WHERE clause
+// adds the same predicate so a write cannot escape the publisher's
+// tenant either.
+//
 // The is_ready column is NEVER written here. The lint analyzer
 // (apps/api/shared/lint/no_direct_is_ready_write.go) enforces that
 // every UPDATE in this file targets pipeline_stage only.
-func recomputePipelineStageForAffected(ctx context.Context, affected []string) error {
+func recomputePipelineStageForAffected(ctx context.Context, affected []string, orgID, projectID string) error {
 	if len(affected) == 0 {
 		return nil
 	}
 
 	// Fetch the four state columns + status + closed_at for every
-	// affected item.
+	// affected item. Tenant-gated read (unblock-tv8.50).
 	rowMap := make(map[string]*itemDerivationInputs, len(affected))
 	rows, err := db.Query(ctx,
 		`SELECT id, status, pipeline_stage,
 		        impl_state, review_state, qa_state, pipeline_state,
 		        (closed_at IS NOT NULL)
 		   FROM workitems.items
-		  WHERE id = ANY($1::text[])`,
-		affected,
+		  WHERE id = ANY($1::text[])
+		    AND org_id = $2
+		    AND ($3 = '' OR project_id = $3)`,
+		affected, orgID, projectID,
 	)
 	if err != nil {
 		return fmt.Errorf("affected state read: %w", err)
@@ -308,14 +371,19 @@ func recomputePipelineStageForAffected(ctx context.Context, affected []string) e
 	rows.Close()
 
 	// Batched comment existence predicate (SPEC §5.7.1 line 781-787).
+	// workitems.comments has no org_id column — gate via sub-SELECT
+	// against workitems.items keyed on item_id (unblock-tv8.50).
 	commentRows, err := db.Query(ctx,
-		`SELECT item_id,
-		        max(CASE WHEN kind = 'review'        THEN 1 ELSE 0 END) AS has_review,
-		        max(CASE WHEN kind = 'investigation' THEN 1 ELSE 0 END) AS has_investigation
-		   FROM workitems.comments
-		  WHERE item_id = ANY($1::text[])
-		  GROUP BY item_id`,
-		affected,
+		`SELECT c.item_id,
+		        max(CASE WHEN c.kind = 'review'        THEN 1 ELSE 0 END) AS has_review,
+		        max(CASE WHEN c.kind = 'investigation' THEN 1 ELSE 0 END) AS has_investigation
+		   FROM workitems.comments c
+		   JOIN workitems.items i ON i.id = c.item_id
+		  WHERE c.item_id = ANY($1::text[])
+		    AND i.org_id = $2
+		    AND ($3 = '' OR i.project_id = $3)
+		  GROUP BY c.item_id`,
+		affected, orgID, projectID,
 	)
 	if err != nil {
 		return fmt.Errorf("affected comments read: %w", err)
@@ -344,8 +412,19 @@ func recomputePipelineStageForAffected(ctx context.Context, affected []string) e
 	for _, id := range affected {
 		inp, ok := rowMap[id]
 		if !ok {
-			// Item disappeared between BFS and derivation read
-			// (FK ON DELETE CASCADE on org/project) — skip silently.
+			// Item not present in the tenant-filtered derivation read.
+			// Two reasons this can happen:
+			//   (a) the row was deleted between BFS and derivation
+			//       read (FK ON DELETE CASCADE on org/project); the
+			//       BFS predicate would also drop it on a fresh walk,
+			//       but the BFS already committed its snapshot.
+			//   (b) (post unblock-tv8.50) the row's tenant disagrees
+			//       with msg.OrgID / msg.ProjectID. This is now also
+			//       blocked at the BFS layer for happy-path cascades,
+			//       but a future caller that bypasses the BFS and
+			//       feeds this function a tampered slice still cannot
+			//       reach a cross-tenant row.
+			// Either way: skip silently. No write occurs.
 			continue
 		}
 		newStage := derivePipelineStage(inp)
@@ -353,11 +432,18 @@ func recomputePipelineStageForAffected(ctx context.Context, affected []string) e
 			// Idempotent no-op. Skip the UPDATE.
 			continue
 		}
+		// Tenant-gated UPDATE (unblock-tv8.50): the WHERE clause
+		// repeats the org_id / project_id predicate so a write cannot
+		// escape the publisher's tenant even if the rowMap lookup
+		// above were ever defeated by a future refactor.
 		if _, err := db.Exec(ctx,
 			`UPDATE workitems.items
 			    SET pipeline_stage = $2
-			  WHERE id = $1 AND pipeline_stage <> $2`,
-			id, newStage,
+			  WHERE id = $1
+			    AND pipeline_stage <> $2
+			    AND org_id = $3
+			    AND ($4 = '' OR project_id = $4)`,
+			id, newStage, orgID, projectID,
 		); err != nil {
 			return fmt.Errorf("pipeline_stage update %s: %w", id, err)
 		}

--- a/apps/api/deps/cascade_subscriber.go
+++ b/apps/api/deps/cascade_subscriber.go
@@ -160,7 +160,7 @@ func handleCascadeRequested(ctx context.Context, msg *CascadeRequested) error {
 	//    tenant-gated (unblock-tv8.50) — symmetric defence-in-depth so a
 	//    tampered `affected` set (e.g. a tenant-bypassing id injected
 	//    between BFS and derivation read) cannot pull another org's row.
-	if err := recomputePipelineStageForAffected(ctx, affected, msg.OrgID, msg.ProjectID); err != nil {
+	if err := recomputePipelineStageForAffected(ctx, affected, msg.OrgID, msg.ProjectID, msg.EventID); err != nil {
 		rlog.Error("deps: cascade subscriber pipeline_stage recompute failed",
 			"err", err, "reason", msg.Reason,
 			"event_id", msg.EventID, "triggered_by", msg.TriggeredByItemID)
@@ -331,7 +331,7 @@ type itemDerivationInputs struct {
 // The is_ready column is NEVER written here. The lint analyzer
 // (apps/api/shared/lint/no_direct_is_ready_write.go) enforces that
 // every UPDATE in this file targets pipeline_stage only.
-func recomputePipelineStageForAffected(ctx context.Context, affected []string, orgID, projectID string) error {
+func recomputePipelineStageForAffected(ctx context.Context, affected []string, orgID, projectID, eventID string) error {
 	if len(affected) == 0 {
 		return nil
 	}
@@ -436,7 +436,7 @@ func recomputePipelineStageForAffected(ctx context.Context, affected []string, o
 		// repeats the org_id / project_id predicate so a write cannot
 		// escape the publisher's tenant even if the rowMap lookup
 		// above were ever defeated by a future refactor.
-		if _, err := db.Exec(ctx,
+		res, err := db.Exec(ctx,
 			`UPDATE workitems.items
 			    SET pipeline_stage = $2
 			  WHERE id = $1
@@ -444,8 +444,28 @@ func recomputePipelineStageForAffected(ctx context.Context, affected []string, o
 			    AND org_id = $3
 			    AND ($4 = '' OR project_id = $4)`,
 			id, newStage, orgID, projectID,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("pipeline_stage update %s: %w", id, err)
+		}
+		// Defence-in-depth surfacing (unblock-tv8.50): the rowMap entry
+		// existed (passed the `!ok` guard above) and the in-memory
+		// derivation produced a stage that differs from the row's
+		// current value (passed the `newStage == inp.pipelineStage`
+		// guard above). The only way the tenant-gated UPDATE can write
+		// zero rows is if the row's org_id / project_id disagree with
+		// the publisher's claim — i.e. a future bypass-caller fed this
+		// function a mismatched (orgID, projectID) against an item that
+		// the BFS tenant predicate would also have dropped. Warn so the
+		// regression is visible instead of silently skipped.
+		if res.RowsAffected() == 0 {
+			rlog.Warn(
+				"pipeline_stage UPDATE no-op on tenant-mismatched item — possible cross-tenant publisher regression",
+				"item_id", id,
+				"org_id", orgID,
+				"project_id", projectID,
+				"event_id", eventID,
+			)
 		}
 	}
 	return nil

--- a/apps/api/deps/cascade_subscriber_handler_test.go
+++ b/apps/api/deps/cascade_subscriber_handler_test.go
@@ -458,3 +458,162 @@ func TestHandleCascadeRequested_DerivesPipelineStage(t *testing.T) {
 		t.Fatalf("pipeline_stage = %q, want %q (rule 9)", got, "Review")
 	}
 }
+
+// TestHandleCascadeRequested_BFS_TenantIsolation locks the
+// defence-in-depth tenant predicate added in unblock-tv8.50.
+//
+// Setup: two distinct orgs (alpha, beta). Each org has one item.
+// We bypass deps.AddEdge (which rejects cross-org edges upstream)
+// and INSERT a cross-tenant 'blocks' row directly into
+// deps.dependencies via raw SQL: alpha_seed → beta_neighbour.
+//
+// Trigger: publish CascadeRequested with OrgID = alpha, ProjectID =
+// alpha's project, TriggeredByItemID = alpha_seed, Reason = close.
+//
+// Assertions:
+//  1. The audit row's affected_item_ids contains alpha_seed but does
+//     NOT contain beta_neighbour. The BFS dropped the cross-tenant
+//     edge in the recursive step because the JOIN to workitems.items
+//     filters on (i.org_id = alpha.org_id).
+//  2. beta_neighbour's pipeline_stage is unchanged (the subscriber
+//     never wrote it — recomputePipelineStageForAffected's tenant
+//     predicate would also reject it even if the BFS had leaked).
+//
+// This test would FAIL before unblock-tv8.50 — the BFS would walk
+// the cross-tenant edge and leak alpha's cascade into beta. The
+// fix gates the BFS by msg.OrgID via JOIN workitems.items and
+// re-validates the tenant in the derivation read.
+func TestHandleCascadeRequested_BFS_TenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	alpha := seedFixtureInternal(t, ctx)
+	beta := seedFixtureInternal(t, ctx)
+
+	alphaSeed := createItemInternal(t, ctx, alpha, "Backlog")
+	betaNeighbour := createItemInternal(t, ctx, beta, "Backlog")
+
+	// Capture beta_neighbour's pipeline_stage BEFORE the cascade so
+	// we can confirm the subscriber never wrote it.
+	betaStageBefore := readPipelineStageInternal(t, ctx, betaNeighbour)
+
+	// Raw SQL bypass: deps.AddEdge would reject this with
+	// "cross-org edges are not allowed" (deps.go:247-257). The
+	// test's whole point is to simulate the latent gap — a row that
+	// somehow exists in deps.dependencies spanning two tenants
+	// (e.g. via a future writer-path regression or a direct DDL
+	// bypass).
+	edgeID := mustULIDInternal(t)
+	if _, err := db.Exec(ctx,
+		`INSERT INTO deps.dependencies (id, from_item, to_item, kind)
+		 VALUES ($1, $2, $3, 'blocks')`,
+		edgeID, alphaSeed, betaNeighbour,
+	); err != nil {
+		t.Fatalf("insert cross-tenant edge: %v", err)
+	}
+
+	eventID := mustULIDInternal(t)
+	msg := &CascadeRequested{
+		EventID:           eventID,
+		OrgID:             alpha.OrgID,
+		ProjectID:         alpha.ProjectID,
+		TriggeredByItemID: alphaSeed,
+		Reason:            "close",
+		EmittedAt:         time.Now().UTC(),
+	}
+	if err := handleCascadeRequested(ctx, msg); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+
+	// Read the audit row's affected_item_ids.
+	var affected []string
+	if err := db.QueryRow(ctx,
+		`SELECT affected_item_ids FROM deps.cascade_events
+		  WHERE event_id = $1 AND triggered_by_item_id = $2`,
+		eventID, alphaSeed,
+	).Scan(&affected); err != nil {
+		t.Fatalf("read affected_item_ids: %v", err)
+	}
+
+	// Assertion 1: alpha_seed must be IN the set (BFS includes the
+	// seed when its tenant matches the publisher).
+	seenAlpha := false
+	for _, id := range affected {
+		if id == alphaSeed {
+			seenAlpha = true
+		}
+		if id == betaNeighbour {
+			t.Fatalf("BFS leaked across tenants: affected_item_ids contains beta_neighbour %q; alpha=%q, affected=%v",
+				betaNeighbour, alphaSeed, affected)
+		}
+	}
+	if !seenAlpha {
+		t.Fatalf("alpha_seed %q missing from affected_item_ids: %v", alphaSeed, affected)
+	}
+
+	// Assertion 2: beta_neighbour's pipeline_stage must be unchanged.
+	betaStageAfter := readPipelineStageInternal(t, ctx, betaNeighbour)
+	if betaStageAfter != betaStageBefore {
+		t.Fatalf("subscriber wrote beta_neighbour.pipeline_stage across tenants: %q → %q",
+			betaStageBefore, betaStageAfter)
+	}
+}
+
+// TestHandleCascadeRequested_BFS_TenantMismatch covers the symmetric
+// edge case: publisher's OrgID disagrees with the seed item's actual
+// org_id. The anchor SELECT in the recursive CTE filters on
+// i.org_id = msg.OrgID, so the BFS returns an empty result. The
+// audit row is still written (the publisher's claim is preserved
+// for forensics) but affected_item_ids is empty and no pipeline_stage
+// write occurs anywhere.
+//
+// This locks the documented behaviour in bfsForwardBlocksClosure's
+// doc comment: "If the publisher's (orgID, projectID) disagrees with
+// the seed's actual row, the anchor SELECT returns no rows ... The
+// audit row INSERT in insertCascadeEventRow still writes with
+// msg.OrgID as authoritative — the audit captures what was REQUESTED,
+// not what was REACHABLE."
+func TestHandleCascadeRequested_BFS_TenantMismatch(t *testing.T) {
+	ctx := context.Background()
+	alpha := seedFixtureInternal(t, ctx)
+	beta := seedFixtureInternal(t, ctx)
+
+	// Seed lives in alpha; publisher claims beta.
+	seed := createItemInternal(t, ctx, alpha, "Backlog")
+	stageBefore := readPipelineStageInternal(t, ctx, seed)
+
+	eventID := mustULIDInternal(t)
+	msg := &CascadeRequested{
+		EventID:           eventID,
+		OrgID:             beta.OrgID, // disagrees with seed's actual org
+		ProjectID:         beta.ProjectID,
+		TriggeredByItemID: seed,
+		Reason:            "close",
+		EmittedAt:         time.Now().UTC(),
+	}
+	if err := handleCascadeRequested(ctx, msg); err != nil {
+		t.Fatalf("handle (tenant mismatch): %v", err)
+	}
+
+	// Audit row exists, kind = 'close', affected_item_ids is empty.
+	var kind string
+	var affected []string
+	if err := db.QueryRow(ctx,
+		`SELECT kind, affected_item_ids FROM deps.cascade_events
+		  WHERE event_id = $1 AND triggered_by_item_id = $2`,
+		eventID, seed,
+	).Scan(&kind, &affected); err != nil {
+		t.Fatalf("read cascade_events: %v", err)
+	}
+	if kind != "close" {
+		t.Fatalf("kind = %q, want %q (audit captures what was requested)", kind, "close")
+	}
+	if len(affected) != 0 {
+		t.Fatalf("affected_item_ids non-empty under tenant mismatch: %v", affected)
+	}
+
+	// Seed's pipeline_stage must be unchanged — the subscriber's
+	// derivation read filtered it out too.
+	stageAfter := readPipelineStageInternal(t, ctx, seed)
+	if stageAfter != stageBefore {
+		t.Fatalf("subscriber wrote across tenant mismatch: pipeline_stage %q → %q", stageBefore, stageAfter)
+	}
+}

--- a/apps/api/deps/cascade_subscriber_handler_test.go
+++ b/apps/api/deps/cascade_subscriber_handler_test.go
@@ -594,20 +594,43 @@ func TestHandleCascadeRequested_BFS_TenantMismatch(t *testing.T) {
 	}
 
 	// Audit row exists, kind = 'close', affected_item_ids is empty.
-	var kind string
-	var affected []string
+	// Lock the "audit captures REQUESTED, not REACHABLE" contract
+	// (cascade_subscriber.go:415-427 invariant + bfsForwardBlocksClosure
+	// doc comment): the audit row's org_id MUST be the publisher's
+	// claim (beta.OrgID), NOT the seed item's actual org_id (alpha.OrgID).
+	type auditRow struct {
+		kind      string
+		orgID     string
+		projectID string
+		affected  []string
+	}
+	var got auditRow
 	if err := db.QueryRow(ctx,
-		`SELECT kind, affected_item_ids FROM deps.cascade_events
+		`SELECT kind, org_id, project_id, affected_item_ids
+		   FROM deps.cascade_events
 		  WHERE event_id = $1 AND triggered_by_item_id = $2`,
 		eventID, seed,
-	).Scan(&kind, &affected); err != nil {
+	).Scan(&got.kind, &got.orgID, &got.projectID, &got.affected); err != nil {
 		t.Fatalf("read cascade_events: %v", err)
 	}
-	if kind != "close" {
-		t.Fatalf("kind = %q, want %q (audit captures what was requested)", kind, "close")
+	if got.kind != "close" {
+		t.Fatalf("kind = %q, want %q (audit captures what was requested)", got.kind, "close")
 	}
-	if len(affected) != 0 {
-		t.Fatalf("affected_item_ids non-empty under tenant mismatch: %v", affected)
+	if len(got.affected) != 0 {
+		t.Fatalf("affected_item_ids non-empty under tenant mismatch: %v", got.affected)
+	}
+	// Audit org_id must equal publisher's claim (beta), not seed's
+	// actual tenant (alpha). This is the locked contract: the audit
+	// captures REQUESTED, not REACHABLE — the publisher's claim
+	// remains visible in the audit even when the BFS walk yields
+	// nothing because the seed lives in a different tenant.
+	if got.orgID != beta.OrgID {
+		t.Fatalf("audit org_id = %q, want publisher's claim %q (NOT seed's actual org %q) — audit must capture REQUESTED, not REACHABLE",
+			got.orgID, beta.OrgID, alpha.OrgID)
+	}
+	if got.orgID == alpha.OrgID {
+		t.Fatalf("audit org_id leaked seed's actual tenant %q — contract violated, audit must reflect publisher's claim %q",
+			alpha.OrgID, beta.OrgID)
 	}
 
 	// Seed's pipeline_stage must be unchanged — the subscriber's


### PR DESCRIPTION
## unblock-tv8.50: BFS closure is org/project-agnostic — missing tenant predicate in recursive step

Defence-in-depth fix for the cascade subscriber. The forward 'blocks' BFS and the §5.7.1 derivation reads now filter on `(org_id, project_id)` so a cascade can never leak across tenants, even if a future writer-path regression or a direct DDL bypass admits a cross-tenant edge into `deps.dependencies`.

### What was done
- Added `(orgID, projectID)` parameters to `bfsForwardBlocksClosure` and `recomputePipelineStageForAffected` in `apps/api/deps/cascade_subscriber.go`.
- BFS anchor + recursive step JOIN `workitems.items` and filter by tenant.
- Derivation items SELECT, comments SELECT (via JOIN to items), and per-item UPDATE all carry the same tenant predicate.
- Used the nullable-project shape `($projectID = '' OR project_id = $projectID)` from `deps.go:767-768`.
- Refreshed the line-348 comment to document the post-tv8.50 semantics (rowMap miss = deleted-or-cross-tenant).

### Files changed
- `apps/api/deps/cascade_subscriber.go`
- `apps/api/deps/cascade_subscriber_handler_test.go`

### Decisions
None — followed the DECISION (orchestrator, 2026-05-19) scope expansion verbatim.

### Deviations
None.

### Tests
- `TestHandleCascadeRequested_BFS_TenantIsolation` — two orgs, raw SQL cross-tenant 'blocks' INSERT bypassing `AddEdge`; publisher in org alpha must NOT reach beta's item. Fails before the fix, passes after.
- `TestHandleCascadeRequested_BFS_TenantMismatch` — publisher's `OrgID` disagrees with the seed's actual `org_id`; BFS returns empty, audit row still written with publisher's claim, no `pipeline_stage` write occurs.
- `encore test ./deps/...` — all green (2.2s).
- `encore test ./...` — all packages green.
- `go vet`, `go build`, `encore check` — clean.