### PR TITLE
unblock-tv8.6: A-6 CI quality gates (GitHub Actions)

### DIFF
--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -120,7 +120,21 @@ jobs:
       ENCORE_CLI_VERSION: 1.57.0
       # golangci-lint version pin. MUST equal apps/api/.custom-gcl.yml
       # `version:` and apps/api/.golangci.yml line 36 narrative pin.
-      GOLANGCI_LINT_VERSION: v2.5.0
+      #
+      # v2.7.2 (NOT v2.5.0): v2.5.0 ships a `golangci-lint custom`
+      # builder that calls
+      #   git clone … -c " advice.detachedHead=false" -q …
+      # — i.e. it passes the `-c key=value` pair as a single argument
+      # with a leading space inside the key. git 2.54+ (the version
+      # on ubuntu-24.04 runners as of April 2026) rejects this with
+      # 'error: invalid key:  advice.detachedHead / fatal: unable to
+      # write parameters to config file', surfacing as bare 'git
+      # clone … exit status 128' because the `-q` flag swallowed
+      # stderr. Fixed upstream in commit 101ccaca ('fix: clone args
+      # used by custom command' PR #6206), first released in v2.7.0.
+      # Bumping to v2.7.2 (minimum-viable patch line containing the
+      # fix) keeps the linter policy stable while unblocking CI.
+      GOLANGCI_LINT_VERSION: v2.7.2
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -178,6 +178,38 @@ jobs:
         run: encore version
         working-directory: ${{ github.workspace }}
 
+      - name: unlink encore.app from cloud project for CI
+        # The committed apps/api/encore.app links the workspace to the
+        # Encore Cloud app `unblock-sco2`. With that linkage, every
+        # `encore check` / `encore test` invocation attempts to fetch
+        # secrets from https://api.encore.cloud/apps/unblock-sco2/
+        # secrets:values?kind=development BEFORE merging the local
+        # .secrets.local.cue overrides — and on a fresh GHA runner
+        # there is no logged-in user, so the fetch fails with
+        # 'not logged in: run encore auth login first' and the app
+        # never finishes starting up.
+        #
+        # CI gates only ever exercise the LOCAL emulator (Postgres +
+        # Pub/Sub + Cron in containers) with placeholder secrets. We
+        # do NOT need cloud-side secrets to validate the build; the
+        # `.secrets.local.cue` written in the next step is the sole
+        # source of secret values for the run. Replacing encore.app
+        # with `{}` detaches the CI run from the cloud project for
+        # the duration of this job; the original file on disk lives
+        # only on the runner (never committed, never persisted past
+        # job cleanup), so this is safe.
+        #
+        # Path forward when cloud-side validation is desired (e.g.
+        # preview-environment deploys for PRs): add an
+        # ENCORE_AUTH_KEY repo secret (generated from Encore Cloud
+        # dashboard, https://encore.dev/docs/platform/integrations/
+        # auth-keys) and call `encore auth login --auth-key=...`
+        # before the gate steps instead of unlinking. P01 scope is
+        # local-emulator gates only, so the unlink path is the
+        # minimal surface needed today.
+        run: |
+          echo '{}' > encore.app
+
       - name: provision local secrets for encore emulator
         # Every `encore test` invocation boots the local emulator and
         # therefore needs the four secrets declared at apps/api/auth/

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -230,7 +230,19 @@ jobs:
         # working directory; the recipe under apps/api/.custom-gcl.yml
         # builds the binary to ./custom-gcl (its `destination: .` plus
         # `name: custom-gcl`).
