### PR TITLE
unblock-tv8.44: Standardize snake_case JSON tags on Encore RPC + Pub/Sub surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,7 @@ cargo doc --no-deps --workspace  # zero warnings
 - All public APIs declared with `//encore:api` (typed) — raw endpoints reserved for the 3 documented public ingress points
 - Per-service `//encore:middleware` for tenant filtering (inject `WHERE org_id = ?` automatically)
 - `//encore:authhandler` reads session, sets `auth.UserID()` + `auth.Data()` (org_id claim)
+- JSON wire convention (SPEC §3.6): every exported field of every Go struct in `apps/api/` that may transit JSON (Encore `//encore:api` request/response, Pub/Sub payloads, MCP tool I/O, error envelopes, internal helper types that may be marshalled) MUST declare an explicit `json:"snake_case_name"` tag. Go's default PascalCase wire serialisation is forbidden. Exception: third-party HTTP unmarshal structs may mirror the third-party wire format (see `apps/api/auth/oauth.go` `githubUserResponse` / `githubAccessTokenResponse`). MCP SDK / JSON-RPC protocol fields (`jsonrpc`, `protocolVersion`, `structuredContent`, `isError`) follow the MCP 2025-06-18 spec verbatim. Quality gate: `grep -rnE 'json:"[A-Z]' apps/api/` must return zero matches.
 
 ### TypeScript (Astro frontend)
 

--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -87,8 +87,8 @@ type Identity = types.Identity
 
 // ValidateRequest is the input to Validate. SPEC §4.1.
 type ValidateRequest struct {
-	Token     string // either auth.sessions.id (browser BFF) or raw API key
-	TokenKind string // "session" | "api_key"
+	Token     string `json:"token"`      // either auth.sessions.id (browser BFF) or raw API key
+	TokenKind string `json:"token_kind"` // "session" | "api_key"
 }
 
 // ValidateResponse is the output of Validate. SPEC §4.1.
