### PR TITLE
unblock-tv8.53: SetStateColumns publishes state_change cascade

### DIFF
--- a/apps/api/deps/cascade_subscriber_derivation_test.go
+++ b/apps/api/deps/cascade_subscriber_derivation_test.go
@@ -31,14 +31,17 @@
 // org/user/project per top-level test) but each rule case mints a new
 // item id.
 //
-// Encore test runtime caveat: SetStateColumns currently has zero
-// publishes to CascadeRequestedTopic (tracked by unblock-tv8.53). The
-// state_change Reason can only enter the subscriber via Claim's I-3
-// reset path today. To decouple these tests from publisher status
-// (and from tv8.53's eventual fix), we invoke the handler DIRECTLY
-// for all four Reasons. The subscriber body is identical across
-// Reasons — only the audit row's kind discriminator differs — so the
-// derivation coverage holds for every Reason equivalently.
+// Encore test runtime caveat: SetStateColumns now publishes
+// state_change for (impl, review, qa) material changes per
+// SPEC §6.3.0 tension #3 (shipped on unblock-tv8.53). The
+// state_change Reason can therefore enter the subscriber via
+// SetStateColumns or via Claim's I-3 reset path. To decouple these
+// tests from publisher state and from the Encore test runtime's
+// non-firing-subscribers caveat, we still invoke the subscriber
+// handler DIRECTLY for all four Reasons. The subscriber body is
+// identical across Reasons — only the audit row's kind discriminator
+// differs — so the derivation coverage holds for every Reason
+// equivalently.
 //
 // Per the bead's DECISION comment: this is NOT a workaround, it is
 // the canonical test pattern under the Encore test runtime (cf.

--- a/apps/api/mcp/handler_set_state.go
+++ b/apps/api/mcp/handler_set_state.go
@@ -68,10 +68,14 @@
 //
 // The §6.3.0 `state_change` cascade publish (post-commit publish to
 // deps.CascadeRequestedTopic when (impl, review, qa) materially
-// change) is tracked SEPARATELY as bead unblock-tv8.53 — NOT in
-// scope for this handler. SetStateColumns currently does not publish
-// state_change; D-6 ships without it per bead unblock-tv8.21
-// INVESTIGATION risk R3.
+// change) lives INSIDE workitems.SetStateColumns (shipped on bead
+// unblock-tv8.53). This MCP handler is unaware of the publish — it
+// calls SetStateColumns and trusts the RPC to fire the cascade per
+// SPEC §6.3.0 tension #3. The handler still appends the
+// intent_comment AFTER SetStateColumns returns; if the comment append
+// fails the cascade has already fired (best-effort post-state per
+// bead unblock-tv8.21 D-6 INVESTIGATION risk R3 — the existing
+// architectural decision is unchanged).
 //
 // SPEC: docs/specs/01-spec-backend-mvp.md § 6.2 Tool 13 (lines
 // 1606-1725) + § 4.4 (workitems.SetStateColumns + AppendComment) +

--- a/apps/api/workitems/helpers.go
+++ b/apps/api/workitems/helpers.go
@@ -83,13 +83,22 @@ type itemRow struct {
 }
 
 // stateRow is the lightweight projection used by SetStateColumns to
-// pull just the columns required for invariant validation.
+// pull just the columns required for invariant validation AND the
+// scope fields (OrgID, ProjectID) consumed by the post-commit
+// state_change cascade publish per SPEC §6.3.0 (Regime B). The scope
+// fields are projected unconditionally so the predicate logic stays
+// uniform across publishing and non-publishing branches; only the
+// publishing branch reads them. Mirrors the FOR UPDATE projection
+// pattern used in Close (workitems.go:1287-1296) and Claim
+// (workitems.go:1431-1438).
 type stateRow struct {
 	Impl      string
 	Review    string
 	QA        string
 	Pipeline  string
 	ClaimedBy *string
+	OrgID     string
+	ProjectID string
 }
 
 // scanItemRow is the canonical scanner for the itemColumnList projection

