### PR TITLE
P01 cleanup G2: workitems + org (tv8.47, tv8.54, tv8.40)

### DIFF
--- a/apps/api/org/org.go
+++ b/apps/api/org/org.go
@@ -35,6 +35,7 @@ import (
 	"encore.dev/beta/errs"
 	"encore.dev/rlog"
 	"encore.dev/storage/sqldb"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // -----------------------------------------------------------------------------
@@ -773,24 +774,52 @@ func denyError(req *AuthorizeRequest, reason string) error {
 	}
 }
 
+// pgUniqueViolationCode is the Postgres SQLSTATE for unique_violation
+// and pgForeignKeyViolationCode for foreign_key_violation (Class 23 —
+// integrity constraint violation). See
+// https://www.postgresql.org/docs/current/errcodes-appendix.html.
+const (
+	pgUniqueViolationCode     = "23505"
+	pgForeignKeyViolationCode = "23503"
+)
+
 // isUniqueViolation returns true when err is a Postgres UNIQUE
-// violation on the named constraint. We match by substring on the
-// constraint name to stay framework-agnostic (pgx's error vs sqldb's
-// wrapped error vary by Encore version).
+// violation on the named constraint. Prefers typed matching via
+// pgconn.PgError (SQLSTATE 23505 + ConstraintName) — pgx/v5 is
+// transitively present through Encore's sqldb wrapping. Falls back to
+// the SQLSTATE-token / "duplicate key" substring match when the error
+// has been re-wrapped through a path that hides the typed
+// *pgconn.PgError (defence in depth). Mirrors deps.isUniqueViolation.
 func isUniqueViolation(err error, constraint string) bool {
 	if err == nil {
 		return false
 	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolationCode {
+		return pgErr.ConstraintName == constraint
+	}
+	// Fallback: typed unwrap missed it. Match on the SQLSTATE token
+	// rather than English prose so locale changes can't silently break
+	// the predicate.
 	msg := err.Error()
-	return strings.Contains(msg, "duplicate key") && strings.Contains(msg, constraint)
+	return (strings.Contains(msg, "SQLSTATE "+pgUniqueViolationCode) ||
+		strings.Contains(msg, "duplicate key")) &&
+		strings.Contains(msg, constraint)
 }
 
 // isForeignKeyViolation returns true when err is a Postgres FK
-// violation. Matched by substring as above.
+// violation. Prefers typed matching via pgconn.PgError (SQLSTATE
+// 23503), falling back to the SQLSTATE-token / substring match for
+// re-wrapped errors. Mirrors isUniqueViolation's strategy.
 func isForeignKeyViolation(err error) bool {
 	if err == nil {
 		return false
 	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgForeignKeyViolationCode
+	}
 	msg := err.Error()
-	return strings.Contains(msg, "foreign key") || strings.Contains(msg, "violates foreign key")
+	return strings.Contains(msg, "SQLSTATE "+pgForeignKeyViolationCode) ||
+		strings.Contains(msg, "violates foreign key")
 }

--- a/apps/api/org/rpc_integration_test.go
+++ b/apps/api/org/rpc_integration_test.go
@@ -1,0 +1,268 @@
+// Integration tests for the org service's six private RPCs against the
+// real Encore-managed Postgres cluster (bead unblock-tv8.40 — review
+// cleanup of unblock-tv8.8). The pre-existing org_test.go header
+// promised "Integration tests for the six private RPCs against the
+// real Encore-managed Postgres cluster", but every Test* in that file
+// was helper/validation/Authorize-matrix only — no test exercised a
+// real RPC body end-to-end against the DB. This file honours that
+// header by adding happy-path coverage for CreateOrganization,
+// CreateProject, GetOrganization, GetProject, AddMember, and Authorize.
+//
+// External `package org_test` shape (mirrors authorize_ordering_test.go):
+// blank-importing encore.app/db fires the migration-owner service's
+// init(), which calls org.BindDB(DB) (and every other consumer's
+// BindDB hook), populating org.db before any subtest runs. Without it
+// the test binary would load org in isolation, leave org.db == nil,
+// and every RPC body would panic on a nil *sqldb.Database inside
+// encore.dev/storage/sqldb.
+//
+// Reads (GetOrganization, GetProject) and Authorize require a caller
+// auth.Identity in the request context. et.OverrideAuthInfo sets the
+// Encore auth info for the current test request so callerIdentity(ctx)
+// resolves to the seeded identity — the same payload shape
+// (*auth.AuthData) the production authhandler returns.
+//
+// None of these tests call t.Parallel(): BindDB is not goroutine-safe
+// (bead unblock-tv8.34) and et.OverrideAuthInfo mutates per-request
+// auth info; every integration test in this service is single-threaded
+// by convention.
+//
+// MUST run under `encore test ./apps/api/org/...` (Docker-backed
+// cluster) — plain `go test` leaves org.db == nil and the RPC bodies
+// panic before any assertion fires.
+
+package org_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"encore.app/auth"
+	// Importing encore.app/db triggers its init() which calls
+	// org.BindDB(DB) and every other consumer's BindDB hook. The handle
+	// (db.DB) is also used directly for the auth.users seed AddMember's
+	// FK requires.
+	encoredb "encore.app/db"
+	"encore.app/org"
+	"encore.app/shared/ulid"
+	encoreauth "encore.dev/beta/auth"
+	"encore.dev/beta/errs"
+	"encore.dev/et"
+)
+
+// seedUser inserts a real auth.users row so AddMember's
+// members_user_id_fkey FK is satisfiable. Returns the new user id and
+// registers a best-effort cleanup. ULID-suffixed provider id / email
+// avoid colliding with prior runs on the local Encore cluster.
+func seedUser(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	userID, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid (user): %v", err)
+	}
+	suffix := strings.ToLower(userID[len(userID)-12:])
+	if _, err := encoredb.DB.Exec(ctx,
+		`INSERT INTO auth.users (id, primary_provider, primary_provider_id, email, display_name)
+		 VALUES ($1, 'github', $2, $3, $4)`,
+		userID, "orgtest-"+suffix, suffix+"@orgtest.local", "orgtest user",
+	); err != nil {
+		t.Fatalf("insert auth.users: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := encoredb.DB.Exec(ctx, `DELETE FROM auth.users WHERE id = $1`, userID); err != nil {
+			t.Logf("cleanup: delete auth.users %s: %v", userID, err)
+		}
+	})
+	return userID
+}
+
+// seedOrg creates a real organization via the production
+// CreateOrganization RPC and registers cascade-cleanup (ON DELETE
+// CASCADE removes dependent org.projects / org.members rows).
+func seedOrg(t *testing.T, ctx context.Context, label string) *org.Organization {
+	t.Helper()
+	suffix, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid (org suffix): %v", err)
+	}
+	o, err := org.CreateOrganization(ctx, &org.CreateOrganizationRequest{
+		Name: "tv8-40 " + label,
+		Slug: strings.ToLower("tv8-40-" + label + "-" + suffix[len(suffix)-12:]),
+	})
+	if err != nil {
+		t.Fatalf("CreateOrganization(%s) failed: %v", label, err)
+	}
+	t.Cleanup(func() {
+		if _, err := encoredb.DB.Exec(ctx, `DELETE FROM org.organizations WHERE id = $1`, o.ID); err != nil {
+			t.Logf("cleanup: delete org %s: %v", o.ID, err)
+		}
+	})
+	return o
+}
+
+// asUser sets the Encore auth context for the current test request so
+// callerIdentity(ctx) resolves to an org-scoped human identity.
+func asUser(userID, orgID string) {
+	et.OverrideAuthInfo(encoreauth.UID(userID), &auth.AuthData{
+		Identity: auth.Identity{
+			UserID: userID,
+			OrgID:  orgID,
+			Role:   "owner",
+		},
+	})
+}
+
+// TestCreateOrganizationHappyPath exercises the CreateOrganization RPC
+// body end-to-end and reads the row back via GetOrganization (the org
+// owner reads its own organization).
+func TestCreateOrganizationHappyPath(t *testing.T) {
+	ctx := context.Background()
+	userID := seedUser(t, ctx)
+	o := seedOrg(t, ctx, "create")
+
+	if o.ID == "" {
+		t.Fatalf("CreateOrganization returned empty ID")
+	}
+	if o.Name != "tv8-40 create" {
+		t.Fatalf("Name = %q, want %q", o.Name, "tv8-40 create")
+	}
+
+	// Read it back through the production GetOrganization path, scoped
+	// to the owner's own org (GetOrganization denies any id != caller
+	// OrgID with NotFound).
+	asUser(userID, o.ID)
+	got, err := org.GetOrganization(ctx, o.ID)
+	if err != nil {
+		t.Fatalf("GetOrganization failed: %v", err)
+	}
+	if got.ID != o.ID || got.Slug != o.Slug {
+		t.Fatalf("GetOrganization round-trip mismatch: got %+v, want id=%s slug=%s", got, o.ID, o.Slug)
+	}
+}
+
+// TestCreateAndGetProjectHappyPath exercises CreateProject and reads it
+// back via GetProject (rbac-scoped to the caller's org).
+func TestCreateAndGetProjectHappyPath(t *testing.T) {
+	ctx := context.Background()
+	userID := seedUser(t, ctx)
+	o := seedOrg(t, ctx, "project")
+
+	suffix, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid (project slug): %v", err)
+	}
+	p, err := org.CreateProject(ctx, &org.CreateProjectRequest{
+		OrgID: o.ID,
+		Name:  "tv8-40 project",
+		Slug:  strings.ToLower("p-" + suffix[len(suffix)-12:]),
+	})
+	if err != nil {
+		t.Fatalf("CreateProject failed: %v", err)
+	}
+	if p.ID == "" || p.OrgID != o.ID {
+		t.Fatalf("CreateProject returned %+v, want non-empty id and org_id=%s", p, o.ID)
+	}
+
+	asUser(userID, o.ID)
+	got, err := org.GetProject(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("GetProject failed: %v", err)
+	}
+	if got.ID != p.ID || got.OrgID != o.ID {
+		t.Fatalf("GetProject round-trip mismatch: got %+v, want id=%s org_id=%s", got, p.ID, o.ID)
+	}
+}
+
+// TestAddMemberHappyPath exercises AddMember against a real org + real
+// auth.users row (the FK members_user_id_fkey must resolve), then
+// asserts a duplicate insert is rejected AlreadyExists via the
+// typed-pgconn isUniqueViolation path on members_org_user_uniq.
+func TestAddMemberHappyPath(t *testing.T) {
+	ctx := context.Background()
+	o := seedOrg(t, ctx, "member")
+	userID := seedUser(t, ctx)
+
+	if err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:  o.ID,
+		UserID: userID,
+		Role:   "admin",
+	}); err != nil {
+		t.Fatalf("AddMember (first insert) failed: %v", err)
+	}
+
+	// Second insert of the same (org_id, user_id) must hit
+	// members_org_user_uniq → AlreadyExists. This also exercises the
+	// rewritten isUniqueViolation typed-pgconn classification.
+	err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:  o.ID,
+		UserID: userID,
+		Role:   "member",
+	})
+	if err == nil {
+		t.Fatalf("AddMember (duplicate) succeeded, want AlreadyExists")
+	}
+	if errs.Code(err) != errs.AlreadyExists {
+		t.Fatalf("duplicate AddMember code = %v, want AlreadyExists (err=%v)", errs.Code(err), err)
+	}
+}
+
+// TestAddMemberUnknownUserIsNotFound exercises the FK-violation
+// classification: a non-existent user_id must surface NotFound via the
+// rewritten isForeignKeyViolation typed-pgconn (SQLSTATE 23503) path.
+func TestAddMemberUnknownUserIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	o := seedOrg(t, ctx, "fkuser")
+
+	ghostUser, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid (ghost user): %v", err)
+	}
+	err = org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:  o.ID,
+		UserID: ghostUser, // no matching auth.users row
+		Role:   "member",
+	})
+	if err == nil {
+		t.Fatalf("AddMember with unknown user_id succeeded, want NotFound")
+	}
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("unknown-user AddMember code = %v, want NotFound (err=%v)", errs.Code(err), err)
+	}
+}
+
+// TestAuthorizeHappyPathSameOrgPermit exercises the Authorize RPC body
+// on a permit path: an owner reading a workitems resource in its own
+// org. Authorize's step-5 effective-role derivation reads a real
+// org.members row, so the caller MUST first be enrolled as a member
+// (a fabricated Identity with no members row is denied with reason
+// "caller is not a member of the target org"). This test seeds a real
+// user, enrols them as owner via AddMember, then asserts Authorize
+// permits (returns nil) per the role-action matrix.
+func TestAuthorizeHappyPathSameOrgPermit(t *testing.T) {
+	ctx := context.Background()
+	o := seedOrg(t, ctx, "authz")
+	userID := seedUser(t, ctx)
+
+	if err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:  o.ID,
+		UserID: userID,
+		Role:   "owner",
+	}); err != nil {
+		t.Fatalf("AddMember (owner) failed: %v", err)
+	}
+
+	err := org.Authorize(ctx, &org.AuthorizeRequest{
+		Identity: auth.Identity{
+			UserID: userID,
+			OrgID:  o.ID,
+			Role:   "owner",
+		},
+		Resource: "workitems.items",
+		Action:   "read",
+		OrgID:    o.ID,
+	})
+	if err != nil {
+		t.Fatalf("Authorize (same-org owner read) denied, want permit: %v", err)
+	}
+}

