### PR TITLE
unblock-tv8.38: BFF-path hardening — redirect_uri + IP parse guard

### DIFF
--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -47,9 +47,10 @@
 #
 # Secrets:
 #
-#   `encore test` boots the local Encore emulator, which reads four
+#   `encore test` boots the local Encore emulator, which reads five
 #   secrets declared in apps/api/auth/secrets.go (MemoryDEK,
-#   APIKeyHMACSecret, GitHubOAuthClientID, GitHubOAuthClientSecret).
+#   APIKeyHMACSecret, GitHubOAuthClientID, GitHubOAuthClientSecret,
+#   GitHubOAuthRedirectURI).
 #   apps/api/mcp/transport.go fail-fasts at boot if APIKeyHMACSecret
 #   is empty (tv8.56 closure 2026-05-15); every package importing
 #   mcp/transport.go would panic before any test runs without it. CI
@@ -223,9 +224,10 @@ jobs:
 
       - name: provision local secrets for encore emulator
         # Every `encore test` invocation boots the local emulator and
-        # therefore needs the four secrets declared at apps/api/auth/
+        # therefore needs the five secrets declared at apps/api/auth/
         # secrets.go to be non-empty (mcp/transport.go fail-fasts on
-        # APIKeyHMACSecret == ""; mirrors the values shipped to
+        # APIKeyHMACSecret == ""; auth/secrets.go init() fail-fasts on
+        # GitHubOAuthRedirectURI == ""; mirrors the values shipped to
         # developers via the local .secrets.local.cue template). This
         # file is .gitignored and is NEVER persisted past the runner.
         #
@@ -241,7 +243,7 @@ jobs:
         # only needs non-empty, well-shaped values), so to keep CI green
         # BEFORE the repo secrets exist, each var falls back to the
         # documented placeholder default via `${VAR:-<default>}`. Once a
-        # human adds the four repo/Org secrets listed below, those values
+        # human adds the repo/Org secrets listed below, those values
         # take over with zero workflow change. Repo secrets the workflow
         # now reads (add via Settings → Secrets and variables → Actions,
         # or `gh secret set <NAME>`):
@@ -249,12 +251,16 @@ jobs:
         #   CI_API_KEY_HMAC_SECRET
         #   CI_GITHUB_OAUTH_CLIENT_ID
         #   CI_GITHUB_OAUTH_CLIENT_SECRET
+        #   CI_GITHUB_OAUTH_REDIRECT_URI  (optional — falls back to the
+        #     http://localhost:4321/auth/callback placeholder when the
+        #     repo secret is absent, so no new secret is required for CI)
         # If unset, the placeholders below are used and CI still passes.
         env:
           CI_MEMORY_DEK: ${{ secrets.CI_MEMORY_DEK }}
           CI_API_KEY_HMAC_SECRET: ${{ secrets.CI_API_KEY_HMAC_SECRET }}
           CI_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.CI_GITHUB_OAUTH_CLIENT_ID }}
           CI_GITHUB_OAUTH_CLIENT_SECRET: ${{ secrets.CI_GITHUB_OAUTH_CLIENT_SECRET }}
+          CI_GITHUB_OAUTH_REDIRECT_URI: ${{ secrets.CI_GITHUB_OAUTH_REDIRECT_URI }}
         run: |
           # CUE string values must be quoted; build the file from masked
           # env vars with documented placeholder fallbacks. The here-doc
@@ -263,6 +269,7 @@ jobs:
           api_hmac="${CI_API_KEY_HMAC_SECRET:-ci-api-key-hmac-secret-32-bytes-of-zeroes-tests}"
           gh_id="${CI_GITHUB_OAUTH_CLIENT_ID:-ci-github-oauth-client-id}"
           gh_secret="${CI_GITHUB_OAUTH_CLIENT_SECRET:-ci-github-oauth-client-secret}"
+          gh_redirect="${CI_GITHUB_OAUTH_REDIRECT_URI:-http://localhost:4321/auth/callback}"
           cat > .secrets.local.cue <<CUE
           // CI-only secrets. Mirrors the dev template shape declared at
           // apps/api/auth/secrets.go. NEVER production values. Sourced
@@ -272,6 +279,7 @@ jobs:
           APIKeyHMACSecret:        "${api_hmac}"
           GitHubOAuthClientID:     "${gh_id}"
           GitHubOAuthClientSecret: "${gh_secret}"
+          GitHubOAuthRedirectURI:  "${gh_redirect}"
           CUE
 
       # ------------------------------------------------------------------

--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -28,6 +28,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -313,6 +314,19 @@ func ExchangeOAuthCode(ctx context.Context, req *ExchangeOAuthCodeRequest) (*Exc
 		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing pkce_verifier"}
 	}
 
