### PR TITLE
P01 cleanup G3: shared/lint + shared/rbac + tests domain (6 beads)

### DIFF
--- a/apps/api/auth/types/types_test.go
+++ b/apps/api/auth/types/types_test.go
@@ -1,0 +1,39 @@
+// This test deliberately lives in the `types` package and imports
+// nothing from encore.dev/* or the auth root package. It is the
+// executable lock on the leaf-cleanness contract documented in
+// types.go: `apps/api/auth/types` MUST stay loadable under plain
+// `go test ./auth/types/...` with no Docker and no Encore runtime.
+//
+// If a future edit drags an encore.dev import (directly or
+// transitively) into this package, this test file stops compiling
+// under plain `go test` and the regression is caught immediately —
+// rather than surfacing far away as a package-init panic in every
+// consumer that imports auth.Identity (org, rbac, …). See bead
+// unblock-tv8.30 for the original extraction rationale and
+// unblock-tv8.37 for this guard.
+package types
+
+import "testing"
+
+// TestIdentityZeroValueIsConstructible pins two things at once:
+//  1. the smoke fact that Identity's zero value is a valid, buildable
+//     value (no required-init invariant sneaks in), and
+//  2. the import-cleanness contract — this file builds and runs with no
+//     Encore/Docker dependency, proving the package is still a leaf.
+func TestIdentityZeroValueIsConstructible(t *testing.T) {
+	var id Identity
+
+	if id.UserID != "" || id.OrgID != "" || id.Role != "" || id.AgentKind != "" {
+		t.Fatalf("zero-value Identity should have empty fields, got %+v", id)
+	}
+
+	// A fully-populated literal must also compile against the locked
+	// field set (guards accidental field renames in the leaf type that
+	// auth.Identity = types.Identity re-exports).
+	_ = Identity{
+		UserID:    "user-ulid",
+		OrgID:     "org-ulid",
+		Role:      "owner",
+		AgentKind: "",
+	}
+}

--- a/apps/api/exitcriteriontest/prime_ready_claim_close_test.go
+++ b/apps/api/exitcriteriontest/prime_ready_claim_close_test.go
@@ -6,9 +6,12 @@
 //   - claim on the returned item succeeds.
 //   - set_state(impl_state=done) on the claimed item is accepted.
 //   - close on the same item succeeds (P01 relaxation: claimed_by_id
-//     IS NOT NULL is the only precondition); cascade subscriber
-//     fires (driven via deps.HandleCascadeRequestedForTest per the
-//     SPEC §11.1.1 round-13 contract).
+//     IS NOT NULL is the only precondition); the close is driven via
+//     the private-mesh workitems.Close so its CascadeRequested publish
+//     is observable in this test scope (see step 5 DEVIATION), and the
+//     cascade subscriber is then driven via
+//     deps.HandleCascadeRequestedForTest on that REAL captured message
+//     per the SPEC §11.1.1 round-13 contract.
 //   - After cascade, prime reflects newly-unblocked dependents
 //     (itm_c, itm_d flip to ready — this is Regime-A-inline per
 //     workitems.Close → deps.RecomputeReadyForBlocksDownstream; the
@@ -36,7 +39,7 @@ import (
 
 	encoredb "encore.app/db"
 	"encore.app/deps"
-	"encore.app/shared/ulid"
+	"encore.app/workitems"
 	"encore.dev/et"
 )
 
@@ -201,33 +204,37 @@ func TestExitCriterion_PrimeReadyClaimCloseCascadeFlow(t *testing.T) {
 		t.Fatalf("post-set_state claimed_by_id is empty — close's precondition would fail")
 	}
 
-	// --- 5) close itm_b ---
+	// --- 5) close itm_b (private mesh) ---
 	//