--- a/apps/api/workitems/integration_test.go
+++ b/apps/api/workitems/integration_test.go
@@ -1274,3 +1274,230 @@ func TestClaimPropertyHalfFailedHalfNotN100(t *testing.T) {
 	t.Logf("N=100 split (failed=%d, normal=%d): state_change publishes: failed=%d, normal=%d",
 		halfFailed, N-halfFailed, failedHits, normalHits)
 }
+
+// -----------------------------------------------------------------------------
+// SetStateColumns cascade publish (bead unblock-tv8.53 / SPEC §6.3.0
+// tension #3 narrow rule). The four tests below cover acceptance
+// criteria #1-#4: §5.7.1-affecting writes publish exactly one
+// CascadeRequested{Reason:"state_change"}, pipe-only writes do NOT
+// publish, I-1's auto-reset of qa_state counts as a material change,
+// and the N=100 half-changing/half-pipe-only property assertion.
+// -----------------------------------------------------------------------------
+
+// TestSetStateImplChangePublishesStateChange — happy path AC #1.
+// setItemState seeds (impl=pending, review=pending, qa=pending,
+// claimed). SetStateColumns(impl_state=done) is §5.7.1-affecting
+// (impl_state moves from pending to done); the post-commit publish
+// MUST fire exactly once, carrying EventID, OrgID, ProjectID, and
+// EmittedAt populated from the locked row's scope + the publisher's
+// wall clock. Mirrors TestClaimResetsReworkOnQAFailed's field-by-field
+// assertion shape (lines 462-518).
+func TestSetStateImplChangePublishesStateChange(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+	itemID := createReadyItem(t, ctx, fx)
+	// Seed: claimed item at (impl=pending, review=pending, qa=pending).
+	// claimed_by_id=fx.UserID is required by the impl_done_requires_claim
+	// structural invariant before we can flip impl_state to done.
+	setItemState(t, ctx, itemID, "pending", "pending", "pending", fx.UserID)
+
+	newImpl := "done"
+	got, err := workitems.SetStateColumns(ctx, &workitems.SetStateRequest{
+		ItemID:    itemID,
+		ImplState: &newImpl,
+	})
+	if err != nil {
+		t.Fatalf("SetStateColumns: %v", err)
+	}
+	if got.ImplState != "done" {
+		t.Fatalf("impl_state = %q, want done", got.ImplState)
+	}
+
+	msgs := cascadeRequestedMessagesFor(itemID, "state_change")
+	if len(msgs) != 1 {
+		t.Fatalf("SetStateColumns(impl=done) must publish exactly 1 state_change cascade for item=%q: got %d (want 1)",
+			itemID, len(msgs))
+	}
+	msg := msgs[0]
+	if msg.EventID == "" {
+		t.Fatalf("state_change cascade: EventID empty (ULID must be minted before tx.Begin per AC #3)")
+	}
+	if msg.OrgID != fx.OrgID {
+		t.Fatalf("state_change cascade: OrgID=%q, want %q (captured at SELECT FOR UPDATE time)", msg.OrgID, fx.OrgID)
+	}
+	if msg.ProjectID != fx.ProjectID {
+		t.Fatalf("state_change cascade: ProjectID=%q, want %q", msg.ProjectID, fx.ProjectID)
+	}
+	if msg.EmittedAt.IsZero() {
+		t.Fatalf("state_change cascade: EmittedAt zero (must be wall-clock at publish time)")
+	}
+	if msg.Reason != "state_change" {
+		t.Fatalf("state_change cascade: Reason=%q, want state_change", msg.Reason)
+	}
+}
+
+// TestSetStatePipeStateOnlyDoesNotPublish — negative path AC #2.
+// SPEC §6.3.0 explicit non-publishers (lines 1803-1809, tension #3
+// ruling): writes that affect ONLY pipeline_state (with no change to
+// impl/review/qa) MUST NOT publish. §5.7.1 derives pipeline_stage from
+// the upstream chain's readiness/closure, not from a downstream item's
+// own pipe_state.
+func TestSetStatePipeStateOnlyDoesNotPublish(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+	itemID := createReadyItem(t, ctx, fx)
+	setItemState(t, ctx, itemID, "pending", "pending", "pending", fx.UserID)
+
+	// pipeline_state default is 'running'; move it to 'paused' with no
+	// impl/review/qa change.
+	newPipeline := "paused"
+	got, err := workitems.SetStateColumns(ctx, &workitems.SetStateRequest{
+		ItemID:        itemID,
+		PipelineState: &newPipeline,
+	})
+	if err != nil {
+		t.Fatalf("SetStateColumns: %v", err)
+	}
+	if got.PipelineState != "paused" {
+		t.Fatalf("pipeline_state = %q, want paused", got.PipelineState)
+	}
+
+	if msgs := cascadeRequestedMessagesFor(itemID, "state_change"); len(msgs) != 0 {
+		t.Fatalf("pipe_state-only SetStateColumns must NOT publish state_change cascade for item=%q: got %d publish(es) (want 0)",
+			itemID, len(msgs))
+	}
+}
+
+// TestSetStateI1AutoResetPublishes — AC #3 (I-1 ordering, R2).
+// I-1: review_state=needs_rework auto-resets qa_state to pending. The
+// predicate runs AFTER I-1, so the qa transition from passed→pending
+// counts as a material §5.7.1-affecting change even though the caller
+// only passed review_state. Confirms the predicate's post-I-1
+// placement.
+func TestSetStateI1AutoResetPublishes(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+	itemID := createReadyItem(t, ctx, fx)
+	// Seed: claimed item with (impl=done, review=approved, qa=passed)
+	// — the I-1 path requires impl=done to satisfy I-4 on review change.
+	setItemState(t, ctx, itemID, "done", "approved", "passed", fx.UserID)
+
+	newReview := "needs_rework"
+	got, err := workitems.SetStateColumns(ctx, &workitems.SetStateRequest{
+		ItemID:      itemID,
+		ReviewState: &newReview,
+	})
+	if err != nil {
+		t.Fatalf("SetStateColumns: %v", err)
+	}
+	if got.ReviewState != "needs_rework" || got.QAState != "pending" {
+		t.Fatalf("I-1: review=%q qa=%q (want needs_rework/pending)", got.ReviewState, got.QAState)
+	}
+
+	msgs := cascadeRequestedMessagesFor(itemID, "state_change")
+	if len(msgs) != 1 {
+		t.Fatalf("I-1 auto-reset must publish exactly 1 state_change cascade for item=%q: got %d (want 1)",
+			itemID, len(msgs))
+	}
+}
+
+// TestSetStatePropertyHalfChangeHalfPipeOnlyN100 — AC #4 property test.
+// Create N=100 claimed items in the (impl=pending, review=pending,
+// qa=pending) posture. First half: SetStateColumns(impl_state=done)
+// — §5.7.1-affecting, MUST publish exactly one state_change each.
+// Second half: SetStateColumns(pipeline_state=paused) — pipe-only,
+// MUST NOT publish.
+//
+// Per DECISION comment on the bead: AC #4's "50 deps.cascade_events
+// rows" reads as "50 et.Topic publishes whose Reason=state_change"
+// because the Encore test runtime does not fire subscribers during
+// `encore test`. The publish surface is the observable contract and
+// matches the canonical pattern from
+// TestClaimPropertyHalfFailedHalfNotN100.
+func TestSetStatePropertyHalfChangeHalfPipeOnlyN100(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+
+	const N = 100
+	const halfChange = N / 2
+
+	changeIDs := make([]string, 0, halfChange)
+	pipeIDs := make([]string, 0, N-halfChange)
+	changeIDSet := make(map[string]struct{}, halfChange)
+	pipeIDSet := make(map[string]struct{}, N-halfChange)
+
+	// Phase 1: create N=100 items seeded as claimed at the
+	// (impl=pending, review=pending, qa=pending) posture. setItemState
+	// writes the workitems.items row directly and therefore does NOT
+	// fire the SetStateColumns cascade publish — the publish count is
+	// clean before Phase 2 begins. Mirrors TestClaimProperty's pattern
+	// at lines 1185-1209.
+	for i := 0; i < N; i++ {
+		id := createReadyItem(t, ctx, fx)
+		setItemState(t, ctx, id, "pending", "pending", "pending", fx.UserID)
+		if i < halfChange {
+			changeIDs = append(changeIDs, id)
+			changeIDSet[id] = struct{}{}
+		} else {
+			pipeIDs = append(pipeIDs, id)
+			pipeIDSet[id] = struct{}{}
+		}
+	}
+
+	// Phase 2: call SetStateColumns per item.
+	newImpl := "done"
+	for _, id := range changeIDs {
+		got, err := workitems.SetStateColumns(ctx, &workitems.SetStateRequest{
+			ItemID:    id,
+			ImplState: &newImpl,
+		})
+		if err != nil {
+			t.Fatalf("SetStateColumns change item %q: %v", id, err)
+		}
+		if got.ImplState != "done" {
+			t.Fatalf("change item %q impl_state=%q (want done)", id, got.ImplState)
+		}
+	}
+	newPipeline := "paused"
+	for _, id := range pipeIDs {
+		got, err := workitems.SetStateColumns(ctx, &workitems.SetStateRequest{
+			ItemID:        id,
+			PipelineState: &newPipeline,
+		})
+		if err != nil {
+			t.Fatalf("SetStateColumns pipe item %q: %v", id, err)
+		}
+		if got.PipelineState != "paused" {
+			t.Fatalf("pipe item %q pipeline_state=%q (want paused)", id, got.PipelineState)
+		}
+	}
+
+	// Phase 3: count publishes via et.Topic. Synchronous — Publish
+	// returns after the message is recorded by the test harness.
+	all := et.Topic(deps.CascadeRequestedTopic).PublishedMessages()
+	var changeHits, pipeHits int
+	for _, msg := range all {
+		if msg == nil || msg.Reason != "state_change" {
+			continue
+		}
+		if _, ok := changeIDSet[msg.TriggeredByItemID]; ok {
+			changeHits++
+			continue
+		}
+		if _, ok := pipeIDSet[msg.TriggeredByItemID]; ok {
+			pipeHits++
+		}
+	}
+
+	if changeHits != halfChange {
+		t.Fatalf("change half: %d state_change publishes (want %d) — §5.7.1-affecting writes must publish exactly once",
+			changeHits, halfChange)
+	}
+	if pipeHits != 0 {
+		t.Fatalf("pipe-only half: %d state_change publishes (want 0) — pipe_state-only writes must NOT publish (SPEC §6.3.0 tension #3)",
+			pipeHits)
+	}
+
+	t.Logf("N=100 split (change=%d, pipe=%d): state_change publishes: change=%d, pipe=%d",
+		halfChange, N-halfChange, changeHits, pipeHits)
+}

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1167,6 +1167,18 @@ func AppendComment(ctx context.Context, req *AppendCommentRequest) (*Comment, er
 // Claim). On violation, returns errs.FailedPrecondition with
 // Meta["invariant"] populated per SPEC §6.2 Tool 13.
 //
+// Side-effects (round-6 §6.3.0 symmetric writer model — tension #3
+// narrow rule, SPEC lines 1700-1711 + 1801): after the validating
+// UPDATE commits, publishes CascadeRequested{Reason:"state_change",
+// TriggeredByItemID:item_id, …} when the write changes one or more
+// of (impl_state, review_state, qa_state) — including I-1's
+// auto-reset of qa_state. Pure pipe_state mutations (no change to
+// the other three) do NOT publish (SPEC §6.3.0 explicit
+// non-publishers, tension #3 ruling). The publish drives the
+// multi-hop pipeline_stage recompute on the forward 'blocks' closure
+// (Regime B; the cascade subscriber is the sole writer of
+// pipeline_stage).
+//
 //encore:api private method=POST path=/workitems.SetStateColumns
 func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 	if req == nil || req.ItemID == "" {
@@ -1176,21 +1188,39 @@ func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 		return nil, err
 	}
 
+	// Mint the cascade event id BEFORE tx.Begin per the round-6
+	// retry-safe dedup pattern (deps.RemoveEdge:468-477). On
+	// ulid.New() failure we proceed with the state mutation and skip
+	// the publish — the AR-11 UNIQUE constraint on
+	// (event_id, triggered_by_item_id) makes the audit row's absence
+	// preferable to failing a committed state change. Mirrors Close's
+	// best-effort handling at workitems.go:1380-1385.
+	eventID, eventIDErr := ulid.New()
+	if eventIDErr != nil {
+		rlog.Warn("workitems: set_state cascade event id generation failed", "err", eventIDErr, "item_id", req.ItemID)
+	}
+
 	tx, err := db.Begin(ctx)
 	if err != nil {
 		return nil, &errs.Error{Code: errs.Internal, Message: "db begin failed"}
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Lock the row and read current state columns.
+	// Lock the row and read current state columns + scope (org_id,
+	// project_id). Scope is projected unconditionally so the
+	// predicate-evaluation branch stays uniform; only the publishing
+	// branch consumes it. COALESCE(project_id,'') mirrors the Close
+	// pattern at workitems.go:1290-1296.
 	var cur stateRow
 	err = tx.QueryRow(ctx,
-		`SELECT impl_state, review_state, qa_state, pipeline_state, claimed_by_id
+		`SELECT impl_state, review_state, qa_state, pipeline_state, claimed_by_id,
+		        org_id, COALESCE(project_id, '')
 		   FROM workitems.items
 		  WHERE id = $1
 		  FOR UPDATE`,
 		req.ItemID,
-	).Scan(&cur.Impl, &cur.Review, &cur.QA, &cur.Pipeline, &cur.ClaimedBy)
+	).Scan(&cur.Impl, &cur.Review, &cur.QA, &cur.Pipeline, &cur.ClaimedBy,
+		&cur.OrgID, &cur.ProjectID)
 	if err != nil {
 		if errors.Is(err, sqldb.ErrNoRows) {
 			return nil, &errs.Error{Code: errs.NotFound, Message: "item not found"}
@@ -1239,6 +1269,17 @@ func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 		return nil, preconditionError("review_change_requires_impl_done", "review_state change requires impl_state=done")
 	}
 
+	// Compute the §6.3.0 tension #3 "materially changed" predicate
+	// BEFORE the UPDATE so the publish gate captures the state
+	// transition post-I-1-auto-reset (R2 of the bead investigation).
+	// Pure pipe_state writes leave newImpl/newReview/newQA equal to
+	// cur and evaluate to false (AC #2). Over-publishing is acceptable
+	// (subscriber's idempotent UPDATE guard absorbs it); under-publishing
+	// would be a correctness bug — hence the simple any-of-three form.
+	publishStateChange := (newImpl != cur.Impl) ||
+		(newReview != cur.Review) ||
+		(newQA != cur.QA)
+
 	// All invariants validated. Apply the update.
 	_, err = tx.Exec(ctx,
 		`UPDATE workitems.items
@@ -1257,6 +1298,31 @@ func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 
 	if err := tx.Commit(); err != nil {
 		return nil, &errs.Error{Code: errs.Internal, Message: "set_state commit failed"}
+	}
+
+	// Round-6 §6.3.0 tension #3 narrow rule (SPEC §6.2 Tool 13 lines
+	// 1700-1711 + §6.3.0 line 1801): publish CascadeRequested with
+	// Reason="state_change" ONLY when the write changed at least one
+	// of (impl_state, review_state, qa_state) — including I-1's
+	// auto-reset of qa_state. Pipe-only writes do NOT publish. Encore
+	// Pub/Sub does not carry ctx across the topic boundary; TraceID is
+	// copied from tracectx into the payload explicitly (mirrors Close
+	// at workitems.go:1377-1397 + Claim at 1492-1526). Best-effort:
+	// log.Warn on publish failure, do not return error — the state
+	// mutation is already committed.
+	if publishStateChange && eventIDErr == nil {
+		if _, err := deps.CascadeRequestedTopic.Publish(ctx, &deps.CascadeRequested{
+			EventID:           eventID,
+			OrgID:             cur.OrgID,
+			ProjectID:         cur.ProjectID,
+			TriggeredByItemID: req.ItemID,
+			Reason:            "state_change",
+			TraceID:           tracectx.TraceID(ctx),
+			EmittedAt:         time.Now().UTC(),
+		}); err != nil {
+			rlog.Warn("workitems: set_state cascade publish failed (set_state already committed)",
+				"err", err, "item_id", req.ItemID)
+		}
 	}
 
 	return readItem(ctx, req.ItemID)


### PR DESCRIPTION
## unblock-tv8.53: workitems.SetStateColumns publish state_change cascade on §5.7.1-affecting writes

Closes the last §6.3.0 cascade-publisher gap: workitems.SetStateColumns now publishes CascadeRequested{Reason:\"state_change\"} post-commit when the validating UPDATE materially changes any of (impl_state, review_state, qa_state) per SPEC §6.2 Tool 13 lines 1700-1711 + §6.3.0 line 1801. Pure pipe_state mutations are explicit non-publishers (tension #3).

### What was done
- Extend stateRow with OrgID + ProjectID (scope captured at SELECT FOR UPDATE).
- Mint cascade event id via ulid.New() BEFORE tx.Begin per the round-6 dedup pattern (deps.RemoveEdge:468-477).
- Compute publishStateChange predicate AFTER I-1's auto-reset of newQA so I-1 transitions count as material changes.
- Post-commit publish mirrors Close (workitems.go:1377-1397) + Claim I-3 (workitems.go:1492-1526): best-effort, rlog.Warn on publish failure, never fail a committed state mutation. TraceID copied from tracectx.TraceID(ctx).
- Refresh stale file-header comments in mcp/handler_set_state.go and deps/cascade_subscriber_derivation_test.go to reflect post-impl reality.

### Files changed
- apps/api/workitems/workitems.go
- apps/api/workitems/helpers.go
- apps/api/workitems/integration_test.go
- apps/api/mcp/handler_set_state.go
- apps/api/deps/cascade_subscriber_derivation_test.go

### Decisions
1. **Predicate granularity** — any-of-three simple form `(newImpl != cur.Impl) || (newReview != cur.Review) || (newQA != cur.QA)` computed post-I-1. Over-publishing is acceptable (subscriber idempotent guard absorbs it); under-publishing would be a correctness bug.
2. **Observation surface** — property test asserts on `et.Topic(deps.CascadeRequestedTopic).PublishedMessages()` filtered by Reason=\"state_change\" rather than on `deps.cascade_events` rows, because the Encore test runtime does not fire subscribers during `encore test`. Same semantic gate; mirrors TestClaimPropertyHalfFailedHalfNotN100 pattern.
3. **EventID minted before tx.Begin** per AC #3 for cross-publisher symmetry with the round-6 dedup discipline.

### Deviations
None — implemented as spec.

### Tests
Four new integration tests covering all four acceptance criteria:
- `TestSetStateImplChangePublishesStateChange` — happy path (AC #1), asserts EventID/OrgID/ProjectID/EmittedAt/Reason populated correctly.
- `TestSetStatePipeStateOnlyDoesNotPublish` — negative path (AC #2).
- `TestSetStateI1AutoResetPublishes` — I-1 ordering check (R2).
- `TestSetStatePropertyHalfChangeHalfPipeOnlyN100` — N=100 property test (AC #4); 50 §5.7.1-affecting writes publish, 50 pipe-only writes do not.

Full `encore test ./apps/api/... -count=1` sweep passes across auth, deps, mcp, org, shared/*, and workitems packages.