+	// IP address guard (BFF-readiness, bead unblock-tv8.38 W2). The
+	// session INSERT below coerces IPAddress with NULLIF($6, '')::inet.
+	// An empty string is allowed (maps to NULL via NULLIF). A non-empty
+	// but unparseable value (e.g. an upstream-controlled X-Forwarded-For
+	// the BFF forwards) would otherwise fail the entire pgx transaction
+	// with an opaque Postgres ::inet cast error surfaced as errs.Internal
+	// (a generic 500 / DoS surface). Reject it here with InvalidArgument
+	// before any DB or provider work. net.ParseIP accepts both IPv4 and
+	// IPv6, matching the ::inet column's domain — no narrowing needed.
+	if req.IPAddress != "" && net.ParseIP(req.IPAddress) == nil {
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "malformed ip_address"}
+	}
+
 	// PKCE verification. The BFF supplies `PKCEChallenge` from its
 	// per-request store (or, for the integration-test surface, inline
 	// on this request). When unset we skip the check (legacy path
@@ -323,7 +337,7 @@ func ExchangeOAuthCode(ctx context.Context, req *ExchangeOAuthCodeRequest) (*Exc
 	}
 
 	// Exchange the code for a GitHub access token.
-	tok, err := exchangeGitHubCode(ctx, req.Code, secrets.GitHubOAuthClientID, secrets.GitHubOAuthClientSecret)
+	tok, err := exchangeGitHubCode(ctx, req.Code, secrets.GitHubOAuthClientID, secrets.GitHubOAuthClientSecret, secrets.GitHubOAuthRedirectURI)
 	if err != nil {
 		rlog.Error("auth: github code exchange failed", "err", err)
 		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "oauth exchange failed"}