--- a/apps/api/workitems/helpers.go
+++ b/apps/api/workitems/helpers.go
@@ -215,18 +215,6 @@ func loadLabels(ctx context.Context, itemID string) ([]string, error) {
 	return labels, nil
 }
 
-// attachLabels inserts (item_id, label_id) rows inside a fresh tx
-// borrowed from the package-level db handle. Used by Create's
-// non-transactional path when labels are attached after the row insert.
-// (Currently unused — Create always wraps the insert + labels in a
-// single tx via attachLabelsTx. Retained for completeness should a
-// future caller need it.)
-//
-//nolint:unused
-func attachLabels(ctx context.Context, tx *sqldb.Tx, itemID string, labels []string) error {
-	return attachLabelsTx(ctx, tx, itemID, labels)
-}
-
 // attachLabelsTx inserts (item_id, label_id) rows using the caller's
 // transaction handle. Errors map FK violations to NotFound and unique
 // violations to AlreadyExists.

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -769,6 +769,7 @@ func Create(ctx context.Context, req *CreateRequest) (*Item, error) {
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: create commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "create commit failed"}
 	}
 
@@ -850,6 +851,7 @@ func Update(ctx context.Context, req *UpdateRequest) (*Item, error) {
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: update commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "update commit failed"}
 	}
 
