### PR TITLE
unblock-tv8.63: §7.1 success-side warnings + warning_codes audit for set_state

### DIFF
--- a/apps/api/db/migrations/0110_mcp_warning_codes.up.sql
+++ b/apps/api/db/migrations/0110_mcp_warning_codes.up.sql
@@ -1,0 +1,38 @@
+-- Migration 0110 — additive mcp.tool_calls.warning_codes column for the
+-- §7.1 success-side warnings audit channel (bead unblock-tv8.63).
+--
+-- The §7.1 success-side warnings of a tool result (currently only
+-- set_state's intent_comment_dropped on the best-effort AppendComment
+-- failure path) are audited via this jsonb array column: it stores the
+-- `code` strings present on the tool's success-result warnings[], or the
+-- empty array `[]` when none. jsonb (not text) so it is a true 0..N list,
+-- queryable for the FR-9 quality analytics
+-- (WHERE warning_codes @> '["intent_comment_dropped"]', GIN-indexable —
+-- mirroring the existing arguments jsonb + tool_calls_arguments_gin_idx
+-- precedent) and array-normalised on write.
+--
+-- result_kind STAYS 'ok' on the partial-failure path (the call
+-- succeeded); the tool_calls_result_chk CHECK constraint
+-- (0070_mcp.up.sql:70-71) is intentionally UNTOUCHED — the audit widening
+-- is this warning column, NOT a new result_kind value.
+--
+-- NEW sequential migration (NOT an amend of 0070): apps/api/db/migrations/
+-- is append-only and 0070 already shipped + ran (local + CI clusters at
+-- schema_migrations.version = 100). golang-migrate (Encore's runner) only
+-- applies migrations numbered HIGHER than the current max, so this file
+-- continues the established multiples-of-10 sequence (0010..0100 -> 0110).
+-- Up-only — no 0110_mcp_warning_codes.down.sql, per the §3.3 "No down.sql
+-- files in P01" convention (zero .down.sql files exist under apps/api).
+--
+-- SPEC anchor: docs/specs/01-spec-backend-mvp.md § 8.1.1 (warning_codes
+-- audit column) + § 7.1 (success-side warnings) + § 6.2 Tool 13
+-- (intent_comment partial-failure). NOTE: §8.1.1 prose pins the filename
+-- as 0071; that numbering is below the already-applied version 100 and
+-- would never run — implemented as 0110 (DEVIATION logged on
+-- unblock-tv8.63 for the reviewer to back-fold the §8.1.1 filename).
+
+ALTER TABLE mcp.tool_calls
+    ADD COLUMN warning_codes jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX tool_calls_warning_codes_gin_idx
+    ON mcp.tool_calls USING gin (warning_codes);

--- a/apps/api/mcp/export_test_writer.go
+++ b/apps/api/mcp/export_test_writer.go
@@ -36,6 +36,8 @@ package mcp
 import (
 	"context"
 	"net/http"
+
+	"encore.app/workitems"
 )
 
 // WriteToolCallForTest is the integration-test-only re-export of
@@ -62,4 +64,24 @@ func WriteToolCallForTest(ctx context.Context, call ToolCall) {
 // smell — the suffix is the audit trail.
 func ServeMCPForTest(w http.ResponseWriter, r *http.Request) {
 	serveMCP(w, r)
+}
+
+// SetAppendIntentCommentForTest overrides the package-level
+// appendIntentComment seam (handler_set_state.go) and returns a restore
+// func the caller MUST invoke (typically via defer) to reinstate the
+// production binding. It exists so the cross-package mcpaudittest suite
+// can force the post-commit AppendComment to fail and exercise the
+// §6.2 Tool 13 intent_comment partial-failure path — the §7.1
+// warnings[] + §8.1.1 warning_codes dropped-path that AC#3 of
+// unblock-tv8.63 requires. There is NO black-box input that makes
+// AppendComment fail after SetStateColumns commits (see the seam's
+// doc-comment + INVESTIGATION risk R1), so a test double is the only
+// honest way to cover this branch.
+//
+// Production callers MUST NOT use this — the suffix is the audit trail;
+// the only caller is the partial-failure integration test.
+func SetAppendIntentCommentForTest(fn func(ctx context.Context, req *workitems.AppendCommentRequest) error) (restore func()) {
+	prev := appendIntentComment
+	appendIntentComment = fn
+	return func() { appendIntentComment = prev }
 }

--- a/apps/api/mcp/handler_set_state.go
+++ b/apps/api/mcp/handler_set_state.go
@@ -1,8 +1,8 @@
 // handler_set_state.go owns the §6.2 Tool 13 (`set_state`) handler —
 // the dedicated mutator for the four state-machine columns
 // (impl_state, review_state, qa_state, pipeline_state) plus an
-// optional `intent_comment` written atomically (best-effort) alongside
-// the state change.
+// optional `intent_comment` written best-effort (non-atomic,
+// post-commit) alongside the state change.
 //
 // # State invariants
 //
@@ -33,19 +33,30 @@
 // as `qa_state → passed` requires a (kind=qa, status=success)
 // comment) ship in P02 per Plan §3.4 — NOT enforced here.
 //
-// # intent_comment atomicity
+// # intent_comment best-effort non-atomicity + warnings signal
 //
-// SPEC §6.2 Tool 13 line 1694 and §4.4 line 732-736 mandate that the
-// state mutation and the intent_comment are written "atomically".
-// Encore's RPC boundary prevents a single Postgres transaction
-// spanning both workitems.SetStateColumns and workitems.AppendComment
-// — orchestrator DECISION (2026-05-18) on bead unblock-tv8.21 accepts
-// this as architectural: SetStateColumns runs first, AppendComment
-// follows on success. If AppendComment fails after the state mutation
-// committed, the failure is logged via rlog.Error (with item_id +
-// payload hash) and the wire envelope still reports the state-change
-// success — the canonical record is the row mutation, the
-// intent_comment is metadata.
+// SPEC §6.2 Tool 13 + §4.4 (back-folded by unblock-tv8.63) document
+// the intent_comment write as best-effort and NON-atomic: Encore's RPC
+// boundary prevents a single Postgres transaction spanning both
+// workitems.SetStateColumns and workitems.AppendComment (orchestrator
+// DECISION 2026-05-18 on bead unblock-tv8.21 — cross-RPC transactions
+// are out of P01 architectural scope). SetStateColumns commits first;
+// AppendComment follows on success and CANNOT roll it back.
+//
+// If AppendComment fails after the state mutation committed, the tool
+// STILL returns SUCCESS (the state was genuinely mutated) and surfaces
+// the dropped comment two non-error ways per the §7.1 success-side
+// warnings contract (activated by unblock-tv8.63):
+//
+//   - caller-visible: structuredContent.warnings[] carries exactly one
+//     {code:intent_comment_dropped, message, details:{kind,status}}
+//     entry — the body is never echoed (only length + sha256 reach the
+//     rlog diagnostic below).
+//   - operator-visible: the rlog.Error diagnostic plus the additive
+//     mcp.tool_calls.warning_codes audit column (§8.1.1) record
+//     ["intent_comment_dropped"]. result_kind STAYS 'ok' on this path —
+//     the call succeeded; the audit widening is the warning column, NOT
+//     a new result_kind value.
 //
 // # intent_comment validation
 //
@@ -124,6 +135,38 @@ type setStateIn struct {
 
 type setStateOut struct {
 	Item primeItem `json:"item"`
+	// WithWarnings embeds the §7.1 success-side warnings array
+	// (`warnings`, omitempty). set_state is the only wired warning
+	// producer in P01/P02: on the intent_comment partial-failure path
+	// it carries exactly one {code:intent_comment_dropped, ...} entry;
+	// on every other (success) path the embedded slice is nil and the
+	// `warnings` key is omitted from structuredContent entirely. The
+	// embedded field is promoted by jsonschema-go into the inferred
+	// output schema as a sibling of `item`. SPEC §7.1.
+	WithWarnings
+}
+
+// appendIntentComment is a package-level seam over the best-effort
+// post-commit workitems.AppendComment call. Production binds it to the
+// real RPC (initialised below); the integration test for the
+// §6.2 Tool 13 intent_comment partial-failure path overrides it via
+// setAppendIntentCommentForTest to force a post-commit failure.
+//
+// The seam exists because there is NO black-box input that makes
+// AppendComment fail AFTER SetStateColumns has committed: malformed
+// intent_comment fields are caught by validateIntentComment at the MCP
+// boundary BEFORE SetStateColumns runs, and AppendComment's own
+// failure modes (FK-violation→NotFound, generic Internal) cannot fire
+// for an item that SetStateColumns just locked + updated and proved to
+// exist. Exercising the §7.1 warnings + §8.1.1 warning_codes
+// dropped-path (AC#3) therefore requires a test double on exactly this
+// call — see the unblock-tv8.63 INVESTIGATION risk R1. The seam wraps
+// the production RPC verbatim, so the production path is unchanged.
+//
+//nolint:gochecknoglobals // test seam over a cross-RPC call by design.
+var appendIntentComment = func(ctx context.Context, req *workitems.AppendCommentRequest) error {
+	_, err := workitems.AppendComment(ctx, req)
+	return err
 }
 
 // setStateCommentBodyMax mirrors handler_comment.go's commentBodyMax —
@@ -225,13 +268,19 @@ func handleSetState(ctx context.Context, req *sdkmcp.CallToolRequest, in setStat
 		return nil, setStateOut{}, mapError(state, tool, err)
 	}
 
+	out := setStateOut{Item: itemToPrime(*item)}
+
 	// State write committed. Now best-effort append the intent_comment;
 	// any failure here is logged but does NOT roll back the state
 	// mutation (orchestrator DECISION 2026-05-18 on bead
 	// unblock-tv8.21: cross-RPC Postgres transactions are out of
-	// architectural scope for P01).
+	// architectural scope for P01). On failure the tool STILL returns
+	// SUCCESS — the state was genuinely mutated — and surfaces the
+	// dropped comment two non-error ways per SPEC §6.2 / §7.1 / §8.1.1:
+	// a structuredContent.warnings[] entry for the caller and a
+	// warning_codes audit entry for the operator. result_kind STAYS ok.
 	if in.IntentComment != nil {
-		_, commentErr := workitems.AppendComment(mcpCtx, &workitems.AppendCommentRequest{
+		commentErr := appendIntentComment(mcpCtx, &workitems.AppendCommentRequest{
 			ItemID:      in.ItemID,
 			AuthorID:    identity.UserID,
 			AuthorAgent: identity.AgentKind,
@@ -252,10 +301,27 @@ func handleSetState(ctx context.Context, req *sdkmcp.CallToolRequest, in setStat
 				"intent_comment_body_sha256", hex.EncodeToString(bodyHash[:]),
 				"intent_comment_body_len", len(in.IntentComment.Body),
 			)
+
+			// §7.1 caller-visible signal: exactly one warning entry.
+			// `details` echoes kind/status only — never the body
+			// (SPEC §6.2: body length + sha256 stay in rlog above).
+			out.Warnings = append(out.Warnings, Warning{
+				Code:    warningCodeIntentCommentDropped,
+				Message: "state mutation committed; intent_comment append failed and was dropped",
+				Details: map[string]any{
+					"intent_comment_kind":   in.IntentComment.Kind,
+					"intent_comment_status": in.IntentComment.Status,
+				},
+			})
+			// §8.1.1 operator-visible signal: record the code on the
+			// audit row's warning_codes column. result_kind STAYS ok
+			// below — the call succeeded.
+			if state != nil && state.Call != nil {
+				state.Call.WarningCodes = append(state.Call.WarningCodes, warningCodeIntentCommentDropped)
+			}
 		}
 	}
 
-	out := setStateOut{Item: itemToPrime(*item)}
 	if state != nil && state.Call != nil {
 		state.Call.ResultKind = ResultOK
 		state.Call.ProjectID = item.ProjectID

--- a/apps/api/mcp/handler_set_state.go
+++ b/apps/api/mcp/handler_set_state.go
@@ -150,7 +150,7 @@ type setStateOut struct {
 // post-commit workitems.AppendComment call. Production binds it to the
 // real RPC (initialised below); the integration test for the
 // §6.2 Tool 13 intent_comment partial-failure path overrides it via
-// setAppendIntentCommentForTest to force a post-commit failure.
+// SetAppendIntentCommentForTest to force a post-commit failure.
 //
 // The seam exists because there is NO black-box input that makes
 // AppendComment fail AFTER SetStateColumns has committed: malformed

--- a/apps/api/mcp/recordtoolcall.go
+++ b/apps/api/mcp/recordtoolcall.go
@@ -9,7 +9,11 @@
 //   - §8.1 — locked column set:
 //     (id, api_key_id, org_id, project_id, item_id, tool_name,
 //     arguments, result_kind, rejection_reason, error_code,
-//     duration_ms, trace_id, called_at).
+//     warning_codes, duration_ms, trace_id, called_at). The
+//     warning_codes jsonb column is the §8.1.1 additive audit
+//     channel for the §7.1 success-side warnings (added
+//     unblock-tv8.63); a nil / empty WarningCodes slice serialises
+//     to the '[]'::jsonb default.
 //   - §10.2 Option B — trace_id is the ULID minted by MCPHandler
 //     at request entry, propagated via context.Context and pulled
 //     here via tracectx.TraceID(ctx). The column type is `text`
@@ -138,6 +142,15 @@ type ToolCall struct {
 	// NOT_FOUND, VALIDATION, CONFLICT, INTERNAL, …).
 	ErrorCode string
 
+	// WarningCodes carries the §7.1 success-side warning `code`
+	// strings present on the tool's success-result warnings[]
+	// (§8.1.1 mcp.tool_calls.warning_codes). The only P01/P02
+	// producer is set_state's intent_comment_dropped on the
+	// AppendComment-failure branch; result_kind STAYS "ok" on that
+	// path. A nil / empty slice serialises to the jsonb default '[]'
+	// (see recordToolCall). Mirrors the Arguments jsonb handling.
+	WarningCodes []string
+
 	// DurationMs is the elapsed wall-clock millisecond count
 	// from MCPHandler entry to the deferred call.
 	DurationMs int
@@ -221,6 +234,26 @@ func recordToolCall(ctx context.Context, call ToolCall) {
 		args = json.RawMessage(`{}`)
 	}
 
+	// Marshal WarningCodes ([]string) to a jsonb array. A nil /
+	// empty slice MUST serialise to the literal `[]` (the §8.1.1
+	// column is NOT NULL DEFAULT '[]'::jsonb) — json.Marshal(nil
+	// []string) yields "null", so collapse that to "[]" explicitly,
+	// mirroring the Arguments `{}` default above. A marshal error is
+	// effectively impossible for a []string but is handled defensively
+	// by falling back to the empty array so the audit row still lands.
+	warningCodes := []byte(`[]`)
+	if len(call.WarningCodes) > 0 {
+		if encoded, marshalErr := json.Marshal(call.WarningCodes); marshalErr == nil {
+			warningCodes = encoded
+		} else {
+			rlog.Error("mcp: recordToolCall: warning_codes marshal failed; defaulting to []",
+				"err", marshalErr,
+				"trace_id", tracectx.TraceID(ctx),
+				"tool", call.ToolName,
+			)
+		}
+	}
+
 	// Nullable string columns: collapse empties to (*string)(nil)
 	// so the SQL driver emits NULL. encore.dev/storage/sqldb
 	// forwards (*string)(nil) as NULL on the wire.
@@ -235,9 +268,9 @@ func recordToolCall(ctx context.Context, call ToolCall) {
 		INSERT INTO mcp.tool_calls
 			(id, api_key_id, org_id, project_id, item_id,
 			 tool_name, arguments, result_kind, rejection_reason,
-			 error_code, duration_ms, trace_id)
+			 error_code, warning_codes, duration_ms, trace_id)
 		VALUES
-			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 	`,
 		id,
 		apiKeyID,
@@ -249,6 +282,7 @@ func recordToolCall(ctx context.Context, call ToolCall) {
 		string(call.ResultKind),
 		rejectionReason,
 		errorCode,
+		warningCodes,
 		call.DurationMs,
 		traceIDArg,
 	)

--- a/apps/api/mcp/warnings.go
+++ b/apps/api/mcp/warnings.go
@@ -1,0 +1,85 @@
+// warnings.go owns the §7.1 success-side warnings contract — the
+// typed, optional `warnings` array a tool MAY carry INSIDE its
+// `structuredContent` success result when the primary mutation
+// succeeded but left a non-fatal residue the caller deserves to
+// observe (e.g. a dropped `intent_comment` on `set_state`).
+//
+// # Why structuredContent, not _meta or a top-level sibling
+//
+// SPEC §7.1 pins the home of warnings to `structuredContent` and
+// rejects the two alternatives for concrete go-sdk v1.6.0 reasons:
+//
+//   - A top-level `CallToolResult` sibling is unreachable: the
+//     go-sdk v1.6.0 CallToolResult struct exposes exactly Meta
+//     (`_meta`), Content, StructuredContent and IsError, with no
+//     index-signature passthrough and no custom MarshalJSON — an
+//     undeclared top-level field simply does not serialise.
+//   - `_meta` is a map[string]any whose keys are string literals,
+//     invisible to the NFR-10 snake_case gate
+//     (`grep -rnE 'json:"[A-Z]' apps/api/`). Routing through a
+//     TYPED struct field is deliberate so the gate actually
+//     inspects the wire keys.
+//
+// jsonschema-go infers `additionalProperties: false` on a tool's
+// inferred output schema and the SDK validates structuredContent
+// against it; an undeclared key would fail validation. The warning
+// channel MUST therefore be a declared field of the tool's typed Out
+// struct. Embedding the shared WithWarnings struct promotes
+// `warnings` into the schema as a sibling of `item`, preserving the
+// single-object shape and additionalProperties:false.
+//
+// # Shape (pinned — shared embedded struct, one wired producer)
+//
+// SPEC §7.1 weighs (A) re-declaring a per-tool Warnings field on each
+// Out struct (rejected: duplicates the Warning definition N times and
+// invites json-tag / omitempty drift) against (B, PINNED) a single
+// shared WithWarnings struct embedded into the Out structs that can
+// emit warnings. Only setStateOut embeds it in P01/P02 — the one
+// wired producer (code `intent_comment_dropped`). Future producers
+// (e.g. a P02 `cascade_delayed`) reuse these types with zero
+// re-definition: add a registry row (§7.1) plus an Out-struct
+// producer; no result-shape change is required.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 7.1 (success-side
+// warnings) + § 6.2 Tool 13 (intent_comment partial-failure) +
+// § 8.1.1 (warning_codes audit column) + § 3.6 (snake_case wire).
+
+package mcp
+
+// warningCodeIntentCommentDropped is the only §7.1 warning code wired
+// in P01/P02. Emitted by Tool 13 (`set_state`) when the state
+// mutation committed but the best-effort `intent_comment`
+// AppendComment failed (DECISION 2026-05-18, unblock-tv8.21). It is
+// both the wire `code` value (§7.1 registry) and the audited
+// `warning_codes` entry (§8.1.1). Keep the literal in sync with the
+// §7.1 registry table.
+const warningCodeIntentCommentDropped = "intent_comment_dropped"
+
+// Warning is the canonical §7.1 warning object carried on a tool's
+// SUCCESS result inside structuredContent. Every key is snake_case
+// per §3.6 (the typed struct tags are inspected by the NFR-10 gate).
+//
+//   - Code is a machine-stable identifier from the §7.1 registry.
+//   - Message is a one-line human-readable summary.
+//   - Details is optional (omitempty) per-code structured context;
+//     its shape is defined per code in the §7.1 registry and its
+//     keys are snake_case. Details MUST NOT carry large or sensitive
+//     payloads (e.g. comment bodies) — for intent_comment_dropped it
+//     echoes kind/status only; the body length + sha256 go to rlog
+//     diagnostics, never the wire.
+type Warning struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// WithWarnings is the shared embeddable carrier for the §7.1
+// success-side warnings array. Out structs that can emit warnings
+// embed it (currently only setStateOut); jsonschema-go promotes the
+// embedded Warnings field into the tool's output schema as a sibling
+// of the tool's primary payload. The `omitempty` tag means a result
+// with no warnings omits the key entirely — the no-warning path emits
+// exactly the pre-existing shape, so the field is purely additive.
+type WithWarnings struct {
+	Warnings []Warning `json:"warnings,omitempty"`
+}

--- a/apps/api/shared/mcpaudittest/d6_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d6_tools_test.go
@@ -50,7 +50,10 @@ import (
 	"testing"
 	"time"
 
+	"encore.app/mcp"
 	"encore.app/shared/ulid"
+	"encore.app/workitems"
+	"encore.dev/beta/errs"
 )
 
 // =============================================================================
@@ -137,7 +140,10 @@ func seedCommentDirect(t *testing.T, itemID, kind, status, body string, createdA
 }
 
 // setStateWireOut models the §6.2 Tool 13 wire shape — the
-// structuredContent JSON object carrying { "item": Item }.
+// structuredContent JSON object carrying { "item": Item } plus the
+// optional §7.1 success-side `warnings` array (omitted entirely when
+// no warning is present). The intent_comment partial-failure path
+// carries exactly one {code:intent_comment_dropped, ...} entry.
 type setStateWireOut struct {
 	Item struct {
 		ID            string `json:"id"`
@@ -146,6 +152,11 @@ type setStateWireOut struct {
 		QAState       string `json:"qa_state"`
 		PipelineState string `json:"pipeline_state"`
 	} `json:"item"`
+	Warnings []struct {
+		Code    string         `json:"code"`
+		Message string         `json:"message"`
+		Details map[string]any `json:"details"`
+	} `json:"warnings"`
 }
 
 func decodeSetStateOut(t *testing.T, raw json.RawMessage) setStateWireOut {
@@ -402,6 +413,183 @@ func TestD6_SetStateIntentCommentWrittenAtomically(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("intent_comment row count = %d, want 1", count)
+	}
+}
+
+// TestD6_SetStateSuccessOmitsWarningsKey pins SPEC §7.1's omitempty
+// contract + the R2 schema-validation concern: a successful set_state
+// with NO dropped intent_comment MUST omit the `warnings` key from
+// structuredContent entirely (not emit `null` or `[]`), and the result
+// MUST still pass the SDK's additionalProperties:false output-schema
+// validation that the embedded WithWarnings field introduces. We
+// inspect the raw structuredContent map (not the typed decode) so the
+// "key absent" mode is caught — a typed slice + omitempty would
+// silently mask an unexpectedly-present `null`.
+func TestD6_SetStateSuccessOmitsWarningsKey(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	// Happy path WITH an intent_comment that succeeds: still no warning.
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+		"intent_comment": map[string]any{
+			"kind":   "review",
+			"status": "warning",
+			"body":   "no warning expected on the success path",
+		},
+	})
+	res := assertStructuredEchoesText(t, env)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(res.StructuredContent, &raw); err != nil {
+		t.Fatalf("unmarshal raw structuredContent: %v; raw=%s", err, string(res.StructuredContent))
+	}
+	if _, ok := raw["warnings"]; ok {
+		t.Fatalf("success structuredContent carried a 'warnings' key; want it omitted (omitempty); raw=%s",
+			string(res.StructuredContent))
+	}
+
+	// Audit row: result_kind='ok' and warning_codes is the empty array.
+	rows := selectToolCalls(t, fx.OrgID)
+	var setStateRow *toolCallRow
+	for i := range rows {
+		if rows[i].ToolName == "set_state" {
+			setStateRow = &rows[i]
+		}
+	}
+	if setStateRow == nil {
+		t.Fatalf("no set_state audit row found")
+	}
+	if setStateRow.ResultKind != "ok" {
+		t.Fatalf("audit result_kind = %q, want ok", setStateRow.ResultKind)
+	}
+	if setStateRow.WarningCodes != "[]" {
+		t.Fatalf("audit warning_codes = %q, want [] on the no-warning path", setStateRow.WarningCodes)
+	}
+}
+
+// TestD6_SetStateIntentCommentDroppedEmitsWarning is the AC#3 test: on
+// the intent_comment partial-failure path (state mutation committed,
+// AppendComment then fails), set_state returns SUCCESS carrying exactly
+// one §7.1 warning {code:intent_comment_dropped, message, details} on
+// the wire AND the §8.1.1 mcp.tool_calls.warning_codes audit column
+// records ["intent_comment_dropped"], with result_kind staying 'ok'.
+//
+// There is no black-box input that makes AppendComment fail after
+// SetStateColumns commits (validation is caught at the MCP boundary
+// first; the item provably exists post-commit) — see the
+// appendIntentComment seam doc-comment + unblock-tv8.63 INVESTIGATION
+// risk R1. We force the failure by overriding the production seam with
+// a stub that returns an error AFTER asserting SetStateColumns already
+// committed (it reads the live state row), then restore it.
+func TestD6_SetStateIntentCommentDroppedEmitsWarning(t *testing.T) {
+	resetToolCalls(t)
+	fx := seedD2Fixture(t)
+	itemID := seedItemForState(t, fx.OrgID, fx.ProjectID,
+		"done", "approved", "passed", "running", fx.UserID)
+
+	// Override the post-commit AppendComment seam to force a failure.
+	// The stub returns an Internal error WITHOUT writing any comment,
+	// simulating a DB blip on the second RPC after the state mutation
+	// has already committed.
+	var stubCalled bool
+	restore := mcp.SetAppendIntentCommentForTest(
+		func(_ context.Context, req *workitems.AppendCommentRequest) error {
+			stubCalled = true
+			if req.ItemID != itemID {
+				t.Errorf("seam received item_id %q, want %q", req.ItemID, itemID)
+			}
+			return &errs.Error{Code: errs.Internal, Message: "simulated AppendComment failure"}
+		},
+	)
+	defer restore()
+
+	env := callTool(t, fx.RawKey, "set_state", map[string]any{
+		"item_id":      itemID,
+		"review_state": "needs_rework",
+		"intent_comment": map[string]any{
+			"kind":   "completed",
+			"status": "success",
+			"body":   "this append is forced to fail post-commit",
+		},
+	})
+	res := assertStructuredEchoesText(t, env)
+
+	if !stubCalled {
+		t.Fatalf("appendIntentComment seam was never invoked")
+	}
+
+	// The primary state mutation committed: item.review_state changed
+	// and (I-1) qa_state auto-reset to pending — the call succeeded.
+	got := decodeSetStateOut(t, res.StructuredContent)
+	if got.Item.ReviewState != "needs_rework" {
+		t.Fatalf("item.review_state = %q, want needs_rework (state committed)", got.Item.ReviewState)
+	}
+	// DB read-back confirms the commit landed despite the dropped comment.
+	_, review, qa, _ := readItemStateColumns(t, itemID)
+	if review != "needs_rework" {
+		t.Fatalf("DB review_state = %q, want needs_rework", review)
+	}
+	if qa != "pending" {
+		t.Fatalf("DB qa_state = %q, want pending (I-1 auto-reset)", qa)
+	}
+
+	// §7.1 caller-visible signal: exactly one warning entry.
+	if len(got.Warnings) != 1 {
+		t.Fatalf("warnings len = %d, want 1; raw=%s", len(got.Warnings), string(res.StructuredContent))
+	}
+	w := got.Warnings[0]
+	if w.Code != "intent_comment_dropped" {
+		t.Fatalf("warning.code = %q, want intent_comment_dropped", w.Code)
+	}
+	if w.Message == "" {
+		t.Fatalf("warning.message is empty; want a human-readable summary")
+	}
+	if got, _ := w.Details["intent_comment_kind"].(string); got != "completed" {
+		t.Fatalf("warning.details.intent_comment_kind = %q, want completed", got)
+	}
+	if got, _ := w.Details["intent_comment_status"].(string); got != "success" {
+		t.Fatalf("warning.details.intent_comment_status = %q, want success", got)
+	}
+	// The comment body MUST NOT leak into details (SPEC §6.2/§7.1).
+	for k, v := range w.Details {
+		if s, ok := v.(string); ok && s == "this append is forced to fail post-commit" {
+			t.Fatalf("warning.details[%q] echoed the comment body; want body excluded", k)
+		}
+	}
+
+	// No comment row landed (the append failed).
+	ctx := context.Background()
+	var count int
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM workitems.comments WHERE item_id = $1`, itemID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count comments: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("comment row count = %d, want 0 (append failed)", count)
+	}
+
+	// §8.1.1 operator-visible signal: the audit row keeps result_kind
+	// 'ok' and records warning_codes ["intent_comment_dropped"].
+	rows := selectToolCalls(t, fx.OrgID)
+	var setStateRow *toolCallRow
+	for i := range rows {
+		if rows[i].ToolName == "set_state" {
+			setStateRow = &rows[i]
+		}
+	}
+	if setStateRow == nil {
+		t.Fatalf("no set_state audit row found")
+	}
+	if setStateRow.ResultKind != "ok" {
+		t.Fatalf("audit result_kind = %q, want ok (call succeeded)", setStateRow.ResultKind)
+	}
+	if setStateRow.WarningCodes != `["intent_comment_dropped"]` {
+		t.Fatalf("audit warning_codes = %q, want [\"intent_comment_dropped\"]", setStateRow.WarningCodes)
 	}
 }
 

--- a/apps/api/shared/mcpaudittest/mcpaudittest_test.go
+++ b/apps/api/shared/mcpaudittest/mcpaudittest_test.go
@@ -223,8 +223,12 @@ type toolCallRow struct {
 	ToolName   string
 	ResultKind string
 	ErrorCode  *string
-	DurationMs int
-	TraceID    *string
+	// WarningCodes is the raw jsonb of the §8.1.1 warning_codes
+	// column (array of §7.1 warning `code` strings; `[]` when none).
+	// Read as a string so assertions can check the exact jsonb shape.
+	WarningCodes string
+	DurationMs   int
+	TraceID      *string
 }
 
 // rbactestToolNamePrefix is the side-tag carried by every
@@ -281,7 +285,7 @@ func selectToolCalls(t *testing.T, orgID string) []toolCallRow {
 	t.Helper()
 	ctx := context.Background()
 	rows, err := db.Query(ctx, `
-		SELECT id, org_id, project_id, tool_name, result_kind, error_code, duration_ms, trace_id
+		SELECT id, org_id, project_id, tool_name, result_kind, error_code, warning_codes::text, duration_ms, trace_id
 		FROM mcp.tool_calls
 		WHERE org_id = $1
 		  AND tool_name NOT LIKE $2
@@ -295,7 +299,7 @@ func selectToolCalls(t *testing.T, orgID string) []toolCallRow {
 	var out []toolCallRow
 	for rows.Next() {
 		var r toolCallRow
-		if err := rows.Scan(&r.ID, &r.OrgID, &r.ProjectID, &r.ToolName, &r.ResultKind, &r.ErrorCode, &r.DurationMs, &r.TraceID); err != nil {
+		if err := rows.Scan(&r.ID, &r.OrgID, &r.ProjectID, &r.ToolName, &r.ResultKind, &r.ErrorCode, &r.WarningCodes, &r.DurationMs, &r.TraceID); err != nil {
 			t.Fatalf("scan tool_calls: %v", err)
 		}
 		out = append(out, r)

--- a/apps/api/shared/rbactest/rbactest_test.go
+++ b/apps/api/shared/rbactest/rbactest_test.go
@@ -476,9 +476,12 @@ type depsCascadeEventsRow struct {
 }
 
 // mcpToolCallsRow mirrors mcp.tool_calls column order verbatim per
-// migration 0070_mcp.up.sql lines 52-68 (13 columns). pgx v5 scans
-// the `arguments jsonb` column into a []byte natively (no jsonb
-// codec registration required).
+// migration 0070_mcp.up.sql lines 52-68 plus the appended
+// warning_codes column from 0110_mcp_warning_codes.up.sql
+// (14 columns). pgx v5 scans the `arguments` / `warning_codes` jsonb
+// columns into []byte natively (no jsonb codec registration required).
+// The fields map positionally to `SELECT *`, so WarningCodes MUST stay
+// last to match the ADD COLUMN ordinal (14, after called_at).
 type mcpToolCallsRow struct {
 	ID              string
 	APIKeyID        *string
@@ -493,6 +496,7 @@ type mcpToolCallsRow struct {
 	DurationMs      int
 	TraceID         *string
 	CalledAt        time.Time
+	WarningCodes    []byte
 }
 
 // mcpAPIKeysRow mirrors mcp.api_keys column order verbatim per


### PR DESCRIPTION
## unblock-tv8.63: D-6 follow-up — intent_comment failure wire signal for set_state

Wires the §7.1 success-side warnings contract so an agent can detect a dropped `intent_comment` on `set_state` without polling the audit trail.

### What was done
On the `set_state` intent_comment partial-failure path (state mutation committed, post-commit `AppendComment` fails) the tool now returns SUCCESS carrying exactly one `structuredContent.warnings[]` entry `{code:intent_comment_dropped, message, details:{intent_comment_kind, intent_comment_status}}` and records `["intent_comment_dropped"]` in the new additive `mcp.tool_calls.warning_codes` jsonb audit column. `result_kind` stays `'ok'` — the call succeeded. Comment body is never echoed to the wire (only len + sha256 to rlog).

### Files changed
- `apps/api/mcp/warnings.go` (new) — shared `Warning` + `WithWarnings` types (§7.1 alt-B), embedded into `setStateOut`
- `apps/api/mcp/handler_set_state.go` — emit warning + audit code on the AppendComment-failure branch; refresh stale "atomic" doc-comment; add `appendIntentComment` test seam
- `apps/api/mcp/recordtoolcall.go` — `ToolCall.WarningCodes []string` marshalled to jsonb (nil/empty → `'[]'`)
- `apps/api/mcp/export_test_writer.go` — `SetAppendIntentCommentForTest` seam setter
- `apps/api/db/migrations/0110_mcp_warning_codes.up.sql` (new) — additive jsonb column + GIN index
- `apps/api/shared/mcpaudittest/*` + `apps/api/shared/rbactest/rbactest_test.go` — test fixtures for the new column + AC#3 test

### Decisions
- Test seam (not concurrent-delete race) to exercise AC#3's post-commit dropped path — there is no black-box input that fails AppendComment after SetStateColumns commits
- `warning_codes::text` scan cast for exact jsonb-shape assertions
- Extended rbactest `mcpToolCallsRow` mirror (SELECT * positional scan) with trailing `WarningCodes []byte`

### Deviations
- Migration numbered **0110**, NOT §8.1.1's pinned `0071`. Empirically verified: `schema_migrations.version=100` (0010..0100 applied); golang-migrate only applies migrations numbered higher than the current max, so a `0071` would never run and the column would silently never exist. The spec's `0071` is an editorial error — flagged for reviewer to back-fold §8.1.1's filename to 0110.

### Tests
`encore test ./...` fully green (16 packages). New `TestD6_SetStateIntentCommentDroppedEmitsWarning` (AC#3) and `TestD6_SetStateSuccessOmitsWarningsKey` (omitempty + schema validation). Gates: go fmt / go vet / encore check / NFR-10 snake_case grep all clean. Verified via encore-mcp: version 100→110, column = jsonb NOT NULL DEFAULT '[]'::jsonb, GIN index present.