--- a/apps/api/auth/exchange_test.go
+++ b/apps/api/auth/exchange_test.go
@@ -1,0 +1,142 @@
+// Integration-adjacent tests for ExchangeOAuthCode input validation.
+//
+// Scope (bead unblock-tv8.38 W2): the BFF-readiness IP-address guard. A
+// non-empty but unparseable IPAddress must be rejected with
+// errs.InvalidArgument *before* any provider exchange or DB work, rather
+// than fall through to the session INSERT's NULLIF($6, '')::inet cast and
+// fail the whole pgx transaction with an opaque Postgres error surfaced as
+// errs.Internal (a generic 500 / DoS surface once the BFF forwards an
+// upstream-controlled X-Forwarded-For).
+//
+// Runner note (bead unblock-tv8.57): the auth root package panics at init()
+// on empty auth secrets (boot fail-fast in secrets.go). Run these under
+// `encore test ./auth/...`, which populates secrets from
+// apps/api/.secrets.local.cue and brings up the Docker cluster. The guard
+// under test returns before reaching sqldb, so the assertion does not
+// depend on the DB — but the package still cannot load under plain
+// `go test`. See apps/api/auth/db.go for the full rationale.
+//
+// We read err.Code by type assertion via the shared errCode helper
+// (authhandler_test.go) rather than errs.Code, which panics as a runtime
+// stub outside the Encore CLI. Every input-error branch of
+// ExchangeOAuthCode returns a concrete *errs.Error, so the assertion is
+// safe regardless of runner.
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"encore.dev/beta/errs"
+)
+
+// TestExchangeOAuthCodeIPGuard verifies the W2 net.ParseIP guard: a
+// malformed ip_address yields InvalidArgument (not a generic Internal /
+// 500) and the validation happens before the GitHub exchange so no
+// network or DB interaction is required.
+func TestExchangeOAuthCodeIPGuard(t *testing.T) {
+	tests := []struct {
+		name      string
+		ipAddress string
+		wantCode  errs.ErrCode
+	}{
+		{
+			name:      "malformed ip rejected with InvalidArgument",
+			ipAddress: "not-an-ip",
+			wantCode:  errs.InvalidArgument,
+		},
+		{
+			name:      "garbage-with-dots rejected with InvalidArgument",
+			ipAddress: "999.999.999.999",
+			wantCode:  errs.InvalidArgument,
+		},
+		{
+			name:      "trailing-junk on a valid prefix rejected",
+			ipAddress: "10.0.0.1 OR 1=1",
+			wantCode:  errs.InvalidArgument,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// A complete request that passes every prior validation
+			// (provider/code/pkce_verifier) so the IP guard is the first
+			// — and only — branch exercised. The guard returns before the
+			// GitHub exchange, so the absence of an httptest stub is
+			// intentional: reaching the network would mean the guard
+			// failed to fire.
+			req := &ExchangeOAuthCodeRequest{
+				Provider:     "github",
+				Code:         "abc123",
+				PKCEVerifier: "the-quick-brown-fox-jumps-over-the-lazy-dog",
+				IPAddress:    tc.ipAddress,
+			}
+			_, err := ExchangeOAuthCode(context.Background(), req)
+			if err == nil {
+				t.Fatalf("ExchangeOAuthCode(ip=%q) = nil error, want %v", tc.ipAddress, tc.wantCode)
+			}
+			if code := errCode(err); code != tc.wantCode {
+				t.Fatalf("ExchangeOAuthCode(ip=%q) code = %v, want %v", tc.ipAddress, code, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestExchangeOAuthCodeAcceptsValidAndEmptyIP confirms the guard does NOT
+// reject well-formed IPv4/IPv6 or an empty string (empty maps to NULL via
+// NULLIF in the session INSERT and must remain allowed). These inputs pass
+// the IP guard and proceed to the GitHub exchange, which fails without a
+// stub — so we assert the error code is NOT InvalidArgument (the guard did
+// not fire), rather than asserting success.
+func TestExchangeOAuthCodeAcceptsValidAndEmptyIP(t *testing.T) {
+	// Stub the GitHub token endpoint so a valid/empty IP that passes the
+	// guard fails deterministically at the exchange (returning an OAuth
+	// error → errs.Unauthenticated) instead of making a live outbound
+	// call to github.com. We assert only that the failure is NOT
+	// InvalidArgument — i.e. the IP guard did not fire.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error":"bad_verification_code","error_description":"stub"}`))
+	}))
+	defer srv.Close()
+
+	oldEndpoint, oldClient := githubTokenEndpoint, oauthHTTPClient
+	githubTokenEndpoint = srv.URL
+	oauthHTTPClient = srv.Client()
+	t.Cleanup(func() {
+		githubTokenEndpoint = oldEndpoint
+		oauthHTTPClient = oldClient
+	})
+
+	tests := []struct {
+		name      string
+		ipAddress string
+	}{
+		{"empty ip allowed (maps to NULL)", ""},
+		{"valid IPv4 allowed", "203.0.113.7"},
+		{"valid IPv6 allowed", "2001:db8::1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &ExchangeOAuthCodeRequest{
+				Provider:     "github",
+				Code:         "abc123",
+				PKCEVerifier: "the-quick-brown-fox-jumps-over-the-lazy-dog",
+				IPAddress:    tc.ipAddress,
+			}
+			_, err := ExchangeOAuthCode(context.Background(), req)
+			// The stubbed exchange fails (bad_verification_code →
+			// Unauthenticated), so we expect a non-nil error — but it
+			// must NOT be InvalidArgument, which would mean the IP guard
+			// wrongly rejected a valid/empty value.
+			if err == nil {
+				t.Fatalf("ExchangeOAuthCode(ip=%q) = nil error, want a non-InvalidArgument error", tc.ipAddress)
+			}
+			if code := errCode(err); code == errs.InvalidArgument {
+				t.Fatalf("ExchangeOAuthCode(ip=%q) wrongly rejected with InvalidArgument", tc.ipAddress)
+			}
+		})
+	}
+}