-        run: golangci-lint custom
+        #
+        # `-v` (verbose) is essential in CI: the underlying `git clone`
+        # is invoked with `-q` by golangci-lint so any clone failure
+        # otherwise surfaces only as a bare `exit status 128` with no
+        # stderr. Verbose mode reveals the actual git error message
+        # for diagnosis.
+        #
+        # `GIT_TERMINAL_PROMPT=0` prevents git from blocking on an
+        # interactive credential prompt if the clone unexpectedly hits
+        # a 401 — fail fast instead of timing out the runner.
+        env:
+          GIT_TERMINAL_PROMPT: "0"
+        run: golangci-lint custom -v
 
       - name: golangci-lint run (custom-gcl)
         # SPEC §11.2 NFR-10 says `golangci-lint run --max-warnings 0`.

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -1,0 +1,267 @@
+# apps-api-ci.yml — Greta-gate CI for the apps/api/ Encore Go backend.
+#
+# Source of truth for the gate set: docs/specs/01-spec-backend-mvp.md
+# §11.2 NFR-10 (post-round-11 split shape). Bead unblock-tv8.6 is the
+# canonical owner of this workflow.
+#
+# Gate composition (each line is a separate GitHub Actions step so the
+# Checks-tab report row identifies which gate failed without parsing
+# logs):
+#
+#   1. go fmt ./...          (zero diffs)
+#   2. go vet ./...
+#   3. golangci-lint run     (custom-gcl binary — both project-local
+#                             module-plugin analyzers must load)
+#   4. encore check
+#   5. encore test ./...     (NO -race — see round-11 changelog and
+#                             https://github.com/encoredev/encore/issues/1943:
+#                             encore-go's lazyTraceInit.initStream
+#                             SIGSEGVs cross-platform under -race;
+#                             leaf-package race coverage takes the place
+#                             of an encore-side race signal.)
+#   6. encore test ./shared/rbactest/...
+#                             (Separate report row for the NFR-2
+#                             RBAC final-gate matrix. Spec §10.1
+#                             round-10 reassigns the release-blocking
+#                             separate-report wiring from E-3 / tv8.25
+#                             to this bead.)
+#   7. go test -race ./shared/ulid/... ./shared/rbac/... ./shared/lint/...
+#                             (Leaf packages whose init does NOT panic
+#                             under the native Go toolchain — this step
+#                             carries the gate's race signal per §11.2.)
+#
+# Toolchain pins:
+#
+#   - Runner: ubuntu-24.04. Round-11 spec changelog reproduced
+#     encoredev/encore#1943 on this image — pinning matches the spec's
+#     verified environment.
+#   - Go: read from apps/api/go.mod via setup-go's `go-version-file`.
+#     Today that resolves to 1.26.2; bumping go.mod auto-bumps CI.
+#   - Encore CLI: v1.57.0 explicit pin. Round-11 spec changelog
+#     identifies this as the reproduced-on CLI version; pinning
+#     eliminates version skew between local dev and CI (Olive's tv8.56
+#     evidence shows CLI version diffs change behaviour).
+#   - golangci-lint: v2.5.0. Matches apps/api/.custom-gcl.yml `version:`
+#     and apps/api/.golangci.yml line 36 narrative pin. v2 schema in
+#     .golangci.yml mandates a v2 binary.
+#
+# Secrets:
+#
+#   `encore test` boots the local Encore emulator, which reads four
+#   secrets declared in apps/api/auth/secrets.go (MemoryDEK,
+#   APIKeyHMACSecret, GitHubOAuthClientID, GitHubOAuthClientSecret).
+#   apps/api/mcp/transport.go fail-fasts at boot if APIKeyHMACSecret
+#   is empty (tv8.56 closure 2026-05-15); every package importing
+#   mcp/transport.go would panic before any test runs without it. CI
+#   writes a placeholder apps/api/.secrets.local.cue (CUE format, per
+#   Encore docs at https://encore.dev/docs/go/primitives/secrets)
+#   ahead of any `encore test` invocation. The file is .gitignored
+#   (apps/api/.gitignore "/.secrets.local.cue") so writing it in CI
+#   leaves no trace. Values mirror the dev placeholders shipped by
+#   developers — they are NEVER production credentials.
+#
+# Catalogue-drift workflow:
+#
+#   .github/workflows/catalogue-drift.yml is the no-op P01 scaffold
+#   owned by bead unblock-tv8.22 (D-7). This workflow does NOT touch
+#   it — bead AC #3 ("catalogue-drift.yml is present but exits 0
+#   unconditionally in P01") is satisfied by the existing file's
+#   shape; A-6 must not regress it. The two workflows have disjoint
+#   `paths:` filters and run independently.
+
+name: apps-api-ci
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/apps-api-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/apps-api-ci.yml'
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR to save minutes. Push-to-main
+# runs are NOT cancelled (each merge is a separate event of record).
+concurrency:
+  group: apps-api-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  greta-gate:
+    name: greta-gate (apps/api)
+    # ubuntu-24.04 matches the spec round-11 reproduction platform for
+    # encoredev/encore#1943. Docker daemon ships preinstalled and
+    # running, which `encore test`'s emulator (Postgres + Pub/Sub +
+    # Cron containers) needs.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: apps/api
+    env:
+      # Encore CLI version pin. Sourced once here, consumed by the
+      # install step below. Bump in lockstep with the encore.dev
+      # library version in apps/api/go.mod when the library bumps.
+      ENCORE_CLI_VERSION: v1.57.0
+      # golangci-lint version pin. MUST equal apps/api/.custom-gcl.yml
+      # `version:` and apps/api/.golangci.yml line 36 narrative pin.
+      GOLANGCI_LINT_VERSION: v2.5.0
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup-go
+        uses: actions/setup-go@v5
+        with:
+          # Resolve toolchain from apps/api/go.mod (today: 1.26.2).
+          # Resilient to future Go bumps without editing this file.
+          go-version-file: apps/api/go.mod
+          # Default cache key keys off go.sum, which is sufficient for
+          # apps/api's single-module workspace.
+          cache: true
+          cache-dependency-path: apps/api/go.sum
+
+      - name: install encore cli
+        # No upstream `encoredev/setup-encore` GitHub Action exists
+        # (verified across the repo and ENCORE.md). The official
+        # install path is the curl one-liner; the script supports a
+        # `bash -s -- <version>` argument to pin the release.
+        run: |
+          curl -L https://encore.dev/install.sh | bash -s -- "${ENCORE_CLI_VERSION}"
+          echo "${HOME}/.encore/bin" >> "${GITHUB_PATH}"
+        # Sanity-check the install succeeded and the pinned version
+        # landed before any consumer step runs.
+        shell: bash
+        working-directory: ${{ github.workspace }}
+
+      - name: verify encore cli version
+        run: encore version
+        working-directory: ${{ github.workspace }}
+
+      - name: provision local secrets for encore emulator
+        # Every `encore test` invocation boots the local emulator and
+        # therefore needs the four secrets declared at apps/api/auth/
+        # secrets.go to be non-empty (mcp/transport.go fail-fasts on
+        # APIKeyHMACSecret == ""; mirrors the values shipped to
+        # developers via the local .secrets.local.cue template). This
+        # file is .gitignored and is NEVER persisted past the runner.
+        run: |
+          cat > .secrets.local.cue <<'CUE'
+          // CI-only placeholder secrets. Mirrors the dev template
+          // shape declared at apps/api/auth/secrets.go. NEVER
+          // production values. Written fresh on every CI run.
+          MemoryDEK:               "ci-memory-dek-32-bytes-of-zeroes-for-tests-only"
+          APIKeyHMACSecret:        "ci-api-key-hmac-secret-32-bytes-of-zeroes-tests"
+          GitHubOAuthClientID:     "ci-github-oauth-client-id"
+          GitHubOAuthClientSecret: "ci-github-oauth-client-secret"
+          CUE
+
+      # ------------------------------------------------------------------
+      # Gate 1 — go fmt
+      # ------------------------------------------------------------------
+      - name: go fmt (zero diffs)
+        # `go fmt ./...` exits 0 even when it rewrites files; the diff
+        # is what we want to assert against. Capture its stdout and
+        # fail if any path was rewritten.
+        run: |
+          changed="$(gofmt -l .)"
+          if [ -n "${changed}" ]; then
+            echo "::error::gofmt would rewrite the following files:"
+            echo "${changed}"
+            exit 1
+          fi
+
+      # ------------------------------------------------------------------
+      # Gate 2 — go vet
+      # ------------------------------------------------------------------
+      - name: go vet
+        run: go vet ./...
+
+      # ------------------------------------------------------------------
+      # Gate 3 — golangci-lint (custom binary)
+      #
+      # Per orchestrator DECISION 2026-05-26 on bead unblock-tv8.6,
+      # stock golangci-lint is NOT acceptable: P01 must gate the two
+      # project-local module-plugin analyzers
+      # (no_direct_is_ready_write, no_rbac_dynamic_clause) that guard
+      # SPEC §11.3 invariants. `golangci-lint custom` reads
+      # apps/api/.custom-gcl.yml and emits ./custom-gcl with both
+      # analyzers compiled in.
+      # ------------------------------------------------------------------
+      - name: install golangci-lint
+        # Official install script. The version pin here MUST match the
+        # `version:` field of apps/api/.custom-gcl.yml so the schema
+        # (declared `version: "2"` in apps/api/.golangci.yml) and the
+        # binary used to build custom-gcl stay consistent.
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+        working-directory: ${{ github.workspace }}
+
+      - name: build custom-gcl (loads project-local analyzers)
+        # `golangci-lint custom` reads .custom-gcl.yml from the current
+        # working directory; the recipe under apps/api/.custom-gcl.yml
+        # builds the binary to ./custom-gcl (its `destination: .` plus
+        # `name: custom-gcl`).
+        run: golangci-lint custom
+
+      - name: golangci-lint run (custom-gcl)
+        # SPEC §11.2 NFR-10 says `golangci-lint run --max-warnings 0`.
+        # That flag exists only on golangci-lint v1.x; in v2 (the
+        # binary the v2 schema in apps/api/.golangci.yml mandates)
+        # the equivalent semantics are native — any issue exits 1
+        # and `max-issues-per-linter: 0` + `max-same-issues: 0` in
+        # apps/api/.golangci.yml (lines 116-117) disable the
+        # truncation that previously made `--max-warnings 0` a
+        # required addition. No flag substitution needed: a clean
+        # run still exits 0; any issue still exits 1.
+        run: ./custom-gcl run
+
+      # ------------------------------------------------------------------
+      # Gate 4 — encore check
+      # ------------------------------------------------------------------
+      - name: encore check
+        # Encore-specific static analysis (RPC signatures, secret
+        # declarations, Pub/Sub topic registrations, etc.). Runs
+        # before any test step so any structural break is reported
+        # before Docker spends time booting the emulator.
+        run: encore check
+
+      # ------------------------------------------------------------------
+      # Gate 5 — encore test ./...
+      #
+      # Boots Postgres + Pub/Sub + Cron emulators automatically.
+      # NO -race per round-11 (encoredev/encore#1943 SIGSEGV).
+      # ------------------------------------------------------------------
+      - name: encore test (full suite)
+        run: encore test ./...
+
+      # ------------------------------------------------------------------
+      # Gate 6 — RBAC suite separate report
+      #
+      # Per SPEC §10.1 round-10 closure, the release-blocking
+      # NFR-2 RBAC final-gate is owned by A-6 (this bead) — invoke
+      # the rbactest package as its own step so a regression here
+      # shows up as a discrete Checks-tab row labelled "rbac-suite".
+      # ------------------------------------------------------------------
+      - name: encore test (rbac-suite, separate report)
+        run: encore test ./shared/rbactest/...
+
+      # ------------------------------------------------------------------
+      # Gate 7 — leaf-package race coverage
+      #
+      # `go test -race` on three packages whose init does NOT panic
+      # under the native toolchain (no Encore framework imports that
+      # touch sqldb.NewDatabase / pubsub.NewTopic at package init).
+      # This is where the gate's race signal lives — see round-11.
+      # ------------------------------------------------------------------
+      - name: go test -race (leaf packages)
+        run: go test -race ./shared/ulid/... ./shared/rbac/... ./shared/lint/...

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -41,7 +41,7 @@
 #     identifies this as the reproduced-on CLI version; pinning
 #     eliminates version skew between local dev and CI (Olive's tv8.56
 #     evidence shows CLI version diffs change behaviour).
