### PR TITLE
BATCH G4 (tv8.39 + tv8.29): auth rollback gating + stale errNotImplemented doc rewording

### DIFF
--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -347,7 +347,16 @@ func ExchangeOAuthCode(ctx context.Context, req *ExchangeOAuthCodeRequest) (*Exc
 	if err != nil {
 		return nil, &errs.Error{Code: errs.Internal, Message: "db begin failed"}
 	}
-	defer func() { _ = tx.Rollback() }()
+	// Roll back on any early return. The `committed` flag suppresses the
+	// rollback once Commit succeeds: pgx would swallow the post-Commit
+	// ErrTxClosed as a no-op anyway, but gating it keeps the intent
+	// explicit and avoids the cosmetically-loose double-finalize.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
 
 	// Upsert auth.users on (primary_provider, primary_provider_id).
 	// We mint a fresh ULID only when no existing row matches.
@@ -383,6 +392,7 @@ func ExchangeOAuthCode(ctx context.Context, req *ExchangeOAuthCodeRequest) (*Exc
 	if err := tx.Commit(); err != nil {
 		return nil, &errs.Error{Code: errs.Internal, Message: fmt.Sprintf("commit: %v", err)}
 	}
+	committed = true
 
 	return &ExchangeOAuthCodeResponse{
 		SessionID: sessionID,
@@ -408,6 +418,12 @@ func upsertGitHubUser(ctx context.Context, tx *sqldb.Tx, gh *githubUserResponse)
 		displayName = gh.Login
 	}
 
+	// newID is always minted, but only consumed on the INSERT path: the
+	// $1 binding becomes the row id when no conflict fires. On the
+	// ON CONFLICT DO UPDATE path Postgres keeps the existing row's id and
+	// RETURNING yields that, so this freshly-minted ULID is discarded. A
+	// wasted ULID per repeat login is cheaper than a pre-flight SELECT to
+	// decide whether to mint one.
 	newID, err := newULID()
 	if err != nil {
 		return "", err

--- a/apps/api/db/db.go
+++ b/apps/api/db/db.go
@@ -99,13 +99,13 @@
 //     consumer pattern.
 //
 //   - workitems.BindDB(DB) and deps.BindDB(DB) populate the workitems
-//     and deps services' nil handles. In P01 A-1 their RPC bodies
-//     return errNotImplemented and do not yet read `db`; the
-//     pre-wiring lands now so beads B-1+ (workitems bodies, FTS,
-//     milestones, claim transaction) and C-1+ (cycle CTE, advisory
-//     locks, cascade Pub/Sub publisher) inherit a non-nil handle the
-//     instant they start touching the database. The skeleton db.go
-//     in each service mirrors auth/db.go and org/db.go verbatim.
+//     and deps services' nil handles. Their RPC bodies now read `db`
+//     directly — B-1+ (workitems bodies, FTS, milestones, claim
+//     transaction) and C-1+ (cycle CTE, advisory locks, cascade
+//     Pub/Sub publisher) have landed — and inherited a non-nil handle
+//     the instant they started touching the database thanks to this
+//     pre-wiring. The db.go in each service mirrors auth/db.go and
+//     org/db.go verbatim.
 //
 //   - rbac.Bind(DB) installs the shared rbac builder's handle. The
 //     previous defense-in-depth pattern (each service called

--- a/apps/api/deps/db.go
+++ b/apps/api/deps/db.go
@@ -28,12 +28,12 @@
 // centralised in apps/api/db/. See the DECISION trail on bead
 // unblock-bne for the empirical trace.
 //
-// In P01 A-1 this file is a skeleton: db is declared (and tagged
-// //nolint:unused) and BindDB is exported. The handle is registered
-// in apps/api/db/db.go's init so the wiring is live from day one;
-// RPC bodies in deps.go currently return errNotImplemented and will
-// start reading `db` in beads C-1+ (cycle CTE, advisory locks,
-// cascade Pub/Sub publisher).
+// db is declared here (tagged //nolint:unused for the rare build that
+// excludes the RPC bodies) and BindDB is exported. The handle is
+// registered in apps/api/db/db.go's init so the wiring is live from
+// day one; the RPC bodies in deps.go read `db` directly now that the
+// C-1+ code (cycle CTE, advisory locks, cascade Pub/Sub publisher)
+// has landed.
 //
 // Hot-path impact: zero. After apps/api/db/db.go's init() runs (once,
 // during Encore process bootstrap) `db` is a non-nil *sqldb.Database
@@ -54,9 +54,9 @@ import "encore.dev/storage/sqldb"
 // a package-level pointer that starts nil and is populated exactly once
 // by BindDB during process bootstrap (called from apps/api/db/db.go's
 // init function — the dedicated migration-owner service per SPEC §3.1).
-// RPC bodies in deps.go will read `db` directly starting in beads
-// C-1+ when DB-touching code lands; the skeleton bodies in P01 A-1
-// return errNotImplemented and do not touch `db`.
+// RPC bodies in deps.go read `db` directly now that the C-1+
+// DB-touching code (cycle CTE, advisory locks, cascade Pub/Sub
+// publisher) has landed.
 //
 //nolint:unused // referenced by RPC bodies starting in beads C-1+ and by apps/api/db's init.
 var db *sqldb.Database

--- a/apps/api/workitems/db.go
+++ b/apps/api/workitems/db.go
@@ -28,11 +28,11 @@
 // centralised in apps/api/db/. See the DECISION trail on bead
 // unblock-bne for the empirical trace.
 //
-// In P01 A-1 this file is a skeleton: db is declared (and tagged
-// //nolint:unused) and BindDB is exported. The handle is registered
-// in apps/api/db/db.go's init so the wiring is live from day one;
-// RPC bodies in workitems.go currently return errNotImplemented and
-// will start reading `db` in beads B-1+ when DB-touching code lands.
+// db is declared here (tagged //nolint:unused for the rare build that
+// excludes the RPC bodies) and BindDB is exported. The handle is
+// registered in apps/api/db/db.go's init so the wiring is live from
+// day one; the RPC bodies in workitems.go read `db` directly now that
+// the B-1+ DB-touching code has landed.
 //
 // Hot-path impact: zero. After apps/api/db/db.go's init() runs (once,
 // during Encore process bootstrap) `db` is a non-nil *sqldb.Database
@@ -53,9 +53,9 @@ import "encore.dev/storage/sqldb"
 // a package-level pointer that starts nil and is populated exactly once
 // by BindDB during process bootstrap (called from apps/api/db/db.go's
 // init function — the dedicated migration-owner service per SPEC §3.1).
-// RPC bodies in workitems.go will read `db` directly starting in beads
-// B-1+ when DB-touching code lands; the skeleton bodies in P01 A-1
-// return errNotImplemented and do not touch `db`.
+// RPC bodies in workitems.go read `db` directly now that the B-1+
+// DB-touching code (workitems bodies, FTS, milestones, claim
+// transaction) has landed.
 //
 //nolint:unused // referenced by RPC bodies starting in beads B-1+ and by apps/api/db's init.
 var db *sqldb.Database


### PR DESCRIPTION
## Batch cleanup G4 — auth + cross-cutting doc-comments

Two review-cleanup beads on one branch, atomic commits, disjoint files.

### unblock-tv8.39 (auth) — commit 9de1e1d
- apps/api/auth/auth.go: gate the deferred `tx.Rollback()` behind a `committed` bool so the post-Commit ErrTxClosed no-op is explicit.
- apps/api/auth/auth.go: document that upsertGitHubUser's minted ULID (`newID`) is discarded on the ON CONFLICT DO UPDATE path.

Items #1 (authhandler EqualFold doc) and #4 (oauth.go length guard) were already DONE — untouched.

### unblock-tv8.29 (cross-cutting docs) — commit 54c171c
The errNotImplemented-consolidation remedy was MOOT (sentinels deleted, mcp.go 405 path already correct). Reworded the 5 stale doc-comments still referencing the deleted sentinel:
- apps/api/workitems/db.go (×2)
- apps/api/deps/db.go (×2)
- apps/api/db/db.go (×1, line drifted :97→:103)

Pure documentation; no behaviour change.

### Gates
- `encore test ./...` green (all suites)
- `go fmt ./...` zero diffs
- `go vet ./...` clean
- `encore check` clean
- JSON PascalCase tag gate clean
- `grep -rn errNotImplemented apps/api/` returns ZERO