--- a/apps/api/auth/oauth.go
+++ b/apps/api/auth/oauth.go
@@ -108,13 +108,22 @@ type githubUserResponse struct {
 // responsible for translating non-200 responses into errs.* codes
 // (typically Unauthenticated for 401, Internal for 5xx).
 //
+// `redirectURI` is the OAuth app's registered callback URL, sourced from
+// the `GitHubOAuthRedirectURI` secret. GitHub OAuth apps that have a
+// registered redirect_uri return `redirect_uri_mismatch` on the token
+// exchange when it is omitted, so it is always sent in the form body
+// (RFC 6749 §4.1.3). An empty value is still set explicitly so the
+// failure mode is GitHub's `redirect_uri_mismatch` rather than a silent
+// omission that some app configurations tolerate.
+//
 // The function uses the package-level oauthHTTPClient so tests can
 // inject an httptest server without monkey-patching.
-func exchangeGitHubCode(ctx context.Context, code, clientID, clientSecret string) (*githubAccessTokenResponse, error) {
+func exchangeGitHubCode(ctx context.Context, code, clientID, clientSecret, redirectURI string) (*githubAccessTokenResponse, error) {
 	form := url.Values{}
 	form.Set("client_id", clientID)
 	form.Set("client_secret", clientSecret)
 	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, githubTokenEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {

--- a/apps/api/auth/oauth_test.go
+++ b/apps/api/auth/oauth_test.go
@@ -96,6 +96,13 @@ func TestExchangeGitHubCode(t *testing.T) {
 			if got := r.Form.Get("code"); got != "abc123" {
 				t.Errorf("code = %q, want abc123", got)
 			}
+			// W1 (bead unblock-tv8.38): redirect_uri MUST be present in
+			// the token-exchange body, sourced from GitHubOAuthRedirectURI.
+			// GitHub OAuth apps with a registered callback return
+			// redirect_uri_mismatch when it is omitted.
+			if got := r.Form.Get("redirect_uri"); got != "https://app.example.com/auth/callback" {
+				t.Errorf("redirect_uri = %q, want https://app.example.com/auth/callback", got)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"access_token":"gho_xxx","token_type":"bearer","scope":"repo user:email"}`))
 		}))
@@ -109,7 +116,7 @@ func TestExchangeGitHubCode(t *testing.T) {
 			oauthHTTPClient = oldClient
 		})
 
-		got, err := exchangeGitHubCode(context.Background(), "abc123", "test-id", "test-secret")
+		got, err := exchangeGitHubCode(context.Background(), "abc123", "test-id", "test-secret", "https://app.example.com/auth/callback")
 		if err != nil {
 			t.Fatalf("exchangeGitHubCode: %v", err)
 		}
@@ -136,7 +143,7 @@ func TestExchangeGitHubCode(t *testing.T) {
 			oauthHTTPClient = oldClient
 		})
 
-		_, err := exchangeGitHubCode(context.Background(), "expired", "id", "secret")
+		_, err := exchangeGitHubCode(context.Background(), "expired", "id", "secret", "https://app.example.com/auth/callback")
 		if err == nil {
 			t.Fatalf("expected error for github error response")
 		}
@@ -159,9 +166,43 @@ func TestExchangeGitHubCode(t *testing.T) {
 			oauthHTTPClient = oldClient
 		})
 
-		_, err := exchangeGitHubCode(context.Background(), "code", "id", "secret")
+		_, err := exchangeGitHubCode(context.Background(), "code", "id", "secret", "https://app.example.com/auth/callback")
 		if err == nil {
 			t.Fatalf("expected error for 500 response")
+		}
+	})
+
+	t.Run("redirect_uri key is always present even when empty", func(t *testing.T) {
+		// Defense-in-depth (bead unblock-tv8.38 W1): exchangeGitHubCode
+		// sets the redirect_uri form key unconditionally. An empty value
+		// is still sent so the failure surfaces as GitHub's
+		// redirect_uri_mismatch rather than a silent omission. The boot
+		// fail-fast in secrets.go guarantees a non-empty value in
+		// production, but the helper itself must not drop the key.
+		var hasKey bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			_, hasKey = r.Form["redirect_uri"]
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"gho_xxx","token_type":"bearer"}`))
+		}))
+		defer srv.Close()
+
+		oldEndpoint, oldClient := githubTokenEndpoint, oauthHTTPClient
+		githubTokenEndpoint = srv.URL
+		oauthHTTPClient = srv.Client()
+		t.Cleanup(func() {
+			githubTokenEndpoint = oldEndpoint
+			oauthHTTPClient = oldClient
+		})
+
+		if _, err := exchangeGitHubCode(context.Background(), "code", "id", "secret", ""); err != nil {
+			t.Fatalf("exchangeGitHubCode: %v", err)
+		}
+		if !hasKey {
+			t.Errorf("redirect_uri key absent from form body; want present (even when empty)")
 		}
 	})
 }

--- a/apps/api/auth/secrets.go
+++ b/apps/api/auth/secrets.go
@@ -15,6 +15,7 @@ package auth
 //	API_KEY_HMAC_SECRET     ↔ APIKeyHMACSecret
 //	GITHUB_OAUTH_CLIENT_ID  ↔ GitHubOAuthClientID
 //	GITHUB_OAUTH_CLIENT_SECRET ↔ GitHubOAuthClientSecret
+//	GITHUB_OAUTH_REDIRECT_URI  ↔ GitHubOAuthRedirectURI
 //
 // Provisioning policy across Encore Cloud env types (per tv8.56):
 //
@@ -36,15 +37,16 @@ package auth
 //	                its pre-deploy CI test runner queries; covering all
 //	                four documented types eliminates the variable.
 //
-// Local emulator (`encore run`) reads the four fields from
+// Local emulator (`encore run`) reads the five fields from
 // `apps/api/.secrets.local.cue` (gitignored), which overlays on top of
 // whatever the platform returns for `--type dev`.
 //