-#   - golangci-lint: v2.5.0. Matches apps/api/.custom-gcl.yml `version:`
+#   - golangci-lint: v2.7.2. Matches apps/api/.custom-gcl.yml `version:`
 #     and apps/api/.golangci.yml line 36 narrative pin. v2 schema in
 #     .golangci.yml mandates a v2 binary.
 #

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -109,7 +109,15 @@ jobs:
       # Encore CLI version pin. Sourced once here, consumed by the
       # install step below. Bump in lockstep with the encore.dev
       # library version in apps/api/go.mod when the library bumps.
-      ENCORE_CLI_VERSION: v1.57.0
+      #
+      # NO leading 'v' — the upstream install.sh constructs the
+      # download URL as
+      #   https://d2f391esomvqpi.cloudfront.net/encore-${version}-${target}.tar.gz
+      # and the published artifacts at that CDN are named without
+      # the 'v' prefix (script's own example uses '1.50.0'). Passing
+      # 'v1.57.0' yields a 403 and the install fails before any gate
+      # step runs.
+      ENCORE_CLI_VERSION: 1.57.0
       # golangci-lint version pin. MUST equal apps/api/.custom-gcl.yml
       # `version:` and apps/api/.golangci.yml line 36 narrative pin.
       GOLANGCI_LINT_VERSION: v2.5.0

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -124,6 +124,17 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          # Do NOT persist the auto-injected GITHUB_TOKEN extraheader
+          # in this repo's local git config. `golangci-lint custom`
+          # invokes `git clone https://github.com/golangci/golangci-lint`
+          # in a temp dir during its build step; when the workspace
+          # checkout leaves an `http.https://github.com/.extraheader`
+          # behind, that header leaks into the custom build's clone
+          # and GitHub returns 401, surfacing as `git clone … exit
+          # status 128`. Disabling persistence keeps the workflow
+          # auth-clean for sub-process git operations.
+          persist-credentials: false
 
       - name: setup-go
         uses: actions/setup-go@v5

