### PR TITLE
unblock-tv8.31: reconcile golangci-lint v2 schema with docstring + custom-gcl example

### DIFF
--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -6,8 +6,9 @@
 # Custom linter wiring:
 #
 # Two project-local analyzers live at apps/api/shared/lint/. Both are
-# consumed via the module-plugin system of golangci-lint v1.57+
-# (see https://golangci-lint.run/plugins/module-plugins/):
+# consumed via the module-plugin system carried into golangci-lint v2.x
+# (see https://golangci-lint.run/plugins/module-plugins/ and the v2
+# migration guide at https://golangci-lint.run/usage/migration-guide/):
 #
 #   - no_direct_is_ready_write — rejects UPDATE statements writing
 #     workitems.items.is_ready or pipeline_stage outside the cascade
@@ -23,11 +24,16 @@
 # Operators who want the custom linters to participate in CI must:
 #
 #   1. Build a custom golangci-lint binary that includes BOTH analyzer
-#      modules (a single .custom-gcl.yml registers the whole module):
+#      modules (a single .custom-gcl.yml registers the whole module).
+#      The `version:` field below pins the BUILT BINARY version (the
+#      tag of golangci-lint to compile against) — NOT the config-file
+#      schema version (that is the top-level `version: "2"` declared
+#      below, line 52). The two must remain consistent: a v2 schema
+#      requires a v2 binary.
 #
 #        cd apps/api
 #        cat > .custom-gcl.yml <<'EOF'
-#        version: v1.61.0
+#        version: v2.5.0
 #        plugins:
 #          - module: encore.app
 #            path: ./shared/lint
@@ -36,7 +42,15 @@
 #
 #   2. Use the resulting `./custom-gcl` binary in CI in place of the
 #      stock `golangci-lint`. Olive (infra-supervisor) wires this into
-#      the GitHub Actions workflow under bead A-6 (unblock-tv8.6).
+#      the GitHub Actions workflow under bead A-6 (unblock-tv8.6); the
+#      exact v2 tag installed in the GHA runner image MUST match the
+#      `version:` pin above.
+#
+# Local developers: this config requires golangci-lint v2.x. If your
+# local binary is v1.x (`golangci-lint --version` reports v1.*), upgrade
+# via `brew upgrade golangci-lint` (or your package manager equivalent)
+# before running the gate. Go 1.26+ source is not reliably typecheckable
+# under v1.x.
 #
 # Local development without a custom binary is still useful: every
 # core linter below runs against the standard golangci-lint binary,

--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -28,7 +28,7 @@
 #      The `version:` field below pins the BUILT BINARY version (the
 #      tag of golangci-lint to compile against) — NOT the config-file
 #      schema version (that is the top-level `version: "2"` declared
-#      below, line 52). The two must remain consistent: a v2 schema
+#      below, line 65). The two must remain consistent: a v2 schema
 #      requires a v2 binary.
 #
 #        cd apps/api


### PR DESCRIPTION
## unblock-tv8.31: Reconcile golangci-lint version pin vs v2 config schema in .golangci.yml

`apps/api/.golangci.yml` declared `version: "2"` (v2 schema) but its docstring referenced "v1.57+" and the embedded `.custom-gcl.yml` example pinned the built-binary version to `v1.61.0`. A v1.x binary cannot load the v2 schema; operators following the docstring would have produced a broken custom-gcl binary, breaking CI under unblock-tv8.6.

### What was done

Aligned the docstring narrative and the embedded `.custom-gcl.yml` example with the file's existing v2 schema header. No behavioural change to the actual linter config — only documentation/example fields were touched.

- Docstring (line 9): "v1.57+" → "carried into golangci-lint v2.x"; added link to v2 migration guide.
- `.custom-gcl.yml` example (line 36): version pin raised from `v1.61.0` → `v2.5.0`.
- Added a clarifying note distinguishing the two `version:` fields (built-binary tag vs. config-file schema).
- Added a local-developer upgrade note for anyone still on v1.x.

### Files changed

- `apps/api/.golangci.yml`

### Decisions

1. Pinned the example to `v2.5.0` (placeholder); Olive overrides at unblock-tv8.6 wiring time to match the exact tag installed in the GHA runner image.
2. Used generic `v2.x` in the docstring rather than a specific minor — the module-plugin system is a v2-wide feature.
3. Added the upgrade note as a separate paragraph (prerequisite signal) rather than folding into the bottom "optional convenience" paragraph.

### Deviations

None — implemented as the investigation prescribed.

### Verification

YAML validity verified via `ruby -ryaml -e 'YAML.load_file'`. The custom-gcl example block is inside a HEREDOC inside a comment, so it does not need to parse as part of the surrounding YAML — only the actual config (lines 65-117) does, and it was untouched. Functional verification of the rendered config is deferred to unblock-tv8.6, where the v2 binary will be installed in the GHA runner and `golangci-lint run --max-warnings 0` will be exercised against `apps/api/`.

Unblocks unblock-tv8.6 (A-6 CI quality gates).