-// All four secrets MUST be set across all four types before deploy. Missing
-// values now surface uniformly as boot-time panics (bead unblock-tv8.57):
-// APIKeyHMACSecret → boot panic in mcp/transport.go's init; MemoryDEK,
-// GitHubOAuthClientID, GitHubOAuthClientSecret → boot panic in this file's
-// init (below). The prior asymmetry — where the latter three resolved to ""
+// All five secrets MUST be set across all four types before deploy. Missing
+// values now surface uniformly as boot-time panics (bead unblock-tv8.57,
+// extended for GitHubOAuthRedirectURI by unblock-tv8.38): APIKeyHMACSecret →
+// boot panic in mcp/transport.go's init; MemoryDEK, GitHubOAuthClientID,
+// GitHubOAuthClientSecret, GitHubOAuthRedirectURI → boot panic in this file's
+// init (below). The prior asymmetry — where the OAuth secrets resolved to ""
 // and failed late on the OAuth/encrypt call path (auth.go:326,459) — is
 // eliminated.
 //
@@ -73,6 +75,15 @@ var secrets struct {
 	// GitHubOAuthClientID. Read by auth.ExchangeOAuthCode. Logical name:
 	// GITHUB_OAUTH_CLIENT_SECRET.
 	GitHubOAuthClientSecret string
+
+	// GitHubOAuthRedirectURI is the OAuth2+PKCE registered callback URL for
+	// the `://unblock` GitHub OAuth app. Sent as the `redirect_uri`
+	// parameter in the code → token exchange POST body (auth/oauth.go
+	// exchangeGitHubCode); GitHub OAuth apps with a registered callback URL
+	// return `redirect_uri_mismatch` on the token exchange when it is
+	// omitted. Read by auth.ExchangeOAuthCode. Logical name:
+	// GITHUB_OAUTH_REDIRECT_URI.
+	GitHubOAuthRedirectURI string
 }
 
 // init enforces boot-time fail-fast on the three auth secrets that were
@@ -88,10 +99,11 @@ var secrets struct {
 //   - MemoryDEK         → runtime panic at the first pgcrypto encrypt of an
 //     oauth_tokens row (auth.go:459) — fails late, on the
 //     OAuth callback path.
-//   - GitHubOAuthClientID / GitHubOAuthClientSecret → silently resolve to ""
-//     and produce a malformed/unauthorized GitHub code
+//   - GitHubOAuthClientID / GitHubOAuthClientSecret / GitHubOAuthRedirectURI →
+//     silently resolve to "" and produce a malformed/unauthorized GitHub code
 //     exchange (auth.go:326) — fails late, with a remote
-//     400/401 that masks the real cause (empty secret).
+//     400/401 (or a `redirect_uri_mismatch` for the empty
+//     redirect URI) that masks the real cause (empty secret).
 //
 // Exercising the OAuth → token-exchange → encrypt path (e.g. the unblock-tv8
 // exit-criterion E2E) would have surfaced those as confusing downstream
@@ -121,5 +133,8 @@ func init() {
 	}
 	if secrets.GitHubOAuthClientSecret == "" {
 		panic("auth: GitHubOAuthClientSecret is empty — provision via `encore secret set` (or apps/api/.secrets.local.cue) before boot; required for the OAuth2+PKCE code exchange (auth.go:326)")
+	}
+	if secrets.GitHubOAuthRedirectURI == "" {
+		panic("auth: GitHubOAuthRedirectURI is empty — provision via `encore secret set` (or apps/api/.secrets.local.cue) before boot; required as the redirect_uri parameter in the OAuth2+PKCE code exchange (auth.go:326) to avoid redirect_uri_mismatch")
 	}
 }

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -1,6 +1,6 @@
 # SPEC: P01 — Backend MVP Implementation Contract
 