@@ -105,8 +105,8 @@ type ValidateRequest struct {
 // (SPEC §4.3.2). Pre-prod stance allows additive struct fields
 // per CLAUDE.md.
 type ValidateResponse struct {
-	Identity Identity
-	APIKeyID string
+	Identity Identity `json:"identity"`
+	APIKeyID string   `json:"api_key_id"`
 }
 
 // Validate accepts an opaque token (session id OR raw API key) and resolves
@@ -257,11 +257,11 @@ func touchLastUsedAt(keyID string) {
 
 // ExchangeOAuthCodeRequest is the input to ExchangeOAuthCode. SPEC §4.1.
 type ExchangeOAuthCodeRequest struct {
-	Provider     string // "github" | "gitlab"
-	Code         string
-	PKCEVerifier string
-	UserAgent    string
-	IPAddress    string
+	Provider     string `json:"provider"` // "github" | "gitlab"
+	Code         string `json:"code"`
+	PKCEVerifier string `json:"pkce_verifier"`
+	UserAgent    string `json:"user_agent"`
+	IPAddress    string `json:"ip_address"`
 
 	// PKCEChallenge is the S256 challenge the client originally sent
 	// to /authorize. SPEC §4.1's locked struct does not include it —
@@ -273,14 +273,14 @@ type ExchangeOAuthCodeRequest struct {
 	// not set it fall through to the legacy (verifier-only)
 	// validation pattern documented at the field. See DECISION on
 	// the bead.
-	PKCEChallenge string
+	PKCEChallenge string `json:"pkce_challenge"`
 }
 
 // ExchangeOAuthCodeResponse is the output of ExchangeOAuthCode. SPEC §4.1.
 type ExchangeOAuthCodeResponse struct {
-	SessionID string // ULID; opaque; used as Bearer for private RPCs
-	UserID    string // ULID
-	ExpiresAt time.Time
+	SessionID string    `json:"session_id"` // ULID; opaque; used as Bearer for private RPCs
+	UserID    string    `json:"user_id"`    // ULID
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 // ExchangeOAuthCode is called by the Astro Action /auth/[provider]/callback
@@ -484,19 +484,19 @@ func splitScopes(raw string) []string {
 
 // IssueAPIKeyRequest is the input to IssueAPIKey. SPEC §4.1.
 type IssueAPIKeyRequest struct {
-	OrgID        string // ULID
-	IssuedToUser string // ULID; nullable (org-level service key)
-	Label        string // human-readable, e.g. "claude-code-laptop"
-	AgentKind    string // AgentKind value
-	Scopes       []string
-	ExpiresAt    *time.Time // nullable; default: never
+	OrgID        string     `json:"org_id"`         // ULID
+	IssuedToUser string     `json:"issued_to_user"` // ULID; nullable (org-level service key)
+	Label        string     `json:"label"`          // human-readable, e.g. "claude-code-laptop"
+	AgentKind    string     `json:"agent_kind"`     // AgentKind value
+	Scopes       []string   `json:"scopes"`
+	ExpiresAt    *time.Time `json:"expires_at"` // nullable; default: never
 }
 
 // IssueAPIKeyResponse is the output of IssueAPIKey. SPEC §4.1.
 type IssueAPIKeyResponse struct {
-	KeyID     string // ULID (mcp.api_keys.id)
-	KeyPrefix string // first 8 chars of the random base32 portion
-	RawKey    string // FULL raw key — returned ONCE; never persisted in clear
+	KeyID     string `json:"key_id"`     // ULID (mcp.api_keys.id)
+	KeyPrefix string `json:"key_prefix"` // first 8 chars of the random base32 portion
+	RawKey    string `json:"raw_key"`    // FULL raw key — returned ONCE; never persisted in clear
 }
 
 // IssueAPIKey creates a new mcp.api_keys row. Called by the seeder CLI
@@ -572,7 +572,7 @@ func IssueAPIKey(ctx context.Context, req *IssueAPIKeyRequest) (*IssueAPIKeyResp
 
 // RevokeAPIKeyRequest is the input to RevokeAPIKey. SPEC §4.1.
 type RevokeAPIKeyRequest struct {
-	KeyID string // ULID
+	KeyID string `json:"key_id"` // ULID
 }
 
 // RevokeAPIKey flips revoked_at; idempotent.

--- a/apps/api/auth/authhandler.go
+++ b/apps/api/auth/authhandler.go
@@ -46,7 +46,7 @@ type AuthParams struct {
 // AuthData is what downstream handlers receive via auth.Data(). Wraps
 // the resolved Identity per SPEC §4.3.3.
 type AuthData struct {
-	Identity Identity
+	Identity Identity `json:"identity"`
 }
 
 // bearerPrefix is the case-sensitive scheme prefix the

--- a/apps/api/auth/types/types.go
+++ b/apps/api/auth/types/types.go
@@ -78,8 +78,8 @@ package types
 // any package, including plain `go test` consumers under
 // `apps/api/shared/*`.
 type Identity struct {
-	UserID    string // ULID
-	OrgID     string // ULID — primary org binding for this auth event
-	Role      string // "owner" | "admin" | "member" | "viewer"
-	AgentKind string // empty for human sessions; AgentKind value for API-key callers
+	UserID    string `json:"user_id"`    // ULID
+	OrgID     string `json:"org_id"`     // ULID — primary org binding for this auth event
+	Role      string `json:"role"`       // "owner" | "admin" | "member" | "viewer"
+	AgentKind string `json:"agent_kind"` // empty for human sessions; AgentKind value for API-key callers
 }

--- a/apps/api/deps/cascade.go
+++ b/apps/api/deps/cascade.go
@@ -54,16 +54,16 @@ type CascadeRequested struct {
 	// EventID is a ULID minted by the publisher. The subscriber
 	// uses (EventID, TriggeredByItemID) as the idempotency key
 	// (UNIQUE constraint on deps.cascade_events).
-	EventID string
+	EventID string `json:"event_id"`
 
 	// OrgID, ProjectID scope the cascade to the org-tenant that
 	// triggered it.
-	OrgID     string
-	ProjectID string
+	OrgID     string `json:"org_id"`
+	ProjectID string `json:"project_id"`
 
 	// TriggeredByItemID is the item whose change initiated the
 	// cascade (e.g. the item being closed in workitems.Close).
-	TriggeredByItemID string
+	TriggeredByItemID string `json:"triggered_by_item_id"`
 
 	// Reason categorises the trigger. Allowed: "close" |
 	// "edge_added" | "edge_removed" | "state_change".
@@ -92,7 +92,7 @@ type CascadeRequested struct {
 	// shared/lint/no_direct_is_ready_write with a scope-tightened
 	// allow-list (encore.app/deps writes is_ready inline; subscriber
 	// in the same package writes pipeline_stage only).
-	Reason string
+	Reason string `json:"reason"`
 
 	// TraceID is the ULID minted by the mcp raw endpoint
 	// (§10.2 Option B). The publisher copies it from
@@ -107,13 +107,13 @@ type CascadeRequested struct {
 	// publish cascades — e.g. an admin script — without an
 	// originating MCP request; the subscriber tolerates a
 	// missing trace id by writing NULL to the column).
-	TraceID string
+	TraceID string `json:"trace_id"`
 
 	// EmittedAt is the publisher's wall clock at publish time.
 	// Distinct from Encore Pub/Sub's own delivery timestamps so
 	// the audit row can record "when did the cascade start in
 	// the publisher's view".
-	EmittedAt time.Time
+	EmittedAt time.Time `json:"emitted_at"`
 }
 
 // CascadeCompleted is the Pub/Sub payload published by the cascade
@@ -130,24 +130,24 @@ type CascadeRequested struct {
 type CascadeCompleted struct {
 	// EventID matches the EventID of the CascadeRequested that
 	// triggered this completion.
-	EventID string
+	EventID string `json:"event_id"`
 
 	// TriggeredByItemID matches the originating
 	// CascadeRequested.TriggeredByItemID.
-	TriggeredByItemID string
+	TriggeredByItemID string `json:"triggered_by_item_id"`
 
 	// AffectedItemIDs is the closure of items whose is_ready /
 	// pipeline_stage was recomputed by this pass. May be empty
 	// if no readiness flip occurred (the subscriber still emits
 	// CascadeCompleted for the audit-trail completeness).
-	AffectedItemIDs []string
+	AffectedItemIDs []string `json:"affected_item_ids"`
 
 	// CascadedCount is len(AffectedItemIDs); duplicated on the
 	// wire so simple consumers don't have to walk the slice.
-	CascadedCount int
+	CascadedCount int `json:"cascaded_count"`
 
 	// CompletedAt is the subscriber's wall clock at commit time.
-	CompletedAt time.Time
+	CompletedAt time.Time `json:"completed_at"`
 }
 
 // CascadeRequestedTopic is the Pub/Sub topic carrying

--- a/apps/api/deps/deps.go
+++ b/apps/api/deps/deps.go
@@ -65,21 +65,21 @@ const recentCascadeEventsLimitCap = 50
 
 // Edge is the canonical dependency edge row shape. SPEC §4.5.
 type Edge struct {
-	ID        string
-	FromItem  string
-	ToItem    string
-	Kind      string // "blocks" | "related"
-	CreatedAt time.Time
-	CreatedBy string
+	ID        string    `json:"id"`
+	FromItem  string    `json:"from_item"`
+	ToItem    string    `json:"to_item"`
+	Kind      string    `json:"kind"` // "blocks" | "related"
+	CreatedAt time.Time `json:"created_at"`
+	CreatedBy string    `json:"created_by"`
 }
 
 // AddEdgeRequest is the input to AddEdge. SPEC §4.5.
 type AddEdgeRequest struct {
-	OrgID     string
-	ProjectID string
-	FromItem  string
-	ToItem    string
-	Kind      string // "blocks" | "related"; default "blocks"
+	OrgID     string `json:"org_id"`
+	ProjectID string `json:"project_id"`
+	FromItem  string `json:"from_item"`
+	ToItem    string `json:"to_item"`
+	Kind      string `json:"kind"` // "blocks" | "related"; default "blocks"
 }
 
 // AddEdge acquires the per-project advisory lock (AF5), runs the
@@ -410,17 +410,17 @@ func AddEdgeInTx(ctx context.Context, tx *sqldb.Tx, req *AddEdgeRequest) (*Edge,
 // RemoveEdgeRequest is the input to RemoveEdge. SPEC §4.5. Pass either
 // EdgeID OR (FromItem + ToItem + Kind), exactly one path.
 type RemoveEdgeRequest struct {
-	EdgeID   string
-	FromItem string
-	ToItem   string
-	Kind     string
+	EdgeID   string `json:"edge_id"`
+	FromItem string `json:"from_item"`
+	ToItem   string `json:"to_item"`
+	Kind     string `json:"kind"`
 }
 
 // RemoveEdgeResponse is the output of RemoveEdge. SPEC §4.5.
 type RemoveEdgeResponse struct {
-	Removed        bool
-	ToItemNowReady bool
-	ToItemID       string
+	Removed        bool   `json:"removed"`
+	ToItemNowReady bool   `json:"to_item_now_ready"`
+	ToItemID       string `json:"to_item_id"`
 }
 
 // RemoveEdge deletes the edge, recomputes is_ready for the direct
@@ -587,12 +587,12 @@ func RemoveEdge(ctx context.Context, req *RemoveEdgeRequest) (*RemoveEdgeRespons
 // API request types to be named structs (E1354). The wire-shape is
 // unchanged. See DEVIATION trail on bead unblock-tv8.1.
 type IsReadyRequest struct {
-	ItemID string
+	ItemID string `json:"item_id"`
 }
 
 // IsReadyResponse is the output of IsReady.
 type IsReadyResponse struct {
-	IsReady bool
+	IsReady bool `json:"is_ready"`
 }
 
 // IsReady returns the current is_ready value for itemID (read directly
@@ -620,14 +620,14 @@ func IsReady(ctx context.Context, req *IsReadyRequest) (*IsReadyResponse, error)
 
 // ClosureRequest is the input to Closure. SPEC §4.5.
 type ClosureRequest struct {
-	ItemID    string
-	Direction string // "incoming" | "outgoing"
-	MaxDepth  int    // 1..256; default 256
+	ItemID    string `json:"item_id"`
+	Direction string `json:"direction"` // "incoming" | "outgoing"
+	MaxDepth  int    `json:"max_depth"` // 1..256; default 256
 }
 
 // ClosureResponse is the output of Closure. SPEC §4.5.
 type ClosureResponse struct {
-	ItemIDs []string
+	ItemIDs []string `json:"item_ids"`
 }
 
 // Closure returns the transitive 'blocks' closure for an item.
@@ -719,25 +719,25 @@ func closureSQL(direction string) string {
 
 // RecentCascadeEventsRequest is the input to RecentCascadeEvents. SPEC §4.5.
 type RecentCascadeEventsRequest struct {
-	OrgID     string
-	ProjectID string
-	Limit     int // capped at 50; default 50
+	OrgID     string `json:"org_id"`
+	ProjectID string `json:"project_id"`
+	Limit     int    `json:"limit"` // capped at 50; default 50
 }
 
 // CascadeEventRow is one row of a RecentCascadeEvents response. SPEC §4.5.
 type CascadeEventRow struct {
-	ID                string
-	EventID           string
-	TriggeredByItemID string
-	AffectedItemIDs   []string
-	CascadedCount     int
-	TriggeredAt       time.Time
-	TraceID           string
+	ID                string    `json:"id"`
+	EventID           string    `json:"event_id"`
+	TriggeredByItemID string    `json:"triggered_by_item_id"`
+	AffectedItemIDs   []string  `json:"affected_item_ids"`
+	CascadedCount     int       `json:"cascaded_count"`
+	TriggeredAt       time.Time `json:"triggered_at"`
+	TraceID           string    `json:"trace_id"`
 }
 
 // RecentCascadeEventsResponse is the output of RecentCascadeEvents. SPEC §4.5.
 type RecentCascadeEventsResponse struct {
-	Events []CascadeEventRow
+	Events []CascadeEventRow `json:"events"`
 }
 
 // RecentCascadeEvents returns the last N (≤50) deps.cascade_events rows

--- a/apps/api/org/org.go
+++ b/apps/api/org/org.go
@@ -44,46 +44,46 @@ import (
 
 // Organization is the canonical org row shape. SPEC §4.2.
 type Organization struct {
-	ID   string // ULID
-	Name string
-	Slug string
+	ID   string `json:"id"` // ULID
+	Name string `json:"name"`
+	Slug string `json:"slug"`
 }
 
 // Project is the canonical project row shape. SPEC §4.2.
 type Project struct {
-	ID    string // ULID
-	OrgID string // ULID
-	Name  string
-	Slug  string
+	ID    string `json:"id"`     // ULID
+	OrgID string `json:"org_id"` // ULID
+	Name  string `json:"name"`
+	Slug  string `json:"slug"`
 }
 
 // CreateOrganizationRequest is the input to CreateOrganization. SPEC §4.2.
 type CreateOrganizationRequest struct {
-	Name string
-	Slug string
+	Name string `json:"name"`
+	Slug string `json:"slug"`
 }
 
 // CreateProjectRequest is the input to CreateProject. SPEC §4.2.
 type CreateProjectRequest struct {
-	OrgID string
-	Name  string
-	Slug  string
+	OrgID string `json:"org_id"`
+	Name  string `json:"name"`
+	Slug  string `json:"slug"`
 }
 
 // AddMemberRequest is the input to AddMember. SPEC §4.2.
 type AddMemberRequest struct {
-	OrgID  string
-	UserID string
-	Role   string // "owner" | "admin" | "member" | "viewer"
+	OrgID  string `json:"org_id"`
+	UserID string `json:"user_id"`
+	Role   string `json:"role"` // "owner" | "admin" | "member" | "viewer"
 }
 
 // AuthorizeRequest is the input to Authorize. SPEC §4.2.
 type AuthorizeRequest struct {
-	Identity  auth.Identity
-	Resource  string // see resource* consts below
-	Action    string // "read" | "write" | "delete"
-	OrgID     string
-	ProjectID string // optional
+	Identity  auth.Identity `json:"identity"`
+	Resource  string        `json:"resource"` // see resource* consts below
+	Action    string        `json:"action"`   // "read" | "write" | "delete"
+	OrgID     string        `json:"org_id"`
+	ProjectID string        `json:"project_id"` // optional
 }
 
 // -----------------------------------------------------------------------------
@@ -411,14 +411,14 @@ func GetProject(ctx context.Context, id string) (*Project, error) {
 // targets with a scan error. Mirror auth.go's time.Time usage for the
 // same column type.
 type projectRow struct {
-	ID          string
-	OrgID       string
-	Slug        string
-	Name        string
-	Description *string
-	ArchivedAt  *time.Time
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID          string     `json:"id"`
+	OrgID       string     `json:"org_id"`
+	Slug        string     `json:"slug"`
+	Name        string     `json:"name"`
+	Description *string    `json:"description"`
+	ArchivedAt  *time.Time `json:"archived_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 // AddMember inserts an org.members row. Role is validated client-side

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -96,118 +96,118 @@ import (
 
 // Item is the canonical work-item row shape. SPEC §4.4.
 type Item struct {
-	ID                  string
-	OrgID               string
-	ProjectID           string
-	MilestoneID         string
-	ParentID            string
-	DiscoveredFromID    string
-	Type                string
-	Title               string
-	Body                string
-	Status              string
-	Priority            string
-	PipelineStage       string
-	AgentKind           string
-	ImplState           string
-	ReviewState         string
-	QAState             string
-	PipelineState       string
-	Severity            string
-	KindOfFinding       string
-	ClaimedByID         string
-	ClaimedByAgent      string
-	ClaimedAt           *time.Time
-	IsReady             bool
-	MilestoneAssignedAt *time.Time
-	MilestoneAssignedBy string
-	Labels              []string
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
-	ClosedAt            *time.Time
+	ID                  string     `json:"id"`
+	OrgID               string     `json:"org_id"`
+	ProjectID           string     `json:"project_id"`
+	MilestoneID         string     `json:"milestone_id"`
+	ParentID            string     `json:"parent_id"`
+	DiscoveredFromID    string     `json:"discovered_from_id"`
+	Type                string     `json:"type"`
+	Title               string     `json:"title"`
+	Body                string     `json:"body"`
+	Status              string     `json:"status"`
+	Priority            string     `json:"priority"`
+	PipelineStage       string     `json:"pipeline_stage"`
+	AgentKind           string     `json:"agent_kind"`
+	ImplState           string     `json:"impl_state"`
+	ReviewState         string     `json:"review_state"`
+	QAState             string     `json:"qa_state"`
+	PipelineState       string     `json:"pipeline_state"`
+	Severity            string     `json:"severity"`
+	KindOfFinding       string     `json:"kind_of_finding"`
+	ClaimedByID         string     `json:"claimed_by_id"`
+	ClaimedByAgent      string     `json:"claimed_by_agent"`
+	ClaimedAt           *time.Time `json:"claimed_at"`
+	IsReady             bool       `json:"is_ready"`
+	MilestoneAssignedAt *time.Time `json:"milestone_assigned_at"`
+	MilestoneAssignedBy string     `json:"milestone_assigned_by"`
+	Labels              []string   `json:"labels"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	ClosedAt            *time.Time `json:"closed_at"`
 }
 
 // CreateRequest is the input to Create. SPEC §4.4.
 type CreateRequest struct {
-	OrgID            string
-	ProjectID        string
-	ParentID         string
-	DiscoveredFromID string
-	Type             string
-	Title            string
-	Body             string
-	Priority         string
-	MilestoneID      string
-	Labels           []string
-	Dependencies     []deps.Edge
-	Severity         string
-	KindOfFinding    string
+	OrgID            string      `json:"org_id"`
+	ProjectID        string      `json:"project_id"`
+	ParentID         string      `json:"parent_id"`
+	DiscoveredFromID string      `json:"discovered_from_id"`
+	Type             string      `json:"type"`
+	Title            string      `json:"title"`
+	Body             string      `json:"body"`
+	Priority         string      `json:"priority"`
+	MilestoneID      string      `json:"milestone_id"`
+	Labels           []string    `json:"labels"`
+	Dependencies     []deps.Edge `json:"dependencies"`
+	Severity         string      `json:"severity"`
+	KindOfFinding    string      `json:"kind_of_finding"`
 }
 
 // Comment is the canonical comment row shape. SPEC §4.4.
 type Comment struct {
-	ID          string
-	ItemID      string
-	ParentID    string
-	AuthorID    string
-	AuthorAgent string
-	Kind        string
-	Status      string
-	Body        string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID          string    `json:"id"`
+	ItemID      string    `json:"item_id"`
+	ParentID    string    `json:"parent_id"`
+	AuthorID    string    `json:"author_id"`
+	AuthorAgent string    `json:"author_agent"`
+	Kind        string    `json:"kind"`
+	Status      string    `json:"status"`
+	Body        string    `json:"body"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // UpdateRequest is the input to Update. SPEC §4.4.
 type UpdateRequest struct {
-	ItemID      string
-	Title       *string
-	Body        *string
-	Priority    *string
-	MilestoneID *string
-	Labels      *[]string
+	ItemID      string    `json:"item_id"`
+	Title       *string   `json:"title"`
+	Body        *string   `json:"body"`
+	Priority    *string   `json:"priority"`
+	MilestoneID *string   `json:"milestone_id"`
+	Labels      *[]string `json:"labels"`
 }
 
 // GetTrailRequest is the input to GetTrail. SPEC §4.4.
 type GetTrailRequest struct {
-	ItemID string
+	ItemID string `json:"item_id"`
 }
 
 // Trail is the comment + edges + findings bundle returned by GetTrail.
 // SPEC §4.4. DependenciesIn / DependenciesOut use deps.Edge (post C-1
 // reconciliation, bead unblock-tv8.10).
 type Trail struct {
-	Item            *Item
-	Comments        []Comment
-	DependenciesIn  []deps.Edge
-	DependenciesOut []deps.Edge
-	Findings        []Item
+	Item            *Item       `json:"item"`
+	Comments        []Comment   `json:"comments"`
+	DependenciesIn  []deps.Edge `json:"dependencies_in"`
+	DependenciesOut []deps.Edge `json:"dependencies_out"`
+	Findings        []Item      `json:"findings"`
 }
 
 // AppendCommentRequest is the input to AppendComment. SPEC §4.4.
 type AppendCommentRequest struct {
-	ItemID      string
-	AuthorID    string
-	AuthorAgent string
-	ParentID    string
-	Kind        string
-	Status      string
-	Body        string
+	ItemID      string `json:"item_id"`
+	AuthorID    string `json:"author_id"`
+	AuthorAgent string `json:"author_agent"`
+	ParentID    string `json:"parent_id"`
+	Kind        string `json:"kind"`
+	Status      string `json:"status"`
+	Body        string `json:"body"`
 }
 
 // SetStateRequest is the input to SetStateColumns. SPEC §4.4.
 type SetStateRequest struct {
-	ItemID        string
-	ImplState     *string
-	ReviewState   *string
-	QAState       *string
-	PipelineState *string
+	ItemID        string  `json:"item_id"`
+	ImplState     *string `json:"impl_state"`
+	ReviewState   *string `json:"review_state"`
+	QAState       *string `json:"qa_state"`
+	PipelineState *string `json:"pipeline_state"`
 }
 
 // GetStateRequest is the input to GetState. SPEC §6.2 Tool 14 line
 // 1730-1733.
 type GetStateRequest struct {
-	ItemID string
+	ItemID string `json:"item_id"`
 }
 
 // RecentKindRow is a single (kind, status, comment_id, created_at) tuple
@@ -216,10 +216,10 @@ type GetStateRequest struct {
 // carrying the most recent (status, comment_id, created_at) for that
 // kind. Ordered by `kind` ASC for deterministic wire output.
 type RecentKindRow struct {
-	Kind      string
-	Status    string
-	CommentID string
-	CreatedAt time.Time
+	Kind      string    `json:"kind"`
+	Status    string    `json:"status"`
+	CommentID string    `json:"comment_id"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // GetStateResponse is the output of GetState. SPEC §6.2 Tool 14 lines
@@ -236,48 +236,48 @@ type RecentKindRow struct {
 // top-level `project_id` field on the §6.2 Tool 14 wire envelope (the
 // state surface is contextually scoped to a project).
 type GetStateResponse struct {
-	ProjectID     string
-	ImplState     string
-	ReviewState   string
-	QAState       string
-	PipelineState string
-	PipelineStage string
-	IsReady       bool
-	ClaimedByID   string
-	ClaimedAt     *time.Time
-	RecentKinds   []RecentKindRow
+	ProjectID     string          `json:"project_id"`
+	ImplState     string          `json:"impl_state"`
+	ReviewState   string          `json:"review_state"`
+	QAState       string          `json:"qa_state"`
+	PipelineState string          `json:"pipeline_state"`
+	PipelineStage string          `json:"pipeline_stage"`
+	IsReady       bool            `json:"is_ready"`
+	ClaimedByID   string          `json:"claimed_by_id"`
+	ClaimedAt     *time.Time      `json:"claimed_at"`
+	RecentKinds   []RecentKindRow `json:"recent_kinds"`
 }
 
 // CloseRequest is the input to Close. SPEC §4.4.
 type CloseRequest struct {
-	ItemID string
-	Reason string
+	ItemID string `json:"item_id"`
+	Reason string `json:"reason"`
 }
 
 // ClaimRequest is the input to Claim. SPEC §4.4.
 type ClaimRequest struct {
-	ItemID        string
-	ClaimerUserID string
-	ClaimerAgent  string
+	ItemID        string `json:"item_id"`
+	ClaimerUserID string `json:"claimer_user_id"`
+	ClaimerAgent  string `json:"claimer_agent"`
 }
 
 // ListRequest is the input to List. SPEC §4.4.
 type ListRequest struct {
-	OrgID         string
-	ProjectID     string
-	MilestoneID   string
-	Status        []string
-	PipelineStage []string
-	ClaimedBy     string
-	Labels        []string
-	Limit         int
-	Cursor        string
+	OrgID         string   `json:"org_id"`
+	ProjectID     string   `json:"project_id"`
+	MilestoneID   string   `json:"milestone_id"`
+	Status        []string `json:"status"`
+	PipelineStage []string `json:"pipeline_stage"`
+	ClaimedBy     string   `json:"claimed_by"`
+	Labels        []string `json:"labels"`
+	Limit         int      `json:"limit"`
+	Cursor        string   `json:"cursor"`
 }
 
 // ListResponse is the output of List. SPEC §4.4.
 type ListResponse struct {
-	Items      []Item
-	NextCursor string
+	Items      []Item `json:"items"`
+	NextCursor string `json:"next_cursor"`
 }
 
 // ReadyRequest is the input to Ready. SPEC §6.2 Tool 2 (lines 1177-1206)
@@ -304,17 +304,17 @@ type ReadyRequest struct {
 	// The rework S1 removed the field so confused-deputy callers
 	// cannot pass a mismatched org_id; the org gate is the
 	// authenticated identity, period.
-	ProjectID   string
-	Limit       int
-	PriorityMin string
+	ProjectID   string `json:"project_id"`
+	Limit       int    `json:"limit"`
+	PriorityMin string `json:"priority_min"`
 
 	// Cursor anchor (§6.2.0 keyset tuple for Tool 2). When CursorID
 	// is non-empty, Ready emits rows STRICTLY AFTER
 	// (CursorPriority, CursorCreatedAt, CursorID) on the canonical
 	// (priority ASC, created_at ASC, id ASC) order.
-	CursorPriority  string
-	CursorCreatedAt time.Time
-	CursorID        string
+	CursorPriority  string    `json:"cursor_priority"`
+	CursorCreatedAt time.Time `json:"cursor_created_at"`
+	CursorID        string    `json:"cursor_id"`
 }
 
 // ReadyResponse is the output of Ready. SPEC §6.2 Tool 2 + §6.2.0.
@@ -327,12 +327,12 @@ type ReadyRequest struct {
 // the triple into the opaque §6.2.0 cursor token (or null) before
 // surfacing on the wire.
 type ReadyResponse struct {
-	Items      []Item
-	TotalReady int
+	Items      []Item `json:"items"`
+	TotalReady int    `json:"total_ready"`
 
-	NextCursorPriority  string
-	NextCursorCreatedAt time.Time
-	NextCursorID        string
+	NextCursorPriority  string    `json:"next_cursor_priority"`
+	NextCursorCreatedAt time.Time `json:"next_cursor_created_at"`
+	NextCursorID        string    `json:"next_cursor_id"`
 }
 
 // SearchRequest is the input to Search. SPEC §4.4 (round-8: typed
@@ -340,10 +340,10 @@ type ReadyResponse struct {
 // satisfied without an opaque blob in the RPC layer — the MCP layer
 // owns the opaque envelope; here we carry the decoded tuple).
 type SearchRequest struct {
-	OrgID     string
-	ProjectID string
-	Query     string
-	Limit     int
+	OrgID     string `json:"org_id"`
+	ProjectID string `json:"project_id"`
+	Query     string `json:"query"`
+	Limit     int    `json:"limit"`
 
 	// CursorRank / CursorItemID / CursorCommentID are populated together
 	// by the MCP cursor decoder when paginating; all three zero values
@@ -352,95 +352,95 @@ type SearchRequest struct {
 	// §6.2 Tool 9 lines 1449-1452. Mirrors the Ready RPC pattern at the
 	// top of this file; the spec §4.4 SearchRequest type was extended
 	// in round-8 to align with the §6.2.0 cursor contract.
-	CursorRank      float64
-	CursorItemID    string
-	CursorCommentID string
+	CursorRank      float64 `json:"cursor_rank"`
+	CursorItemID    string  `json:"cursor_item_id"`
+	CursorCommentID string  `json:"cursor_comment_id"`
 }
 
 // SearchHit is one row of a Search response. SPEC §4.4.
 type SearchHit struct {
-	ItemID    string
-	Source    string
-	CommentID string
-	Rank      float64
-	Snippet   string
+	ItemID    string  `json:"item_id"`
+	Source    string  `json:"source"`
+	CommentID string  `json:"comment_id"`
+	Rank      float64 `json:"rank"`
+	Snippet   string  `json:"snippet"`
 }
 
 // SearchResponse is the output of Search. SPEC §4.4 (round-8: typed
 // next-cursor fields). The MCP layer encodes the triple into the
 // opaque §6.2.0 cursor token (or null) before surfacing on the wire.
 type SearchResponse struct {
-	Hits []SearchHit
+	Hits []SearchHit `json:"hits"`
 
 	// NextCursorRank / NextCursorItemID / NextCursorCommentID carry the
 	// keyset anchor of the row that would START the next page on the
 	// canonical FTS sort tuple. All three populated together when more
 	// rows exist; all three zero on end-of-stream. Search over-fetches
 	// LIMIT+1 to detect end-of-stream — same pattern as Ready.
-	NextCursorRank      float64
-	NextCursorItemID    string
-	NextCursorCommentID string
+	NextCursorRank      float64 `json:"next_cursor_rank"`
+	NextCursorItemID    string  `json:"next_cursor_item_id"`
+	NextCursorCommentID string  `json:"next_cursor_comment_id"`
 }
 
 // Milestone is the canonical milestone row shape. SPEC §4.4.1.
 type Milestone struct {
-	ID                string
-	ParentMilestoneID string
-	OrgID             string
-	ProjectID         string
-	Name              string
-	Description       string
-	StartDate         string
-	EndDate           string
-	CancelledAt       *time.Time
-	CancelledReason   string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	ID                string     `json:"id"`
+	ParentMilestoneID string     `json:"parent_milestone_id"`
+	OrgID             string     `json:"org_id"`
+	ProjectID         string     `json:"project_id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	StartDate         string     `json:"start_date"`
+	EndDate           string     `json:"end_date"`
+	CancelledAt       *time.Time `json:"cancelled_at"`
+	CancelledReason   string     `json:"cancelled_reason"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
 }
 
 // CreateMilestoneRequest is the input to CreateMilestone. SPEC §4.4.1.
 type CreateMilestoneRequest struct {
-	OrgID             string
-	ProjectID         string
-	ParentMilestoneID string
-	Name              string
-	Description       string
-	StartDate         string
-	EndDate           string
+	OrgID             string `json:"org_id"`
+	ProjectID         string `json:"project_id"`
+	ParentMilestoneID string `json:"parent_milestone_id"`
+	Name              string `json:"name"`
+	Description       string `json:"description"`
+	StartDate         string `json:"start_date"`
+	EndDate           string `json:"end_date"`
 }
 
 // UpdateMilestoneRequest is the input to UpdateMilestone. SPEC §4.4.1.
 type UpdateMilestoneRequest struct {
-	MilestoneID     string
-	Name            *string
-	Description     *string
-	StartDate       *string
-	EndDate         *string
-	CancelledAt     *time.Time
-	CancelledReason *string
+	MilestoneID     string     `json:"milestone_id"`
+	Name            *string    `json:"name"`
+	Description     *string    `json:"description"`
+	StartDate       *string    `json:"start_date"`
+	EndDate         *string    `json:"end_date"`
+	CancelledAt     *time.Time `json:"cancelled_at"`
+	CancelledReason *string    `json:"cancelled_reason"`
 }
 
 // AssignItemRequest is the input to AssignItem. SPEC §4.4.1.
 type AssignItemRequest struct {
-	ItemID         string
-	MilestoneID    string
-	AssignedByUser string
+	ItemID         string `json:"item_id"`
+	MilestoneID    string `json:"milestone_id"`
+	AssignedByUser string `json:"assigned_by_user"`
 }
 
 // MilestoneTreeRequest is the input to MilestoneTree. SPEC §4.4.1.
 type MilestoneTreeRequest struct {
-	OrgID            string
-	ProjectID        string
-	RootMilestoneID  string
-	IncludeCancelled bool
+	OrgID            string `json:"org_id"`
+	ProjectID        string `json:"project_id"`
+	RootMilestoneID  string `json:"root_milestone_id"`
+	IncludeCancelled bool   `json:"include_cancelled"`
 }
 
 // MilestoneNode is one node in the recursive milestone tree response.
 // SPEC §4.4.1.
 type MilestoneNode struct {
-	Milestone Milestone
-	Depth     int
-	Children  []MilestoneNode
+	Milestone Milestone       `json:"milestone"`
+	Depth     int             `json:"depth"`
+	Children  []MilestoneNode `json:"children"`
 }
 
 // MilestoneTreeResponse is the output of MilestoneTree. SPEC §4.4.1.
@@ -451,7 +451,7 @@ type MilestoneNode struct {
 // Encore serialises by field, not by type name. See DECISION trail on
 // bead unblock-tv8.1.)
 type MilestoneTreeResponse struct {
-	Roots []MilestoneNode
+	Roots []MilestoneNode `json:"roots"`
 }
 
 // -----------------------------------------------------------------------------

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -313,6 +313,49 @@ CLI inserts `auth.users` rows directly. The OAuth secrets exist so unit
 tests that exercise `auth.ExchangeOAuthCode` against a stubbed provider
 have a place to read fixtures from.
 
+### 3.6 JSON wire convention (snake_case lock)
+
+Every exported field of every Go struct in `apps/api/` that may transit
+JSON — Encore `//encore:api` request/response types, Pub/Sub payloads,
+MCP tool I/O DTOs, error envelopes, and internal helper structs that
+may be passed to `encoding/json` — MUST declare an explicit
+`json:"snake_case_name"` struct tag. Go's default field-name
+serialisation (PascalCase on the wire) is forbidden — explicit tags
+are the only sanctioned form.
+
+Rationale: §6.2 (MCP tool wire) and §7 (error envelope) already lock
+snake_case for the public agent-facing surface, and
+`apps/api/mcp/**` already implements it verbatim. Extending the same
+convention to the private Encore RPC surface and Pub/Sub payloads
+collapses the project to a single rule, aligns the JSON wire with
+Postgres column names (zero impedance between DB rows and the JSON
+shape an agent observes), and matches `://unblock`'s agent-native
+MCP-first focus. The TypeScript-client cost is absorbed at the
+Astro BFF (Zod schemas at the Astro Actions boundary handle the
+snake_case ↔ camelCase rename if the frontend wants idiomatic JS
+property names).
+
+Exception (third-party HTTP unmarshal): structs that decode a
+third-party HTTP response MAY mirror the third-party wire format —
+the project does not control that shape. See
+`apps/api/auth/oauth.go`'s `githubUserResponse` and
+`githubAccessTokenResponse` (coincidentally already snake_case;
+unmodified).
+
+JSON-RPC protocol fields (`jsonrpc`, `protocolVersion`,
+`structuredContent`, `isError`) follow the MCP 2025-06-18 transport
+specification verbatim — they are not under this project's wire
+convention.
+
+Query-string serialisation (Encore default snake_case per ENCORE.md)
+remains unchanged; the rule above applies to JSON bodies, not URL
+query parameters.
+
+Quality gate (NFR-10): `grep -rnE 'json:"[A-Z]' apps/api/` MUST
+return zero matches. Cross-references:
+[§6.2 (MCP tool wire — snake_case already locked)](#62-tool-by-tool-contracts) /
+[§7 (error envelope — snake_case already locked)](#7-error-envelope-locked).
+
 ---
 
 ## 4. Service Surfaces
@@ -1126,6 +1169,11 @@ object or a JSON-RPC error object per §7.
 
 The arguments and result schemas below are **canonical** for P01. Phase 02
 may add fields (additive only); existing fields are immutable.
+
+> **Wire convention** (cross-ref §3.6): every JSON key in this section is
+> snake_case. §3.6 generalises the same convention to the private Encore
+> RPC surface and Pub/Sub payloads; the rules quoted in this section are
+> the original lock and remain authoritative for MCP.
 
 ### 6.1 MCP framing
 
@@ -2062,6 +2110,11 @@ envelope on overflow includes the offending chain prefix.
 ---
 
 ## 7. Error Envelope (locked)
+
+> **Wire convention** (cross-ref §3.6): every JSON key in this section is
+> snake_case. §3.6 generalises the same convention to the private Encore
+> RPC surface and Pub/Sub payloads; the envelope quoted here remains the
+> authoritative lock for MCP tool errors.
 
 All MCP tool errors return a JSON-RPC 2.0 error object:
 


### PR DESCRIPTION
## unblock-tv8.44: Standardize snake_case JSON tags on all Encore API and internal types in apps/api/

Adds explicit `json:\"snake_case\"` struct tags to every exported field of every Go struct in `apps/api/{auth,org,workitems,deps}/*` that may transit JSON (Encore private RPC types + deps cascade Pub/Sub payloads). Replaces Go's default PascalCase wire serialisation with the same convention SPEC §6.2 + §7 already lock for the public MCP wire.

### What was done
- Added explicit snake_case json tags to ~30 structs across auth/org/workitems/deps and their internal helpers (Identity, AuthData, ValidateRequest/Response, ExchangeOAuthCode*, IssueAPIKey*, RevokeAPIKeyRequest, Organization, Project, CreateOrganizationRequest, CreateProjectRequest, AddMemberRequest, AuthorizeRequest, projectRow, Item, Comment, Trail, CreateRequest, UpdateRequest, AppendCommentRequest, SetStateRequest, GetStateRequest/Response, CloseRequest, ClaimRequest, ListRequest/Response, ReadyRequest/Response, SearchRequest/Hit/Response, Milestone, CreateMilestoneRequest, UpdateMilestoneRequest, AssignItemRequest, MilestoneTreeRequest/Node/Response, Edge, AddEdgeRequest, RemoveEdgeRequest/Response, IsReadyRequest/Response, ClosureRequest/Response, RecentCascadeEventsRequest/Row/Response, CascadeRequested, CascadeCompleted, RecentKindRow).
- Patched docs/specs/01-spec-backend-mvp.md — added §3.6 \"JSON wire convention (snake_case lock)\" between §3.5 and §4, with cross-references from §6.2 and §7.
- Patched CLAUDE.md — added a Go Coding Standards bullet locking the convention with the grep quality gate.

### Files changed
- CLAUDE.md
- docs/specs/01-spec-backend-mvp.md
- apps/api/auth/auth.go
- apps/api/auth/authhandler.go
- apps/api/auth/types/types.go
- apps/api/deps/cascade.go
- apps/api/deps/deps.go
- apps/api/org/org.go
- apps/api/workitems/workitems.go

### Decisions
None — implemented exactly as the orchestrator's 2026-05-21 DECISION (snake_case everywhere; MCP carve-out preserved; third-party oauth.go preserved).

### Deviations
None — implemented as spec.

### Exceptions carried forward (verified)
- `apps/api/auth/oauth.go` `githubUserResponse` / `githubAccessTokenResponse` — third-party HTTP unmarshal types (GitHub-controlled wire), untouched.
- `apps/api/mcp/**` — already snake_case per SPEC §6.2 + §7, untouched (tag count: 204, unchanged).
- `apps/api/shared/mcpaudittest/*` protocol fields (`structuredContent`, `isError`, `protocolVersion`) — MCP 2025-06-18 SDK-mandated camelCase, untouched.

### Quality gates
- `go fmt ./...` → zero diffs
- `go vet ./...` → clean
- `encore check` → exit 0
- `encore test ./...` → all green (auth, deps, mcp, org, shared/*, workitems)
- `grep -rnE 'json:\"[A-Z]' apps/api/` → 0 matches
- `grep -rn 'json:\"' apps/api/mcp/ | wc -l` → 204 (unchanged from pre-state)

### Breaking change
Pre-1.0, no external consumers. The Encore private RPC wire and deps cascade Pub/Sub payloads now serialise as snake_case rather than PascalCase. Single-deploy atomic switch (Encore deploys publisher + subscriber together).