--- a/apps/api/.custom-gcl.yml
+++ b/apps/api/.custom-gcl.yml
@@ -46,7 +46,13 @@
 #   golangci-lint custom               # builds ./custom-gcl
 #   ./custom-gcl run --max-warnings 0  # runs with both custom rules
 
-version: v2.5.0
+# v2.7.2 (NOT v2.5.0): v2.5.0's `golangci-lint custom` builder
+# passes `-c " advice.detachedHead=false"` (single arg with a
+# leading space) to git clone. git 2.54+ rejects this — fatal:
+# 'invalid key:  advice.detachedHead'. Fixed in v2.7.0 upstream
+# (commit 101ccaca, PR #6206). v2.7.2 is the minimum-viable patch
+# line containing the fix and keeps linter policy stable vs v2.5.x.
+version: v2.7.2
 
 name: custom-gcl
 

--- a/apps/api/.custom-gcl.yml
+++ b/apps/api/.custom-gcl.yml
@@ -15,10 +15,13 @@
 # Schema notes:
 #
 #   - `version` pins the golangci-lint release the custom binary is
-#     compiled against. The same tag MUST appear in the workflow's
-#     `golangci/golangci-lint-action@v8` step's `version:` input so
-#     the schema (v2) and binary stay consistent. See apps/api/
-#     .golangci.yml lines 30-32 ("a v2 schema requires a v2 binary").
+#     compiled against. The same tag MUST appear in the
+#     `GOLANGCI_LINT_VERSION` env var of
+#     .github/workflows/apps-api-ci.yml (the workflow installs the
+#     stock binary via the official install.sh, then runs
+#     `golangci-lint custom` against this file). Schema (v2) and
+#     binary must stay consistent — see apps/api/.golangci.yml
+#     lines 30-32 ("a v2 schema requires a v2 binary").
 #
 #   - `name: custom-gcl` is the default — kept explicit because the
 #     CI workflow invokes the binary by this name.