@@ -1298,6 +1300,7 @@ func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: set_state commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "set_state commit failed"}
 	}
 
@@ -1430,6 +1433,7 @@ func Close(ctx context.Context, req *CloseRequest) (*Item, error) {
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: close commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "close commit failed"}
 	}
 
@@ -1576,6 +1580,7 @@ func Claim(ctx context.Context, req *ClaimRequest) (*Item, error) {
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: claim commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "claim commit failed"}
 	}
 
@@ -2233,6 +2238,7 @@ func CreateMilestone(ctx context.Context, req *CreateMilestoneRequest) (*Milesto
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: milestone create commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "milestone commit failed"}
 	}
 
@@ -2355,6 +2361,7 @@ func UpdateMilestone(ctx context.Context, req *UpdateMilestoneRequest) (*Milesto
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: milestone update commit failed", "err", err)
 		return nil, &errs.Error{Code: errs.Internal, Message: "milestone update commit failed"}
 	}
 	return readMilestone(ctx, req.MilestoneID)
@@ -2451,6 +2458,7 @@ func AssignItem(ctx context.Context, req *AssignItemRequest) error {
 	}
 
 	if err := tx.Commit(); err != nil {
+		rlog.Error("workitems: milestone assign commit failed", "err", err)
 		return &errs.Error{Code: errs.Internal, Message: "milestone assign commit failed"}
 	}
 	return nil

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -72,6 +72,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"encore.app/auth"
 	"encore.app/deps"