-	// Tracker for the cascade publish: et.Topic.PublishedMessages
-	// records messages emitted in the current test scope. We capture
-	// the slice AFTER the close call so the filter sees the new
-	// publish; the slice's order is publish order, so the close
-	// publish is the most recent matching entry.
-	closeEnv := callTool(t, f.RawKey, sessionID, "close", map[string]any{
-		"item_id": itemB,
-		"reason":  "exit-criterion-e2e",
+	// DEVIATION (round-15, bead unblock-tv8.66): the close is driven
+	// through the private-mesh //encore:api workitems.Close rather than
+	// the MCP `close` tool surface. SPEC §11.1.1 (round-13) endorses
+	// EITHER path ("Invoke the producing RPC through the normal MCP /
+	// private-mesh path"); we choose the mesh path here for the SAME
+	// reason cascade_kinds_test.go does (see that file's file-level
+	// DEVIATION block): et.Topic(...).PublishedMessages() only observes
+	// publishes emitted in the test goroutine's request-manager scope.
+	// The MCP transport runs inside an httptest.NewServer goroutine that
+	// bypasses Encore's request manager, so an MCP-surface close
+	// publishes CascadeRequested correctly on the production side but the
+	// publish is INVISIBLE to cascadeMessagesFor from this scope. Driving
+	// the mesh API preserves every production semantic (same inline
+	// is_ready Regime-A recompute, same post-commit Publish via the same
+	// code path) while making the real publish — and its real event_id —
+	// observable. The MCP `close` tool surface is exercised end-to-end in
+	// apps/api/shared/mcpaudittest/d3_tools_test.go.
+	closedItem, err := workitems.Close(ctx, &workitems.CloseRequest{
+		ItemID: itemB,
+		Reason: "exit-criterion-e2e",
 	})
-	closeRaw := expectSuccess(t, closeEnv)
-	var closeStruct struct {
-		Item struct {
-			ID       string `json:"id"`
-			Status   string `json:"status"`
-			ClosedAt string `json:"closed_at"`
-		} `json:"item"`
+	if err != nil {
+		t.Fatalf("workitems.Close: %v", err)
 	}
-	if err := json.Unmarshal(closeRaw, &closeStruct); err != nil {
-		t.Fatalf("unmarshal close: %v", err)
+	if closedItem.Status != "Done" {
+		t.Fatalf("post-close status = %q, want Done", closedItem.Status)
 	}
-	if closeStruct.Item.Status != "Done" {
-		t.Fatalf("post-close status = %q, want Done", closeStruct.Item.Status)
-	}
-	if closeStruct.Item.ClosedAt == "" {
-		t.Fatalf("post-close closed_at is empty")
+	if closedItem.ClosedAt == nil {
+		t.Fatalf("post-close closed_at is nil")
 	}
 
 	// --- 6) After close (Regime A inline recompute): itm_c, itm_d are is_ready=true ---
@@ -285,37 +292,31 @@ func TestExitCriterion_PrimeReadyClaimCloseCascadeFlow(t *testing.T) {
 	})
 	_ = expectSuccess(t, postCloseEnv)
 
-	// --- 7) Drive the cascade subscriber to materialise the row ---
+	// --- 7) Capture the REAL close publish, then drive the subscriber ---
 	//
 	// Per SPEC §11.1.1 round-13: Encore Pub/Sub subscriptions do not
-	// fire under encore test. The §11.1.1 four-step pattern wants us
-	// to capture via et.Topic.PublishedMessages() then drive the
-	// subscriber. However, et.Topic.PublishedMessages() is empty here
-	// because workitems.Close fired from the httptest-server goroutine
-	// (the MCP transport path) which is outside Encore's request
-	// manager scope — see the cascade_kinds_test.go file-level
-	// DEVIATION block for the full rationale. We synthesise the
-	// CascadeRequested message in-test with a fresh event_id and
-	// invoke HandleCascadeRequestedForTest directly. The production
-	// publish DID occur (visible in the workitems.Close trace log);
-	// the row materialisation contract under test is independent of
-	// the publish-side observation.
-	synthEventID, err := ulid.New()
-	if err != nil {
-		t.Fatalf("ulid for synthesized cascade event: %v", err)
+	// fire under encore test, so the four-step pattern is (1) invoke the
+	// producing RPC, (2) capture et.Topic.PublishedMessages() filtered to
+	// that close, (3) invoke HandleCascadeRequestedForTest on the
+	// captured message, (4) assert the row. Because step 5 above drove
+	// workitems.Close through the private mesh (in THIS test goroutine's
+	// request-manager scope), the publish IS observable here — so we
+	// assert the production-generated event_id end-to-end rather than a
+	// test-fabricated one.
+	msgs := cascadeMessagesFor(itemB, "close")
+	if len(msgs) != 1 {
+		t.Fatalf("CascadeRequested{kind=close, item=%s} publish count = %d, want 1", itemB, len(msgs))
 	}
-	synthMsg := &deps.CascadeRequested{
-		EventID:           synthEventID,
-		OrgID:             f.OrgID,
-		ProjectID:         f.ProjectID,
-		TriggeredByItemID: itemB,
-		Reason:            "close",
+	closeMsg := msgs[0]
+	if closeMsg.EventID == "" {
+		t.Fatalf("captured close CascadeRequested has empty event_id")
 	}
-	if err := deps.HandleCascadeRequestedForTest(ctx, synthMsg); err != nil {
+
+	if err := deps.HandleCascadeRequestedForTest(ctx, closeMsg); err != nil {
 		t.Fatalf("HandleCascadeRequestedForTest: %v", err)
 	}
 
-	// --- 8) Assert exactly one deps.cascade_events row with kind='close' ---
+	// --- 8) Assert exactly one deps.cascade_events row carrying the REAL event_id ---
 	var (
 		rowCount int
 		eventID  string
@@ -324,15 +325,15 @@ func TestExitCriterion_PrimeReadyClaimCloseCascadeFlow(t *testing.T) {
 		`SELECT count(*), COALESCE(max(event_id), '')
 		   FROM deps.cascade_events
 		  WHERE triggered_by_item_id = $1 AND kind = 'close' AND event_id = $2`,
-		itemB, synthEventID,
+		itemB, closeMsg.EventID,
 	).Scan(&rowCount, &eventID); err != nil {
 		t.Fatalf("cascade_events count query: %v", err)
 	}
 	if rowCount != 1 {
-		t.Fatalf("cascade_events (event=%s kind=close item=%s): %d rows, want 1", synthEventID, itemB, rowCount)
+		t.Fatalf("cascade_events (event=%s kind=close item=%s): %d rows, want 1", closeMsg.EventID, itemB, rowCount)
 	}
-	if eventID != synthEventID {
-		t.Fatalf("cascade_events.event_id = %q, want %q (the synthesised event id)", eventID, synthEventID)
+	if eventID != closeMsg.EventID {
+		t.Fatalf("cascade_events.event_id = %q, want %q (the real publish event id)", eventID, closeMsg.EventID)
 	}
 }
 

--- a/apps/api/perftest/doc.go
+++ b/apps/api/perftest/doc.go
@@ -12,10 +12,17 @@
 //     established, (b) the API key is validated once before the timer
 //     starts, and (c) no first-request cold-start outliers — M ≥ 10
 //     warm-up iterations are discarded before measurement begins.
-//   - The harness ALWAYS logs the per-call latency samples, the
-//     computed p99, and the goroutine deltas as JSON-Lines via
-//     t.Logf (informative on every run — aligns with the AC verb
-//     "reports").
+//   - The harness ALWAYS logs the latency samples, the computed p99,
+//     and the goroutine deltas as JSON-Lines via t.Logf (informative on
+//     every run — aligns with the AC verb "reports"). Each latency
+//     sample is the wall-clock duration of ONE FULL `prime → ready →
+//     claim` SEQUENCE (three chained MCP round-trips), NOT one
+//     individual MCP call: the p99 budget in SPEC §11.2 NFR-1 is
+//     defined over the end-to-end sequence, so the per-sample unit is
+//     per-sequence. (The AC and SPEC prose say "per-call latency
+//     samples"; that wording predates the sequence-level measurement
+//     and is read here as "per measured sequence" — see
+//     harness_test.go's latencySampleLine doc.)
 //   - A hard-fail (t.Fatalf on p99 ≥ 2 s OR drained-baseline > 20) is
 //     gated by the UNBLOCK_PERF_GATE=1 environment variable so CI
 //     stays advisory on slow shared GH Actions runners. Release-

--- a/apps/api/perftest/harness_test.go
+++ b/apps/api/perftest/harness_test.go
@@ -158,9 +158,13 @@ func percentile(sorted []time.Duration, p float64) time.Duration {
 	return sorted[rank-1]
 }
 
-// latencySampleLine is one JSON-Lines record per measured sequence.
+// latencySampleLine is one JSON-Lines record per measured sequence —
+// LatencyMs is the wall-clock duration of one full prime → ready →
+// claim sequence, NOT one individual MCP call.
 // Emitted via t.Logf so a CI parser can lift the samples (SPEC §11.2:
-// "logs per-call latency samples … as JSON-Lines"). record="sample".
+// "logs per-call latency samples … as JSON-Lines"; the spec's "per-call"
+// wording predates the sequence-level measurement and is realised here
+// as per-sequence — see doc.go's NFR-1 sample-unit note). record="sample".
 type latencySampleLine struct {
 	Record    string `json:"record"`
 	Iteration int    `json:"iteration"`

--- a/apps/api/shared/lint/no_rbac_dynamic_clause.go
+++ b/apps/api/shared/lint/no_rbac_dynamic_clause.go
@@ -186,6 +186,12 @@ func runNoRbacDynamicClause(pass *analysis.Pass) (interface{}, error) {
 					// For has signature For[T](identity, table) — table
 					// is the SECOND positional arg. Require len > 1.
 					if len(call.Args) < 2 {
+						// Wrong arity — a call with fewer than two
+						// arguments cannot type-check, so go/types
+						// complains elsewhere; this analyzer is only
+						// concerned with the safety contract (the table
+						// argument being a compile-time constant) and has
+						// nothing to assert when the table arg is absent.
 						return true
 					}
 					second := call.Args[1]

--- a/apps/api/shared/lint/testdata/src/badpkg/badpkg.go
+++ b/apps/api/shared/lint/testdata/src/badpkg/badpkg.go
@@ -74,9 +74,3 @@ const (
 	// fire. Pins the \bitems\b word boundary on the table name.
 	cleanSiblingTable = `UPDATE workitems.dependency_items SET created_at = now() WHERE parent_id = $1`
 )
-
-// Reference the consts so go vet does not complain about unused
-// package-level identifiers in the analysistest run.
-var _ = flagged1 + flagged2 + flagged3 + flagged4 + flagged5 +
-	cleanColumn + cleanSelect + cleanComment + cleanInsert +
-	cleanIdentifier + cleanDelete + cleanSiblingTable

--- a/apps/api/shared/lint/testdata/src/encore.app/shared/rbac/rbac.go
+++ b/apps/api/shared/lint/testdata/src/encore.app/shared/rbac/rbac.go
@@ -26,6 +26,15 @@ type ScopedQuery[T any] struct {
 
 // Identity is a stand-in for auth.Identity; the analyzer doesn't
 // inspect it.
+//
+// DRIFT NOTE (unblock-tv8.37): this is a deliberately minimal mirror of
+// the real auth/types.Identity (apps/api/auth/types/types.go). Post bead
+// unblock-tv8.30 that real type carries four fields
+// (UserID/OrgID/Role/AgentKind); only OrgID is reproduced here because
+// the analyzer resolves Identity solely by its package path, never by
+// its field set. Do NOT chase the real type's fields here — keep this
+// stand-in minimal. It exists only so the fixture's For()/Where() chain
+// type-checks under the analysistest GOPATH overlay.
 type Identity struct {
 	OrgID string
 }

--- a/apps/api/shared/rbac/rbac.go
+++ b/apps/api/shared/rbac/rbac.go
@@ -129,6 +129,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 
 	"encore.app/auth/types"
 	"encore.dev/storage/sqldb"
@@ -154,20 +155,36 @@ import (
 // unchanged. Per-service `initbind.go` files were retired in bead
 // unblock-bne's pre-review scope expansion; the central bind in
 // apps/api/db/db.go is now sufficient.
-var db *sqldb.Database
+//
+// The handle is held in an atomic.Pointer rather than a plain
+// *sqldb.Database so the single-write contract is enforced by the
+// memory model, not merely documented: Bind's store and every Run-time
+// load are synchronised, so a concurrent reader can never observe a
+// torn or partially published handle even if the bind/read ordering is
+// ever violated. The first non-nil Bind wins; later Bind calls are
+// no-ops (see Bind).
+var db atomic.Pointer[sqldb.Database]
 
 // Bind installs the unblock-database handle that Run will dispatch
 // against. Called exactly once at process start by the dedicated
 // apps/api/db/ migration-owner service's init (the sole binding
 // authority for every consumer's handle, post bead unblock-bne
-// pre-review). Subsequent calls overwrite the handle; tests rely on
-// this for swap-in of fakes.
+// pre-review).
 //
-// Concurrency: Bind is not goroutine-safe; the contract is that it
-// runs during Encore service initialisation, before any handler can
-// observe a partially constructed builder.
+// Single-write enforcement: only the first non-nil handle is accepted.
+// CompareAndSwap from the nil zero value guarantees that any later Bind
+// call (e.g. an accidental second wiring, or a racing parallel test
+// setup) leaves the originally-installed handle untouched rather than
+// silently overwriting it. A nil argument is ignored.
+//
+// Concurrency: Bind is goroutine-safe. Concurrent Bind callers race
+// only to install the first handle; all but the winner observe the
+// already-bound handle and return without mutating it.
 func Bind(database *sqldb.Database) {
-	db = database
+	if database == nil {
+		return
+	}
+	db.CompareAndSwap(nil, database)
 }
 
 // ErrMissingScope is returned by Run when the *ScopedQuery[T] receiver
@@ -383,13 +400,14 @@ func (q *ScopedQuery[T]) Run(ctx context.Context) ([]T, error) {
 		return nil, ErrEmptyTable
 	}
 
-	if db == nil {
+	database := db.Load()
+	if database == nil {
 		return nil, ErrNotBound
 	}
 
 	sql, args := q.build()
 
-	rows, err := db.Query(ctx, sql, args...)
+	rows, err := database.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, fmt.Errorf("rbac: query %q: %w", q.table, err)
 	}

--- a/apps/api/shared/rbactest/doc.go
+++ b/apps/api/shared/rbactest/doc.go
@@ -86,9 +86,11 @@
 //
 // Concurrency.
 //
-// The suite does NOT call t.Parallel anywhere. rbac.Bind (and the
-// per-service BindDB hooks) are not goroutine-safe; bead
-// unblock-tv8.34 tracks the hardening discussion. The single-binding
+// The suite does NOT call t.Parallel anywhere. rbac.Bind is
+// goroutine-safe as of bead unblock-tv8.34: the handle lives in an
+// atomic.Pointer and Bind installs it via CompareAndSwap from nil, so
+// the first non-nil handle wins and any later or racing Bind (or a nil
+// argument) is a no-op. The single-binding
 // contract is shared with the wider domain-service tree (auth, org,
 // workitems, deps); rbactest takes the same guarantee Encore's process
 // init provides ("BindDB completes before any handler dispatches") and

--- a/apps/api/shared/rbactest/rbactest_test.go
+++ b/apps/api/shared/rbactest/rbactest_test.go
@@ -18,8 +18,10 @@
 //     the policy contract (cross-org deny everywhere; same-org per
 //     the role matrix and the agent-resource set).
 //
-// Concurrency: no t.Parallel anywhere — rbac.Bind is not goroutine-
-// safe; bead unblock-tv8.34 tracks the hardening.
+// Concurrency: no t.Parallel anywhere. rbac.Bind is goroutine-safe as
+// of bead unblock-tv8.34 (single-write via atomic.Pointer.CompareAndSwap
+// from nil — first non-nil handle wins); the suite stays sequential
+// regardless, since the matrix shares one bound handle.
 
 package rbactest
 

--- a/apps/api/shared/rbactest/rbactest_test.go
+++ b/apps/api/shared/rbactest/rbactest_test.go
@@ -242,32 +242,19 @@ func runOrgScopedTuple(t *testing.T, fx *Fixture, callerOrg, targetOrg, role, ta
 		id := identityFor(fx, callerOrg, role)
 		targetOrgID := fx.Orgs[targetOrg]
 
-		// Run a scoped read. T = scopedRow is a minimal projection
-		// over (id, org_id) — the scanner reads exported fields in
-		// declaration order, which matches `SELECT * FROM <table>`
-		// only if T's field count matches the table's column count.
-		// We therefore use rbac.For[scopedRow] only when the table's
-		// row shape begins with (id, org_id, ...) — true for
-		// org.projects and org.members (verified against
-		// migrations 0030_org.up.sql lines 19-43).
+		// Run a scoped read via selectScopedOrgIDs. rbac.For issues an
+		// implicit `SELECT *` (apps/api/shared/rbac rbac.go), so the
+		// reflection scanner expects T's exported-field count to equal
+		// the table's column count. The suite therefore uses one
+		// full-column row type per KindOrgScoped table — orgProjectsRow
+		// and orgMembersRow, declared below — each mirroring its table's
+		// exact layout from migration 0030_org.up.sql. We only read the
+		// OrgID field for the leak assertion; the remaining fields exist
+		// solely so the field count matches `SELECT *`.
 		//
-		// For C-6/E-3 extensions the table shapes diverge and the
-		// suite will need per-table row types (or an explicit
-		// SELECT). Within B-3 the minimal projection is sufficient
-		// because both KindOrgScoped tables share the (id, org_id,
-		// ...) prefix and we discard every column after org_id by
-		// declaring only those two fields and pairing them with an
-		// explicit SELECT via a Where that is a no-op…
-		//
-		// Reality: rbac.For uses `SELECT *` (apps/api/shared/rbac
-		// rbac.go ~line 413). The scanner expects T's field count
-		// to equal the column count. Declaring scopedRow as a
-		// full-column shape per table is overkill for the row-leak
-		// assertion (we only need org_id). The suite instead uses
-		// a separate, raw SQL probe that selects just `org_id` for
-		// the leak check and exercises rbac.For with a typed-row T
-		// matching the actual table layout. See selectScopedOrgIDs
-		// below.
+		// For C-6/E-3 extensions the table shapes diverge further; add a
+		// matching per-table row type and a switch case in
+		// selectScopedOrgIDs (see its doc-comment below).
 		gotOrgIDs, err := selectScopedOrgIDs(context.Background(), id, table)
 		if err != nil {
 			// Same-org callers may legitimately see rows; cross-org
@@ -367,19 +354,20 @@ func runAuthorizeOnlyTuple(t *testing.T, fx *Fixture, callerOrg, targetOrg, role
 	})
 }
 
-// scopedRow is the minimal projection used by selectScopedOrgIDs to
-// read just `(id, org_id)` from each KindOrgScoped table. The
-// rbac.For builder issues `SELECT *` (apps/api/shared/rbac.go
-// ~line 413), so the suite cannot directly use rbac.For with a
-// two-field T over a many-column table — the scanner would mismatch
-// column count vs field count.
+// The per-table row types below (orgProjectsRow, orgMembersRow) are the
+// typed projections used by selectScopedOrgIDs to read each
+// KindOrgScoped table. The rbac.For builder issues `SELECT *`
+// (apps/api/shared/rbac rbac.go), so the suite cannot use a two-field
+// (id, org_id) row over a many-column table — the reflection scanner
+// would mismatch column count vs field count. Each row type therefore
+// mirrors its table's full column layout; the suite reads only OrgID and
+// the remaining fields exist solely to balance the column count.
 //
-// Workaround: use a typed row shape that matches each table's full
-// column layout. Both KindOrgScoped tables in B-3 (org.projects,
-// org.members) share the (id, org_id, ...) prefix but diverge in
-// the suffix; we therefore declare per-table row types below.
+// (Earlier rounds described a single `scopedRow` projection here; that
+// type was inlined into the per-table row types below and no longer
+// exists.)
 //
-// This is a row-shape helper, not part of the policy contract.
+// These are row-shape helpers, not part of the policy contract.
 // When C-6 / E-3 add new KindOrgScoped tables, add a matching row
 // type and extend the switch in selectScopedOrgIDs.
 

--- a/apps/api/shared/rbactest/seed.go
+++ b/apps/api/shared/rbactest/seed.go
@@ -62,6 +62,7 @@ import (
 	"time"
 
 	"encore.app/shared/ulid"
+	"encore.dev/rlog"
 	"encore.dev/storage/sqldb"
 )
 
@@ -546,7 +547,7 @@ func (f *Fixture) Teardown(ctx context.Context, db *sqldb.Database) {
 	for _, orgID := range f.Orgs {
 		if _, err := db.Exec(ctx, `DELETE FROM org.organizations WHERE id = $1`, orgID); err != nil {
 			// Log and continue — teardown is best-effort.
-			fmt.Printf("rbactest teardown: delete org %q: %v\n", orgID, err)
+			rlog.Error("rbactest teardown: delete org failed", "org_id", orgID, "err", err)
 		}
 	}
 
@@ -555,7 +556,7 @@ func (f *Fixture) Teardown(ctx context.Context, db *sqldb.Database) {
 	//    handles the dependent rows.
 	for _, userID := range f.Users {
 		if _, err := db.Exec(ctx, `DELETE FROM auth.users WHERE id = $1`, userID); err != nil {
-			fmt.Printf("rbactest teardown: delete user %q: %v\n", userID, err)
+			rlog.Error("rbactest teardown: delete user failed", "user_id", userID, "err", err)
 		}
 	}
 }


### PR DESCRIPTION
## P01 review-cleanup batch G3

Six review-cleanup beads on one branch (`chore/p01-cleanup-g3-lint-rbac-tests`), one atomic commit per bead. Scope per the authoritative 2026-05-29 TRIAGE RESCOPE comments (LIVE items only).

| Bead | Commit | What |
|------|--------|------|
| unblock-tv8.34 | d7c0c56 | Enforce `rbac.Bind()` single-write via `atomic.Pointer` (CompareAndSwap, first non-nil wins) + synchronised Run-time load; remove badpkg unused-const suppression block |
| unblock-tv8.36 | 5e2ed0f | Explanatory comment on `rbac.For` arity-skip in `no_rbac_dynamic_clause` analyzer (mirrors Where-branch) |
| unblock-tv8.37 | 7191132 | New `auth/types/types_test.go` leaf smoke test (plain `go test`, no Docker) + drift note on analysistest fixture Identity stand-in |
| unblock-tv8.43 | 8b44054 | Drop stale `scopedRow` doc references (inlined to per-table row types) + teardown `fmt.Printf` → `rlog` structured logging |
| unblock-tv8.66 | 8f24501 | Assert REAL close-cascade `event_id` (drive `workitems.Close` via private mesh so publish is observable) instead of a fabricated one |
| unblock-tv8.69 | 88e94ff | Doc: NFR-1 latency sample unit is per-sequence, not per-call |

### Key decision (tv8.66)
Step-5 close now runs through the private-mesh `workitems.Close` rather than the MCP `close` tool, because `et.Topic(...).PublishedMessages()` only observes publishes in the test goroutine's request-manager scope (MCP transport runs in an httptest goroutine that bypasses it). SPEC §11.1.1 round-13 endorses either path; this is the established `cascade_kinds_test.go` precedent. MCP close-tool surface stays covered in `mcpaudittest/d3_tools_test.go`.

### Gates (from apps/api)
- `encore test ./...` — all green
- `go test ./auth/types/...` — green (leaf, no Docker)
- `go fmt ./...` — zero diffs
- `go vet ./...` — clean
- `encore check` — clean
- JSON PascalCase tag gate — zero matches
- `golangci-lint` not run locally (toolchain mismatch; CI covers it)

### Dropped (out of scope per triage)
- tv8.66 pt2 (I-5 spec ambiguity) → epic note; pt3 (MCP add_dependency perf) → P02 bead unblock-tv8.70