-**Status:** APPROVED (round-15 NFR-1 harness test-isolation + mcpaudittest hardening applied 2026-05-29; round-14 NFR-1 latency-harness scope applied 2026-05-29; round-6 cascade-symmetry applied 2026-05-12; round-5 tracing applied 2026-05-12; round-4 auth applied 2026-05-11; DRIFT-1/-2 applied 2026-05-08; round-2 applied 2026-05-08; round-3 research applied 2026-05-08; original APPROVED 2026-05-07)
+**Status:** APPROVED (§3.5 fifth-secret addition applied 2026-06-02; round-15 NFR-1 harness test-isolation + mcpaudittest hardening applied 2026-05-29; round-14 NFR-1 latency-harness scope applied 2026-05-29; round-6 cascade-symmetry applied 2026-05-12; round-5 tracing applied 2026-05-12; round-4 auth applied 2026-05-11; DRIFT-1/-2 applied 2026-05-08; round-2 applied 2026-05-08; round-3 research applied 2026-05-08; original APPROVED 2026-05-07)
 **Changelog:**
 - 2026-05-08 — DRIFT-1 (naming): clarified §3.5 that the four logical secret names are spec-level identifiers; added logical-name ↔ Go-field mapping table for the Encore Go secrets manifest.
 - 2026-05-08 — DRIFT-2 (format): corrected the local-secrets file path/format from `.encore/local-secrets.toml` (TOML) to `apps/api/.secrets.local.cue` (CUE) per Encore official docs (https://encore.dev/docs/go/primitives/secrets); updated syntax examples and gitignore guidance.
@@ -16,6 +16,7 @@
 - 2026-05-29 — round-15 (NFR-1 harness test-isolation + mcpaudittest hardening; CI-failure closure on bead `unblock-tv8.24` rework, CI run 26633703926): the round-14 gate-semantics assumption — that the harness could live in the default `encore test ./...` suite with `UNBLOCK_PERF_GATE` merely controlling assertion fatality — was proven incomplete by CI. Under the default full-suite run, the perftest package co-schedules with ~15 other test packages against ONE shared local Postgres: warm-cache `Validate`/`Claim`/`Ready` calls ballooned from a local ~87 ms p99 to 5–16 s; one measurement-loop response returned an empty body and tripped a hard `t.Fatalf` ("no SSE data" at `harness_test.go:220`) that the gate does NOT guard (it guards only the p99/goroutine assertions, not transport errors); and the harness's ~630 concurrent `mcp.tool_calls` audit-row writes broke `mcpaudittest`'s `TestD1_POSTNoAuthReturnsUnauthenticated` global-count assertion (`tool_calls rows = 1, want 0`). §11.2 NFR-1 gains two paragraphs: (1) **Test isolation** — the harness MUST be excluded from the default suite (Gate 5) and run ONLY in a dedicated isolated CI step under `UNBLOCK_PERF_GATE=1`; with the gate unset the package MUST contribute zero DB load and zero `mcp.tool_calls` rows (no seed, no loops — not merely log-and-pass); mechanism (build tag `//go:build perf` vs `UNBLOCK_PERF_GATE`-gated `t.Skip`/`TestMain` short-circuit) is the implementer's choice, validated by `encore check` + both suite runs; dedicated CI step owned by Olive. (2) **mcpaudittest hardening** — `selectToolCalls` (global `mcp.tool_calls` query) MUST be scoped to the test's own org/session so the D1 audit-row assertions are robust to any concurrent writer; a pre-existing latent test-isolation defect that the perftest load made deterministic, fixed in the same rework. Additionally the W3 paragraph's assertion wording is corrected from "asserts 401 / errs.Unauthenticated" to the actual MCP transport signal (HTTP 200 + JSON-RPC envelope `code -32000`, `data.kind=UNAUTHENTICATED`), ratifying the DEVIATION logged on the bead and confirmed at code review. No DDL / migration / public-API / `go.mod` change. Spec status remains APPROVED — test-harness isolation + sibling-test correctness, not re-architecting. Bead `unblock-tv8.24` reopened to rework in lockstep.
 - 2026-05-29 — round-14 (NFR-1 latency-harness scope codification; spec-drift closure from `/investigate` on bead `unblock-tv8.24`): §11.2 NFR-1 expanded from a single latency line into the full E-2 harness contract, folding in the two cross-linked WARNINGs from the closed B-1 review (`unblock-tv8.7`) that were recorded on the bead but absent from the spec. (DRIFT-A) seeding doctrine pinned — harness owns its fixture via direct `sqldb.Exec` per the §11.1.1 round-12 doctrine, shortULID-salted slug, in-test key issuance via direct `INSERT INTO mcp.api_keys`, seed `N = 2 × iterations` ready rows. (DRIFT-B) W3 negative-auth-path coverage promoted from cross-link note to acceptance scope — the harness package ships a sibling test covering the §4.3.2 negative paths (revoked / expired / unknown-prefix / bad-HMAC / missing-prefix), each asserting `401` / `errs.Unauthenticated`, closing the inspection-only gap from B-1. (DRIFT-C) W4 goroutine-leak detection given a concrete contract — three `runtime.NumGoroutine` samples (`baseline` / `peak` / `drained` after a 2 s post-loop sleep) with assertion `drained - baseline ≤ 20` (drain-window check, not a per-iteration ratio). Gate semantics pinned — harness always logs samples + p99 + goroutine deltas as JSON-Lines via `t.Logf`; hard-fail (`t.Fatalf`) gated by `UNBLOCK_PERF_GATE=1` to keep CI advisory on slow runners, release-blocking wiring deferred to P02 (Olive). The cold-start exclusion is sharpened to "M ≥ 10 warm-up iterations discarded". No DDL change, no migration, no public API change, no `go.mod` addition, no production-code-path change — the harness is a new test-only Encore package (`apps/api/perftest/`) mirroring `apps/api/exitcriteriontest/`. Spec status remains APPROVED — this is a test-harness contract codification, not a re-architecting. Bead `unblock-tv8.24` AC patched in lockstep.
 - 2026-05-22 — round-12 (seeder CLI deleted from P01 scope; spec-drift closure from `/investigate` on bead `unblock-tv8.23`): the one-shot `apps/api/cmd/unblock-seed/` Go CLI is removed from P01 entirely. Four blockers triggered the deletion — (DRIFT-1) no `auth.users` private RPC exists for the seeder to call; (DRIFT-2) the state-machine does not allow the canonical fixture's `Done`/`Ready` end-states via RPC; (DRIFT-3) `--issue-key` lacks operand flags; (DRIFT-4) Encore parser invariant E1388 forbids `package main` under `cmd/` from calling private RPCs, making "tiny CLI that calls private RPCs" architecturally impossible without scope inflation (new public RPCs or promoting the binary to an Encore service — both compromise design). Seeding responsibility moves to the E2E test package (`apps/api/exitcriteriontest/`) which owns a `TestMain` + direct-SQL seed mirroring `apps/api/shared/rbactest/seed.go:46-53` ("All rows go through direct `sqldb.Exec`, NOT through the auth/org RPCs"); fixture data lives as Go constants/structs in `apps/api/exitcriteriontest/fixture.go` (no YAML, no `gopkg.in/yaml.v3` dependency). The canonical 5-item graph topology (former §9.2: `itm_a`..`itm_e` with chain `a→b`, `b→c`, `b→d`, `d→e` plus the cycle-attempt edge closing the loop) is relocated verbatim into §11.1 as the authoritative exit-criterion fixture description. `--issue-key` is deferred entirely from P01 — no operator-key CLI in scope; in-test key issuance happens via direct `INSERT INTO mcp.api_keys` (computing `key_hash` with `secrets.APIKeyHMACSecret` per `apps/api/auth/apikey.go:103-111`); dev exploration outside tests uses `psql`. No new migrations, no DDL change, no `go.mod` additions. Patches in lockstep: §1 overview seeder bullet removed; §4.1 `IssueAPIKey` doc-comment updated; §4.4 / §4.4.1 / §6.2 Tool 4 seeder consumer notes rewritten; §9 deleted (tombstone retained to preserve §10..§14 numbering and the 30 cross-references that depend on it); §11.1 exit-criterion fixture relocation + E2E seed ownership note added; §11.4 docs and §14 approval checklist seeder mentions removed; §12 task-table E-1 row deleted (bead `unblock-tv8.23` cancelled in lockstep, post-spec, by the orchestrator); plan §2.1/§2.4/§4.5/§6 Q3 and root SPEC §9.4.6 / research AF4 / `apps/api/auth/auth.go` / `apps/api/db/migrations/0070_mcp.up.sql` updated. Spec status remains APPROVED — this is a scope reduction, not a re-architecting.
+- 2026-06-02 — fifth-secret addition (§3.5; spec-drift closure from `/investigate` on bead `unblock-tv8.38` W1): §3.5 expands the locked secret set from four to **five**, adding `GITHUB_OAUTH_REDIRECT_URI` / `GitHubOAuthRedirectURI` — the OAuth2+PKCE registered callback URL sent as the `redirect_uri` parameter in the GitHub token-exchange POST body, preventing `redirect_uri_mismatch` once the BFF wires a real GitHub OAuth app. Consumer is `auth.ExchangeOAuthCode` (same call site as the other two GitHub OAuth secrets). Patched in lockstep: the DRIFT-1 naming note (four→five), the logical-name ↔ Go-field mapping table, the Go manifest struct, the `.secrets.local.cue` example, and the purpose table. This is a lockstep additive contract change — the auth service's boot fail-fast init MUST include the new secret, and every env type + `.secrets.local.cue` MUST provision it (per Olive). Spec status remains APPROVED — this is an additive contract clarification, not a re-architecting.
 
 **Author:** Ada (architect)
 **Date:** 2026-05-08
@@ -264,9 +265,9 @@ reads from a **CUE** file at `apps/api/.secrets.local.cue` (Encore app
 root, next to `encore.app`), per Encore official docs
 (https://encore.dev/docs/go/primitives/secrets).
 
-> **DRIFT-1 — naming.** The four secret identifiers below
+> **DRIFT-1 — naming.** The five secret identifiers below
 > (`MEMORY_DEK`, `API_KEY_HMAC_SECRET`, `GITHUB_OAUTH_CLIENT_ID`,
-> `GITHUB_OAUTH_CLIENT_SECRET`) are **spec-level logical names**, not
+> `GITHUB_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_REDIRECT_URI`) are **spec-level logical names**, not
 > literal manifest field names. The Encore Go secrets manifest declares
 > them as Go struct fields in PascalCase, and Encore secret-manager keys
 > + CUE-file keys must use those Go field names verbatim.
@@ -280,6 +281,7 @@ key and the `.secrets.local.cue` field name):
 | `API_KEY_HMAC_SECRET` | `APIKeyHMACSecret` |
 | `GITHUB_OAUTH_CLIENT_ID` | `GitHubOAuthClientID` |
 | `GITHUB_OAUTH_CLIENT_SECRET` | `GitHubOAuthClientSecret` |