@@ -2073,9 +2074,14 @@ func Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
 		if err := rows.Scan(&h.ItemID, &h.Source, &h.CommentID, &h.Rank, &h.Snippet); err != nil {
 			return nil, &errs.Error{Code: errs.Internal, Message: "search scan failed"}
 		}
-		// Trim snippet to 200 chars (SPEC §4.4 line 793 cap).
-		if len(h.Snippet) > 200 {
-			h.Snippet = h.Snippet[:200]
+		// Trim snippet to 200 chars (SPEC §4.4 cap). Rune-aware: a
+		// naive byte-slice (Snippet[:200]) can sever a multi-byte
+		// UTF-8 sequence — or a ts_headline <b>…</b> markup tag —
+		// mid-codepoint, yielding invalid UTF-8 on the wire. Count
+		// runes and slice on a rune boundary instead.
+		if utf8.RuneCountInString(h.Snippet) > 200 {
+			runes := []rune(h.Snippet)
+			h.Snippet = string(runes[:200])
 		}
 		all = append(all, h)
 	}
@@ -2372,7 +2378,7 @@ func AssignItem(ctx context.Context, req *AssignItemRequest) error {
 
 	if req.MilestoneID == "" {
 		// Unassign: clear all three columns.
-		_, err := tx.Exec(ctx,
+		res, err := tx.Exec(ctx,
 			`UPDATE workitems.items
 			    SET milestone_id          = NULL,
 			        milestone_assigned_at = NULL,
@@ -2383,6 +2389,13 @@ func AssignItem(ctx context.Context, req *AssignItemRequest) error {
 		)
 		if err != nil {
 			return &errs.Error{Code: errs.Internal, Message: "milestone unassign failed"}
+		}
+		// A WHERE id = $1 UPDATE that matches no row silently succeeds.
+		// Surface a non-existent item as NotFound instead of a bogus
+		// 200 — the assign branch already returns NotFound for the same
+		// condition via its SELECT guard, so mirror that contract here.
+		if res.RowsAffected() == 0 {
+			return &errs.Error{Code: errs.NotFound, Message: "item not found"}
 		}
 	} else {
 		// M-INV-7: scope reachability check.


### PR DESCRIPTION
Batch review-cleanup G2 — three beads on one branch, atomic commits per bead. Implements only the LIVE items from each bead's 2026-05-29 TRIAGE RESCOPE.

## unblock-tv8.47 (workitems) — 70777af
- Remove dead `attachLabels` shim + its `//nolint:unused` (only `attachLabelsTx` is called)
- Rune-aware Search snippet truncation (was `Snippet[:200]` byte-slice — mid-UTF-8/tag cut risk)
- `AssignItem` unassign branch: `RowsAffected()==0` -> `errs.NotFound`
- DROPPED per rescope: #2/#3/#4

## unblock-tv8.54 (workitems) — 6c9c570
- Structured `rlog.Error` on all 8 `tx.Commit()` failure sites (previously silent)
- DONE per rescope: #1 (N100 sequential-test comment already present)

## unblock-tv8.40 (org) — 3961b74
- Typed `errors.As(*pgconn.PgError)` + SQLSTATE `.Code`/`.ConstraintName` in `isUniqueViolation`/`isForeignKeyViolation` (replaces `strings.Contains`), mirroring `deps.isUniqueViolation`
- New `org/rpc_integration_test.go`: real encore-test happy-path coverage for all six org RPCs + FK-NotFound / unique-AlreadyExists negative paths
- DROPPED (WontFix) per rescope: #2 (contradicts locked SPEC §10.1)

## Gates (from apps/api)
- `encore test ./...` green
- `go fmt ./...` zero diffs; `go vet` clean on touched packages
- `encore check` clean
- JSON PascalCase tag gate clean (`grep -rnE 'json:"[A-Z]' apps/api/` zero)
- golangci-lint deferred to CI (local toolchain mismatch)