### PR TITLE
Batch cleanup I1 (infra): supply-chain pins + lint scope + doc fix (unblock-tv8.67, unblock-tv8.68)

### DIFF
--- a/.github/scripts/encore-install.sh
+++ b/.github/scripts/encore-install.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# ─────────────────────────────────────────────────────────────────────
+# VENDORED COPY — do not curl this live from CI (tv8.67).
+#
+# Upstream:  https://encore.dev/install.sh  (Encore's own CDN; served as
+#            application/x-sh, NOT a GitHub-hosted file, so there is no
+#            commit SHA to pin a `curl | bash` against — vendoring is the
+#            only way to freeze the supply-chain surface).
+# Vendored:  2026-06-01.
+# sha256:    of the upstream bytes captured on the vendor date is recorded
+#            in .github/workflows/apps-api-ci.yml's "install encore cli"
+#            step comment. The CLI *binary* version is still pinned at the
+#            call site via the ${ENCORE_CLI_VERSION} argument (this script
+#            only constructs the CloudFront tarball URL from it).
+#
+# Refresh procedure (when bumping the Encore CLI or picking up an upstream
+# installer fix):
+#   1. curl -sSfL https://encore.dev/install.sh -o .github/scripts/encore-install.sh
+#   2. Re-apply this vendoring header (git diff to confirm only intended
+#      upstream changes landed — review the diff line-by-line).
+#   3. Update the vendor date above and the sha256 note in the workflow.
+# ─────────────────────────────────────────────────────────────────────
+# Based on Deno installer: Copyright 2019 the Deno authors. All rights reserved. MIT license.
+# TODO(everyone): Keep this script simple and easily auditable.
+
+# Script will install the latest Encore release by default.
+# If a version is provided, it will install the specified version.
+# Example: curl -L https://encore.dev/install.sh | bash -s -- 1.50.0
+
+set -e
+
+version=$1
+
+case $(uname -sm) in
+	"Darwin x86_64") target="darwin_amd64" ;;
+	"Darwin arm64")  target="darwin_arm64" ;;
+	"Darwin arm64")  target="darwin_arm64" ;;
+	"Linux aarch64") target="linux_arm64"  ;;
+	"Linux arm64")   target="linux_arm64"  ;;
+	*) target="linux_amd64" ;;
+esac
+
+if [ -z "$version" ]; then
+  encore_uri=$(curl -sSf -N "https://encore.dev/api/releases?target=${target}&show=url")
+  if [ ! "$encore_uri" ]; then
+    echo "Error: Unable to determine latest Encore release." 1>&2
+    exit 1
+  fi
+else
+  encore_uri="https://d2f391esomvqpi.cloudfront.net/encore-${version}-${target}.tar.gz"
+fi
+
+encore_install="${ENCORE_INSTALL:-$HOME/.encore}"
+
+bin_dir="$encore_install/bin"
+exe="$bin_dir/encore"
+tar="$encore_install/encore.tar.gz"
+
+if [ ! -d "$bin_dir" ]; then
+ 	mkdir -p "$bin_dir"
+fi
+
+curl --fail --location --progress-bar --output "$tar" "$encore_uri"
+cd "$encore_install"
+
+# If encore-go already exists, delete it.
+# Merging multiple Go releases into the same directory
+# leads to very difficult-to-understand fatal errors.
+if [ -d "./encore-go" ]; then
+	rm -rf "./encore-go"
+fi
+
+# Same goes for runtime
+if [ -d "./runtimes" ]; then
+	rm -rf "./runtimes"
+fi
+
+tar -C "$encore_install" -xzf "$tar"
+chmod +x "$bin_dir"/*
+rm "$tar"
+
+"$exe" version
+
+echo "Encore was installed successfully to $exe"
+if command -v encore >/dev/null; then
+	echo "Run 'encore --help' to get started"
+else
+	case $SHELL in
+	/bin/zsh) shell_profile=".zshrc" ;;
+	*) shell_profile=".bash_profile" ;;
+	esac
+	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
+	echo "  export ENCORE_INSTALL=\"$encore_install\""
+	echo "  export PATH=\"\$ENCORE_INSTALL/bin:\$PATH\""
+	echo "Run '$exe --help' to get started"
+fi

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -163,11 +163,22 @@ jobs:
 
       - name: install encore cli
         # No upstream `encoredev/setup-encore` GitHub Action exists
-        # (verified across the repo and ENCORE.md). The official
-        # install path is the curl one-liner; the script supports a
-        # `bash -s -- <version>` argument to pin the release.
+        # (verified across the repo and ENCORE.md). The official install
+        # path is `curl -L https://encore.dev/install.sh | bash`, but that
+        # pipes a live, mutable script from Encore's CDN into a shell —
+        # the moving supply-chain surface tv8.67 set out to eliminate.
+        # encore.dev/install.sh is NOT a GitHub-hosted file (served as
+        # application/x-sh from Encore's own site), so there is no commit
+        # SHA to pin it against the way we pin golangci-lint's installer.
+        # We therefore VENDOR the installer at .github/scripts/encore-install.sh
+        # (captured 2026-06-01; upstream sha256
+        # 3e8344b509dac145165498c53aeb4b9eaeac050eaeab404cbca86014b27f4ba5)
+        # and run the committed, reviewable copy. The CLI *binary* version
+        # is still pinned via the ${ENCORE_CLI_VERSION} argument — the
+        # script consumes it to build the exact CloudFront tarball URL.
+        # Refresh procedure is documented in the vendored script header.
         run: |
-          curl -L https://encore.dev/install.sh | bash -s -- "${ENCORE_CLI_VERSION}"
+          bash .github/scripts/encore-install.sh "${ENCORE_CLI_VERSION}"
           echo "${HOME}/.encore/bin" >> "${GITHUB_PATH}"
         # Sanity-check the install succeeded and the pinned version
         # landed before any consumer step runs.
@@ -217,15 +228,50 @@ jobs:
         # APIKeyHMACSecret == ""; mirrors the values shipped to
         # developers via the local .secrets.local.cue template). This
         # file is .gitignored and is NEVER persisted past the runner.
+        #
+        # SOURCING (tv8.67): the values are now SOURCED from GitHub
+        # Actions secrets rather than baked inline as plaintext. The
+        # previous heredoc printed the literal placeholders into the
+        # workflow file (and thus into any log capture / `set -x` trace
+        # of the step verbatim). By piping them through `env:` from
+        # `${{ secrets.* }}`, GitHub masks them in logs (`***`) and the
+        # SOURCE of truth moves out of the committed YAML.
+        #
+        # These remain NEVER-production placeholders (the local emulator
+        # only needs non-empty, well-shaped values), so to keep CI green
+        # BEFORE the repo secrets exist, each var falls back to the
+        # documented placeholder default via `${VAR:-<default>}`. Once a
+        # human adds the four repo/Org secrets listed below, those values
+        # take over with zero workflow change. Repo secrets the workflow
+        # now reads (add via Settings → Secrets and variables → Actions,
+        # or `gh secret set <NAME>`):
+        #   CI_MEMORY_DEK
+        #   CI_API_KEY_HMAC_SECRET
+        #   CI_GITHUB_OAUTH_CLIENT_ID
+        #   CI_GITHUB_OAUTH_CLIENT_SECRET
+        # If unset, the placeholders below are used and CI still passes.
+        env:
+          CI_MEMORY_DEK: ${{ secrets.CI_MEMORY_DEK }}
+          CI_API_KEY_HMAC_SECRET: ${{ secrets.CI_API_KEY_HMAC_SECRET }}
+          CI_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.CI_GITHUB_OAUTH_CLIENT_ID }}
+          CI_GITHUB_OAUTH_CLIENT_SECRET: ${{ secrets.CI_GITHUB_OAUTH_CLIENT_SECRET }}
         run: |
-          cat > .secrets.local.cue <<'CUE'
-          // CI-only placeholder secrets. Mirrors the dev template
-          // shape declared at apps/api/auth/secrets.go. NEVER
-          // production values. Written fresh on every CI run.
-          MemoryDEK:               "ci-memory-dek-32-bytes-of-zeroes-for-tests-only"
-          APIKeyHMACSecret:        "ci-api-key-hmac-secret-32-bytes-of-zeroes-tests"
-          GitHubOAuthClientID:     "ci-github-oauth-client-id"
-          GitHubOAuthClientSecret: "ci-github-oauth-client-secret"
+          # CUE string values must be quoted; build the file from masked
+          # env vars with documented placeholder fallbacks. The here-doc
+          # is NOT quoted ('CUE' → CUE) so ${...:-default} expands.
+          mem_dek="${CI_MEMORY_DEK:-ci-memory-dek-32-bytes-of-zeroes-for-tests-only}"
+          api_hmac="${CI_API_KEY_HMAC_SECRET:-ci-api-key-hmac-secret-32-bytes-of-zeroes-tests}"
+          gh_id="${CI_GITHUB_OAUTH_CLIENT_ID:-ci-github-oauth-client-id}"
+          gh_secret="${CI_GITHUB_OAUTH_CLIENT_SECRET:-ci-github-oauth-client-secret}"
+          cat > .secrets.local.cue <<CUE
+          // CI-only secrets. Mirrors the dev template shape declared at
+          // apps/api/auth/secrets.go. NEVER production values. Sourced
+          // from GitHub Actions secrets (masked) with placeholder
+          // fallbacks; written fresh on every CI run; .gitignored.
+          MemoryDEK:               "${mem_dek}"
+          APIKeyHMACSecret:        "${api_hmac}"
+          GitHubOAuthClientID:     "${gh_id}"
+          GitHubOAuthClientSecret: "${gh_secret}"
           CUE
 
       # ------------------------------------------------------------------
@@ -261,12 +307,26 @@ jobs:
       # analyzers compiled in.
       # ------------------------------------------------------------------
       - name: install golangci-lint
-        # Official install script. The version pin here MUST match the
-        # `version:` field of apps/api/.custom-gcl.yml so the schema
-        # (declared `version: "2"` in apps/api/.golangci.yml) and the
-        # binary used to build custom-gcl stay consistent.
+        # Official install script — pinned to a commit SHA, NOT `master`
+        # (tv8.67 supply-chain hygiene). Previously this curled
+        #   raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+        # which re-fetches whatever HEAD of master happens to be at run
+        # time — a moving, attacker-influenceable surface for PRs from
+        # forks. We pin to the install.sh as it shipped at the v2.7.2 tag
+        # commit 9f61b0f53f80672872fced07b6874397c3ed197b (the v2.7.2 tag
+        # is a lightweight tag pointing directly at that commit; verified
+        # 2026-06-01). The script still takes the same `[-b <bindir>]
+        # <tag>` arguments, so it downloads the GOLANGCI_LINT_VERSION
+        # release tarball exactly as before — only the script's own
+        # provenance is now frozen.
+        #
+        # The binary version pin (${GOLANGCI_LINT_VERSION} = v2.7.2) MUST
+        # match the `version:` field of apps/api/.custom-gcl.yml so the
+        # schema (declared `version: "2"` in apps/api/.golangci.yml) and
+        # the binary used to build custom-gcl stay consistent. Keep this
+        # commit SHA in lockstep with GOLANGCI_LINT_VERSION on any bump.
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/9f61b0f53f80672872fced07b6874397c3ed197b/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
           echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
         working-directory: ${{ github.workspace }}

--- a/apps/api/.golangci.yml
+++ b/apps/api/.golangci.yml
@@ -118,9 +118,20 @@ linters:
       # generator's wiring and flags the function as dead code.
       # Removing it would break the runtime (Encore's generated
       # __etype_service_init__ calls initService directly), so we
-      # exclude the false positive for every package that declares a
-      # service struct via //encore:service.
-      - linters:
+      # exclude the false positive — but ONLY in the packages that
+      # actually declare an //encore:service-anchored initService today:
+      #   apps/api/db/db.go               (the single migration/bind owner)
+      #   apps/api/exitcriteriontest/      (integration harness)
+      #   apps/api/perftest/               (NFR-1 latency harness)
+      #   apps/api/shared/mcpaudittest/    (MCP audit integration harness)
+      #   apps/api/shared/rbactest/        (NFR-2 RBAC final-gate harness)
+      # All five sit under either `db/` or a `*test/` directory, so the
+      # `path:` regex below scopes the suppression to exactly those trees
+      # (tv8.67). An unused `func initService` appearing anywhere ELSE —
+      # e.g. a real dead service hook in a domain package — is NO LONGER
+      # silenced and will fail the gate as a genuine `unused` finding.
+      - path: (db|.*test)/.*\.go
+        linters:
           - unused
         text: "func initService is unused"
 

--- a/apps/api/shared/lint/plugin.go
+++ b/apps/api/shared/lint/plugin.go
@@ -21,11 +21,19 @@
 //     verbatim — no per-invocation construction — so behaviour is
 //     identical between the `go run ./shared/lint/cmd/<name>` direct
 //     path and the custom-gcl path.
-//   - LinterPlugin.GetLoadMode pins LoadModeSyntax: both analyzers
-//     inspect AST literals and import paths only (no type-information
-//     queries, no SSA), so the lighter syntax-only load mode is the
-//     correct match. Switching to LoadModeTypesInfo would force
-//     golangci-lint to populate go/types info we do not consume.
+//   - LinterPlugin.GetLoadMode diverges by analyzer ON PURPOSE: each
+//     plugin pins the lightest load mode it can actually run under, so
+//     the two implementations below return different modes.
+//     no_direct_is_ready_write pins register.LoadModeSyntax because it
+//     inspects AST literals and import paths only (no type-info queries,
+//     no SSA); forcing LoadModeTypesInfo there would make golangci-lint
+//     populate go/types info that analyzer never consumes.
+//     no_rbac_dynamic_clause pins register.LoadModeTypesInfo because it
+//     reads pass.TypesInfo (receiver-type checks via .Selections,
+//     package-qualified resolution via .Uses), and those maps are only
+//     populated under the type-info load mode — syntax-only would leave
+//     them nil and break the analyzer. The per-method GetLoadMode
+//     comments below name the exact call sites each mode is dictated by.
 //   - register.Plugin is called from init() so the registration fires
 //     the moment the custom binary's main package blank-imports
 //     encore.app/shared/lint via the module-plugin loader's generated


### PR DESCRIPTION
Batch cleanup I1 — two infra-domain review beads on one branch (disjoint files).

## unblock-tv8.67 (P2 — supply-chain / lint hygiene)
- **Installer pinning.** golangci-lint `install.sh` curl URL pinned from `.../master/...` to commit SHA `9f61b0f` (the v2.7.2 tag commit). Encore `install.sh` has no GitHub source to SHA-pin, so it is **vendored** to `.github/scripts/encore-install.sh` (provenance + refresh header; upstream sha256 recorded). CLI binary version still pinned via `ENCORE_CLI_VERSION`.
- **initService exclusion scoped.** `.golangci.yml` `func initService is unused` exclusion gains `path: (db|.*test)/.*\.go` so a genuine unused `initService` in a domain package is no longer silenced. Verified via a throwaway probe in `org/` that the linter now catches it.
- **Secrets sourcing.** `.secrets.local.cue` placeholders now sourced from GitHub Actions secrets (masked in logs) with documented placeholder fallbacks, so CI stays green before the secrets are added.

### Human action (optional — CI passes without it)
Add these repo secrets (Settings → Secrets and variables → Actions, or `gh secret set <NAME>`). Until added, documented NEVER-production placeholders are used:
- `CI_MEMORY_DEK`
- `CI_API_KEY_HMAC_SECRET`
- `CI_GITHUB_OAUTH_CLIENT_ID`
- `CI_GITHUB_OAUTH_CLIENT_SECRET`

## unblock-tv8.68 (P3 — doc only)
- Fixed the false `plugin.go` package header (claimed both analyzers pin `LoadModeSyntax`). Rewrote it to describe the intentional per-plugin divergence: Syntax for `no_direct_is_ready_write`, TypesInfo for `no_rbac_dynamic_clause`. Per-method comments left untouched.

## Validation
- `actionlint` clean on the final workflow (embedded shellcheck passed on every `run:` block).
- `custom-gcl config verify` exit 0; `custom-gcl run --enable-only=unused` over all five initService packages → 0 issues; probe confirms out-of-scope `initService` now fails.
- Secrets step simulated both ways: unset → byte-identical placeholder CUE; set → GH values override.
- `go build` / `go vet` / `gofmt -l` clean on `apps/api/shared/lint/`.

Beads: unblock-tv8.67, unblock-tv8.68 (both → in-review, needs-review).