+| `GITHUB_OAUTH_REDIRECT_URI` | `GitHubOAuthRedirectURI` |
 
 The Encore Go secrets manifest (declared once in the `auth` service):
 
@@ -289,6 +291,7 @@ var secrets struct {
     APIKeyHMACSecret        string
     GitHubOAuthClientID     string
     GitHubOAuthClientSecret string
+    GitHubOAuthRedirectURI  string
 }
 ```
 
@@ -300,6 +303,7 @@ MemoryDEK:               "dev-dek-32-bytes-base64..."
 APIKeyHMACSecret:        "dev-hmac-secret..."
 GitHubOAuthClientID:     "dev-client-id"
 GitHubOAuthClientSecret: "dev-client-secret"
+GitHubOAuthRedirectURI:  "http://localhost:4321/auth/callback"
 ```
 
 | Secret (logical) | Purpose | Used by |
@@ -308,6 +312,7 @@ GitHubOAuthClientSecret: "dev-client-secret"
 | `API_KEY_HMAC_SECRET` | server-side secret for `HMAC-SHA256(secret, raw_key)` per C7 (Bearer auth) AND `HMAC-SHA256(secret, cursor_payload)` per §6.2.0 (paginated cursor signing — re-uses the same key, no new secret) | `auth` (Bearer auth check on every MCP call; API key issuance); `mcp` (paginated cursor encode/decode per §6.2.0) |
 | `GITHUB_OAUTH_CLIENT_ID` | OAuth2+PKCE client id (test app at v1.0) | `auth.ExchangeOAuthCode` |
 | `GITHUB_OAUTH_CLIENT_SECRET` | OAuth2+PKCE client secret | `auth.ExchangeOAuthCode` |