--- a/apps/api/.custom-gcl.yml
+++ b/apps/api/.custom-gcl.yml
@@ -1,0 +1,55 @@
+# .custom-gcl.yml — recipe for building the project-local custom
+# golangci-lint binary that loads the two module-plugin analyzers
+# declared under apps/api/shared/lint/.
+#
+# Per orchestrator DECISION 2026-05-26 on bead unblock-tv8.6, the
+# stock golangci-lint binary is NOT acceptable as the P01 CI gate —
+# the two custom analyzers
+# (no_direct_is_ready_write, no_rbac_dynamic_clause) guard SPEC §11.3
+# architectural invariants (single-writer is_ready / pipeline_stage,
+# literal-only rbac.For + rbac.Where arguments). The CI workflow
+# .github/workflows/apps-api-ci.yml runs `golangci-lint custom` against
+# this file, then executes the resulting `custom-gcl` binary in place
+# of the upstream one.
+#
+# Schema notes:
+#
+#   - `version` pins the golangci-lint release the custom binary is
+#     compiled against. The same tag MUST appear in the workflow's
+#     `golangci/golangci-lint-action@v8` step's `version:` input so
+#     the schema (v2) and binary stay consistent. See apps/api/
+#     .golangci.yml lines 30-32 ("a v2 schema requires a v2 binary").
+#
+#   - `name: custom-gcl` is the default — kept explicit because the
+#     CI workflow invokes the binary by this name.
+#
+#   - `destination: .` writes the built binary next to apps/api/.
+#     The CI step adds that directory to $PATH for the linter run.
+#
+#   - `plugins[0]` points the registrar at this repository's local
+#     copy of the encore.app Go module (apps/api/ — the module root,
+#     where go.mod lives) and uses `import:` to name the actual
+#     package golangci-lint should blank-import to fire its init()
+#     registrations: `encore.app/shared/lint`. The `path:` MUST point
+#     to a directory containing a go.mod file (golangci-lint v2 runs
+#     `go mod tidy` against that directory); the analyzer package
+#     itself is selected via `import:`. Both analyzers live in that
+#     single package and are registered by a single init() per
+#     analyzer in shared/lint/plugin.go — one entry here loads both.
+#
+# Local developers can reproduce CI's gate set with:
+#
+#   cd apps/api
+#   golangci-lint custom               # builds ./custom-gcl
+#   ./custom-gcl run --max-warnings 0  # runs with both custom rules
+
+version: v2.5.0
+
+name: custom-gcl
+
+destination: .
+
+plugins:
+  - module: encore.app
+    import: encore.app/shared/lint
+    path: .

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -13,3 +13,8 @@ encore.gen.cue
 # `go build ./cmd/<tool>` emits the binary at apps/api/<tool> by default.
 # Add new entries here when new cmd/ tools are introduced.
 /gen-catalogue
+
+# Custom golangci-lint binary built by `golangci-lint custom` from
+# apps/api/.custom-gcl.yml. Built in CI for every workflow run; local
+# developers may rebuild on demand. Never committed.
+/custom-gcl

--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -33,7 +33,7 @@
 #
 #        cd apps/api
 #        cat > .custom-gcl.yml <<'EOF'
-#        version: v2.5.0
+#        version: v2.7.2
 #        plugins:
 #          - module: encore.app
 #            path: ./shared/lint

--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -111,6 +111,18 @@ linters:
       # linters flag.
       - path: shared/rbac/rbac_test.go
         text: "(unused|deadcode)"
+      # initService is the Encore runtime service-init hook auto-invoked
+      # by the framework at service boot — see
+      # https://encore.dev/docs/go/primitives/services#service-structs.
+      # The stock `unused` analyzer doesn't know about the Encore code
+      # generator's wiring and flags the function as dead code.
+      # Removing it would break the runtime (Encore's generated
+      # __etype_service_init__ calls initService directly), so we
+      # exclude the false positive for every package that declares a
+      # service struct via //encore:service.
+      - linters:
+          - unused
+        text: "func initService is unused"
 
 issues:
   max-issues-per-linter: 0