+| `GITHUB_OAUTH_REDIRECT_URI` | OAuth2+PKCE registered callback URL included in the token-exchange POST body (prevents `redirect_uri_mismatch` once the BFF wires real GitHub) | `auth.ExchangeOAuthCode` |
 
 **Gitignore status (verified 2026-05-08).** The current
 `apps/api/.gitignore` ignores `/.encore` and the generated `encore.gen.*`


### PR DESCRIPTION
## unblock-tv8.38: B-1 BFF-path hardening: redirect_uri + IP parse guard

Two BFF-readiness defensive gaps in the auth service, both currently masked by test stubs / trusted-caller assumptions.

### What was done
- **W1 (redirect_uri):** `exchangeGitHubCode` now sends `redirect_uri` in the GitHub token-exchange POST body, sourced from a new `GitHubOAuthRedirectURI` secret. Prevents `redirect_uri_mismatch` once the BFF wires a real GitHub OAuth app. The new secret has a boot-time fail-fast in `auth/secrets.go` `init()` for parity with the existing four.
- **W2 (IP parse guard):** `ExchangeOAuthCode` now guards `req.IPAddress` with `net.ParseIP` before the `NULLIF($6,'')::inet` session INSERT. A non-empty unparseable IP is rejected with `errs.InvalidArgument` instead of failing the whole pgx transaction with an opaque `::inet` cast error surfaced as a generic 500. Empty string remains allowed (maps to NULL).
- SPEC §3.5 patched in lockstep (four → five locked secrets), per the orchestrator's pre-approved spec-drift resolution.

### Files changed
- `apps/api/auth/oauth.go`, `apps/api/auth/auth.go`, `apps/api/auth/secrets.go`
- `apps/api/auth/oauth_test.go`, `apps/api/auth/exchange_test.go` (new)
- `docs/specs/01-spec-backend-mvp.md` (§3.5 lockstep)
- `apps/api/.secrets.local.cue` (gitignored — local boot)

### Decisions
1. IP guard placed in the early validation block (before exchange/DB) for fail-fast and stub-free testing.
2. `redirect_uri` form key set unconditionally (even when empty) so failures surface as GitHub's explicit `redirect_uri_mismatch`.

### Deviations
None — implemented as spec.