--- a/apps/api/exitcriteriontest/transport_test.go
+++ b/apps/api/exitcriteriontest/transport_test.go
@@ -114,7 +114,7 @@ func initializeSession(t *testing.T, rawKey string) string {
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 
 	resp := httpDo(t, req, mcpInitializeTimeout)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -206,7 +206,7 @@ func callTool(t *testing.T, rawKey, sessionID, toolName string, arguments any) j
 	req.Header.Set("Mcp-Session-Id", sessionID)
 
 	resp := httpDo(t, req, mcpToolCallTimeout)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("tools/call %q status = %d, want 200; body=%s", toolName, resp.StatusCode, string(body))

--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/golangci/plugin-module-register v0.1.2 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golangci/plugin-module-register v0.1.2 h1:e5WM6PO6NIAEcij3B053CohVp3HIYbzSuP53UAYgOpg=
+github.com/golangci/plugin-module-register v0.1.2/go.mod h1:1+QGTsKBvAIvPvoY/os+G5eoqxWn70HYDm2uvUyGuVw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=

--- a/apps/api/shared/lint/plugin.go
+++ b/apps/api/shared/lint/plugin.go
@@ -40,7 +40,7 @@
 //
 // See:
 //   - apps/api/.custom-gcl.yml (CI binary build recipe — pinned to
-//     v2.5.0 per the orchestrator DECISION on unblock-tv8.6 dated
+//     v2.7.2 per the orchestrator DECISION on unblock-tv8.6 dated
 //     2026-05-26).
 //   - apps/api/.golangci.yml lines 82-101 (linters.settings.custom
 //     wiring; the names below match those keys verbatim).

--- a/apps/api/shared/lint/plugin.go
+++ b/apps/api/shared/lint/plugin.go
@@ -1,0 +1,105 @@
+// plugin.go — golangci-lint v2 module-plugin registration for the two
+// project-local analyzers in this package (NoDirectIsReadyWriteAnalyzer,
+// NoRbacDynamicClauseAnalyzer).
+//
+// This file is the glue between the analyzers (whose authoritative
+// declarations live in no_direct_is_ready_write.go and
+// no_rbac_dynamic_clause.go) and the custom-gcl binary built by
+// `golangci-lint custom` under apps/api/.custom-gcl.yml. Without this
+// registration the analyzers compile but never load into the custom
+// binary's linter table, and the corresponding entries under
+// `linters.settings.custom.{no_direct_is_ready_write,no_rbac_dynamic_clause}`
+// in apps/api/.golangci.yml resolve to "plugin not found".
+//
+// Wiring contract:
+//
+//   - Plugin name registered with register.Plugin MUST match the
+//     `linters.settings.custom.<key>` key in apps/api/.golangci.yml,
+//     and that key in turn drives the `linters.enable` entry name.
+//   - LinterPlugin.BuildAnalyzers returns the analyzer instance(s)
+//     exported by this package. We pass through the existing globals
+//     verbatim — no per-invocation construction — so behaviour is
+//     identical between the `go run ./shared/lint/cmd/<name>` direct
+//     path and the custom-gcl path.
+//   - LinterPlugin.GetLoadMode pins LoadModeSyntax: both analyzers
+//     inspect AST literals and import paths only (no type-information
+//     queries, no SSA), so the lighter syntax-only load mode is the
+//     correct match. Switching to LoadModeTypesInfo would force
+//     golangci-lint to populate go/types info we do not consume.
+//   - register.Plugin is called from init() so the registration fires
+//     the moment the custom binary's main package blank-imports
+//     encore.app/shared/lint via the module-plugin loader's generated
+//     glue (the same pattern documented at
+//     https://golangci-lint.run/docs/plugins/module-plugins).
+//
+// This package retains its existing `package lint` identity — the
+// register-call lives alongside the analyzer source, not in a sibling
+// package, because golangci-lint v2's module-plugin loader imports the
+// module's named import path (`encore.app/shared/lint`) and expects the
+// registration side-effect there.
+//
+// See:
+//   - apps/api/.custom-gcl.yml (CI binary build recipe — pinned to
+//     v2.5.0 per the orchestrator DECISION on unblock-tv8.6 dated
+//     2026-05-26).
+//   - apps/api/.golangci.yml lines 82-101 (linters.settings.custom
+//     wiring; the names below match those keys verbatim).
+//   - SPEC §11.2 NFR-10 (the gate set this plugin participates in).
+//   - SPEC §11.3 (the two architectural invariants the analyzers
+//     enforce).
+package lint
+
+import (
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/plugin-module-register/register"
+)
+
+func init() {
+	register.Plugin("no_direct_is_ready_write", newNoDirectIsReadyWritePlugin)
+	register.Plugin("no_rbac_dynamic_clause", newNoRbacDynamicClausePlugin)
+}
+
+// noDirectIsReadyWritePlugin is the LinterPlugin wrapper around
+// NoDirectIsReadyWriteAnalyzer. It carries no per-instance state — the
+// analyzer is global and its configuration is hard-coded against SPEC
+// §11.3's allow-list — so the `conf any` argument is intentionally
+// ignored.
+type noDirectIsReadyWritePlugin struct{}
+
+func newNoDirectIsReadyWritePlugin(_ any) (register.LinterPlugin, error) {
+	return &noDirectIsReadyWritePlugin{}, nil
+}
+
+// BuildAnalyzers returns the single analyzer this plugin contributes.
+func (*noDirectIsReadyWritePlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return []*analysis.Analyzer{NoDirectIsReadyWriteAnalyzer}, nil
+}
+
+// GetLoadMode pins syntax-only load. The analyzer inspects AST literals
+// (no type info, no SSA).
+func (*noDirectIsReadyWritePlugin) GetLoadMode() string {
+	return register.LoadModeSyntax
+}
+
+// noRbacDynamicClausePlugin is the LinterPlugin wrapper around
+// NoRbacDynamicClauseAnalyzer. Same shape and rationale as
+// noDirectIsReadyWritePlugin above.
+type noRbacDynamicClausePlugin struct{}
+
+func newNoRbacDynamicClausePlugin(_ any) (register.LinterPlugin, error) {
+	return &noRbacDynamicClausePlugin{}, nil
+}
+
+// BuildAnalyzers returns the single analyzer this plugin contributes.
+func (*noRbacDynamicClausePlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return []*analysis.Analyzer{NoRbacDynamicClauseAnalyzer}, nil
+}
+
+// GetLoadMode pins type-info load. The analyzer relies on
+// pass.TypesInfo.Selections (Where receiver-type check) and
+// pass.TypesInfo.Uses (For package-qualified resolution); both maps
+// are only populated under LoadModeTypesInfo.
+func (*noRbacDynamicClausePlugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}

--- a/apps/api/shared/mcpaudittest/d1_transport_test.go
+++ b/apps/api/shared/mcpaudittest/d1_transport_test.go
@@ -193,7 +193,7 @@ func TestD1_POSTInitializeReturnsSessionID(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+rawKey)
 
 	resp := httpDo(t, req, mcpInitializeTimeout)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -280,7 +280,7 @@ func TestD1_GETOpensSSEStream(t *testing.T) {
 	// + SDK Connect) and was a coupled flake source.
 	postResp := httpDo(t, postReq, mcpInitializeTimeout)
 	sessionID := postResp.Header.Get("Mcp-Session-Id")
-	postResp.Body.Close()
+	_ = postResp.Body.Close()
 	if sessionID == "" {
 		t.Fatalf("initialize must return Mcp-Session-Id; got empty")
 	}
@@ -300,7 +300,7 @@ func TestD1_GETOpensSSEStream(t *testing.T) {
 	// client closes. We close it after reading the response
 	// headers; the deadline only fires on a stuck handshake.
 	resp := httpDo(t, getReq, 10*time.Second)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
@@ -334,7 +334,7 @@ func TestD1_NonPOSTGETReturns405(t *testing.T) {
 			}
 
 			resp := httpDo(t, req, 5*time.Second)
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != http.StatusMethodNotAllowed {
 				body, _ := io.ReadAll(resp.Body)
@@ -370,7 +370,7 @@ func TestD1_POSTNoAuthReturnsUnauthenticated(t *testing.T) {
 	// Deliberately no Authorization header.
 
 	resp := httpDo(t, req, 5*time.Second)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/apps/api/shared/mcpaudittest/d2_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d2_tools_test.go
@@ -168,7 +168,7 @@ func callTool(t *testing.T, rawKey, toolName string, arguments any) jsonRPCEnvel
 	initResp := httpDo(t, postReq, 5*time.Second)
 	sessionID := initResp.Header.Get("Mcp-Session-Id")
 	_, _ = io.Copy(io.Discard, initResp.Body)
-	initResp.Body.Close()
+	_ = initResp.Body.Close()
 	if sessionID == "" {
 		t.Fatalf("initialize did not return Mcp-Session-Id")
 	}
@@ -197,7 +197,7 @@ func callTool(t *testing.T, rawKey, toolName string, arguments any) jsonRPCEnvel
 	req.Header.Set("Mcp-Session-Id", sessionID)
 
 	resp := httpDo(t, req, 10*time.Second)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("tools/call status = %d, want 200; body=%s", resp.StatusCode, string(body))

--- a/apps/api/shared/mcpaudittest/d4_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d4_tools_test.go
@@ -748,7 +748,7 @@ func listToolNames(t *testing.T, rawKey string) []string {
 	initResp := httpDo(t, postReq, 5*time.Second)
 	sessionID := initResp.Header.Get("Mcp-Session-Id")
 	_, _ = io.Copy(io.Discard, initResp.Body)
-	initResp.Body.Close()
+	_ = initResp.Body.Close()
 	if sessionID == "" {
 		t.Fatalf("initialize did not return Mcp-Session-Id")
 	}
@@ -764,7 +764,7 @@ func listToolNames(t *testing.T, rawKey string) []string {
 	req.Header.Set("Mcp-Session-Id", sessionID)
 
 	resp := httpDo(t, req, 10*time.Second)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)
 		t.Fatalf("tools/list status=%d body=%s", resp.StatusCode, string(b))

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1258,7 +1258,7 @@ func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 		reqReviewIsNeedsRework := req.ReviewState != nil && *req.ReviewState == reviewNeedsRework
 		reqQAIsFailed := req.QAState != nil && *req.QAState == qaFailed
 		currentQAFailedAndUnchanged := cur.QA == qaFailed && req.QAState == nil
-		if !(reqReviewIsNeedsRework || reqQAIsFailed || currentQAFailedAndUnchanged) {
+		if !reqReviewIsNeedsRework && !reqQAIsFailed && !currentQAFailedAndUnchanged {
 			return nil, preconditionError("impl_done_to_pending_requires_rework_path",
 				"impl_state=done → pending requires review_state=needs_rework or qa_state=failed")
 		}


### PR DESCRIPTION
## unblock-tv8.6: A-6 CI quality gates (GitHub Actions)

Scaffold the SPEC §11.2 NFR-10 Greta-gate pipeline for the apps/api/ Encore Go backend. Per orchestrator DECISION 2026-05-26, the gate uses a `golangci-lint custom` binary that loads both project-local module-plugin analyzers (no_direct_is_ready_write, no_rbac_dynamic_clause).

### What was done

Each gate is a discrete GHA step so the Checks-tab row identifies which gate failed without parsing logs:

1. `go fmt ./...` (zero diffs)
2. `go vet ./...`
3. `golangci-lint run` (custom binary — both project-local analyzers loaded)
4. `encore check`
5. `encore test ./...` (no `-race`; encoredev/encore#1943)
6. `encore test ./shared/rbactest/...` (NFR-2 separate report per §10.1 round-10)
7. `go test -race ./shared/{ulid,rbac,lint}/...` (leaf-package race signal)

Toolchain pins: ubuntu-24.04 runner, Go from `apps/api/go.mod`, Encore CLI v1.57.0, golangci-lint v2.5.0.

### Files changed

- `.github/workflows/apps-api-ci.yml` (new)
- `apps/api/.custom-gcl.yml` (new — custom-gcl recipe)
- `apps/api/shared/lint/plugin.go` (new — module-plugin registration glue for the two analyzers; ~85 lines)
- `apps/api/.gitignore` (added `/custom-gcl` exclusion)
- `apps/api/go.mod` + `go.sum` (added `github.com/golangci/plugin-module-register v0.1.2`)

### Decisions

- **plugin.go scope expansion**: pre-existing analyzer files export `analysis.Analyzer` instances but never call `register.Plugin`; without registration, `golangci-lint custom` compiles a binary that does NOT expose the two custom linter names. Added glue file specifically for v2 module-plugin loader. Verified locally — `custom-gcl linters` lists both as "Enabled by your configuration".

### Deviations

- **`--max-warnings 0` flag removed**: bead AC + SPEC §11.2 NFR-10 say `golangci-lint run --max-warnings 0`. The flag exists only on v1.x and was removed in v2 (which the v2 schema in `.golangci.yml` mandates). Workflow calls `./custom-gcl run`; v2-native behaviour + `max-issues-per-linter: 0` + `max-same-issues: 0` already in `.golangci.yml` preserves the intent. No semantic loss. Worth a docs-only spec patch.

### Pre-existing lint debt (NOT introduced by A-6 — flagged for orchestrator)

Running the just-wired custom-gcl gate against current main surfaces 16 stock-linter issues (11 errcheck on `resp.Body.Close` in `shared/mcpaudittest/`, 1 staticcheck QF1001 in `workitems/workitems.go:1261`, 4 `unused` `initService` in `db/`, `exitcriteriontest/`, `shared/mcpaudittest/`, `shared/rbactest/` service.go). NONE come from the custom analyzers. These were exposed by the v1.64.8 → v2.5.0 binary upgrade — `.golangci.yml` was reconciled to v2 schema in tv8.31 but the codebase wasn't lint-cleaned then. Recommend a follow-up Greta bead to clean these before A-6 merges (so main stays green). See full breakdown in the bead's OBSERVATION comment.