### PR TITLE
unblock-f6z: secrets provisioning coherence — single committed SoT + CI drift-check

### DIFF
--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -241,13 +241,26 @@ jobs:
           echo '{}' > encore.app
 
       - name: secrets SoT drift-check (secrets.go ↔ secrets.nonprod.cue)
-        # Bead unblock-f6z deliverable #4. Assert that EVERY field of
-        # `var secrets struct` in apps/api/auth/secrets.go has a matching
-        # entry in the committed source of truth, apps/api/
-        # secrets.nonprod.cue. This catches "added the Go field + boot
-        # guard but forgot to provision" at PR time — the failure mode
-        # that left GitHubOAuthRedirectURI unprovisioned and crashed the
-        # deploy.
+        # Bead unblock-f6z deliverable #4 (+ follow-up: BIDIRECTIONAL).
+        # Assert an EXACT BIJECTION between the fields of `var secrets struct`
+        # in apps/api/auth/secrets.go and the keys of the committed source of
+        # truth, apps/api/secrets.nonprod.cue. Two failure modes, BOTH a hard
+        # FAIL (no soft warnings — an ignorable check would re-open the same
+        # false-green gap that crashed the deploy):
+        #   Direction 1 (comm -23): a secrets.go field MISSING from the SoT —
+        #     "added the Go field + boot guard but forgot to provision" (the
+        #     failure mode that left GitHubOAuthRedirectURI unprovisioned and
+        #     crashed the deploy).
+        #   Direction 2 (comm -13): a SoT key NOT declared in secrets.go —
+        #     a STALE/EXTRA SoT entry (e.g. a placeholder left behind after a
+        #     Go secret was removed). This would silently over-provision a
+        #     dead secret and rot the SoT.
+        #
+        # WHY auth/secrets.go IS THE CANONICAL SET: per SPEC §3.5 and the
+        # secrets.go doc-comment, the auth service is the canonical consumer
+        # and declares the SUPERSET of all secrets. Other packages (e.g.
+        # mcp/transport.go) declare their own SUBSET `var secrets struct`. The
+        # SoT must therefore be an exact bijection with auth/secrets.go.
         #
         # BOUNDARY (honest scope): this validates the code ↔ SoT contract
         # ONLY. It does NOT and CANNOT validate the Encore Platform secret
@@ -259,7 +272,7 @@ jobs:
         # compile step):
         #   - struct fields: leading PascalCase identifier of each
         #     `<Field> string` line inside the `var secrets struct { … }`
-        #     block.
+        #     block of auth/secrets.go (the canonical superset).
         #   - SoT fields: leading identifier of each `<Field>: "…"` line
         #     (comment lines start with `//` and never match).
         run: |
@@ -277,17 +290,30 @@ jobs:
             exit 1
           fi
 
-          # Every Go field MUST be present in the SoT. (Extra SoT fields are
-          # allowed in principle, but `comm -23` below reports any Go field
-          # with no SoT match — that is the drift we fail on.)
+          fail=0
+
+          # Direction 1: every Go field MUST be present in the SoT.
           missing="$(comm -23 <(printf '%s\n' "${go_fields}") <(printf '%s\n' "${sot_fields}"))"
           if [ -n "${missing}" ]; then
             echo "::error::secrets.go declares fields absent from apps/api/secrets.nonprod.cue:"
             echo "${missing}"
             echo "Add a placeholder line for each to secrets.nonprod.cue and run scripts/secrets-provision.sh (see apps/api/SECRETS.md)."
+            fail=1
+          fi
+
+          # Direction 2: every SoT key MUST be declared in secrets.go.
+          extra="$(comm -13 <(printf '%s\n' "${go_fields}") <(printf '%s\n' "${sot_fields}"))"
+          if [ -n "${extra}" ]; then
+            echo "::error::apps/api/secrets.nonprod.cue declares keys absent from 'var secrets struct' in auth/secrets.go:"
+            echo "${extra}"
+            echo "Remove the stale placeholder line(s) from secrets.nonprod.cue, or add the missing field + boot guard to auth/secrets.go (see apps/api/SECRETS.md)."
+            fail=1
+          fi
+
+          if [ "${fail}" -ne 0 ]; then
             exit 1
           fi
-          echo "secrets SoT drift-check OK — all $(printf '%s\n' "${go_fields}" | grep -c .) secrets.go field(s) present in secrets.nonprod.cue"
+          echo "secrets SoT drift-check OK — exact bijection: all $(printf '%s\n' "${go_fields}" | grep -c .) secrets.go field(s) ↔ secrets.nonprod.cue key(s)"
 
       - name: provision local secrets for encore emulator
         # Bead unblock-f6z: the local emulator needs the five secrets

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -45,21 +45,39 @@
 #     and apps/api/.golangci.yml line 36 narrative pin. v2 schema in
 #     .golangci.yml mandates a v2 binary.
 #
-# Secrets:
+# Secrets (bead unblock-f6z — single committed source of truth):
 #
 #   `encore test` boots the local Encore emulator, which reads five
 #   secrets declared in apps/api/auth/secrets.go (MemoryDEK,
 #   APIKeyHMACSecret, GitHubOAuthClientID, GitHubOAuthClientSecret,
 #   GitHubOAuthRedirectURI).
 #   apps/api/mcp/transport.go fail-fasts at boot if APIKeyHMACSecret
-#   is empty (tv8.56 closure 2026-05-15); every package importing
-#   mcp/transport.go would panic before any test runs without it. CI
-#   writes a placeholder apps/api/.secrets.local.cue (CUE format, per
-#   Encore docs at https://encore.dev/docs/go/primitives/secrets)
-#   ahead of any `encore test` invocation. The file is .gitignored
-#   (apps/api/.gitignore "/.secrets.local.cue") so writing it in CI
-#   leaves no trace. Values mirror the dev placeholders shipped by
-#   developers — they are NEVER production credentials.
+#   is empty (tv8.56 closure 2026-05-15); auth/secrets.go init()
+#   fail-fasts on the four auth secrets; every package importing them
+#   would panic before any test runs without the values.
+#
+#   The non-prod placeholder values are committed ONCE at
+#   apps/api/secrets.nonprod.cue (the SOURCE OF TRUTH). CI copies that
+#   file to apps/api/.secrets.local.cue ahead of any `encore test`
+#   invocation (the SoT is already valid CUE in the exact shape Encore
+#   expects). The destination is .gitignored
+#   (apps/api/.gitignore "/.secrets.local.cue") so copying it in CI
+#   leaves no trace. These are NEVER production credentials — they are
+#   deterministic, public placeholders safe to commit and log.
+#
+#   This REVERSES tv8.67's split GitHub `CI_*` repo-secret registry:
+#   there are no `${{ secrets.CI_* }}` reads and no `${VAR:-default}`
+#   fallbacks here anymore. A missing/mismatched secret can no longer be
+#   masked into a green build — the drift-check gate below catches a
+#   secrets.go field that is absent from the SoT at PR time.
+#
+#   HONESTY / BOUNDARY: CI runs against the LOCAL emulator only (it
+#   unlinks encore.app via `echo '{}' > encore.app`, so it has no
+#   platform auth). The drift-check therefore validates
+#   secrets.go ↔ secrets.nonprod.cue ONLY. It CANNOT see the Encore
+#   Platform secret matrix. Platform parity (prod/dev/local/pr) relies
+#   on apps/api/scripts/secrets-provision.sh + the SECRETS.md runbook +
+#   the deploy-time boot fail-fast — not on this workflow.
 #
 # Catalogue-drift workflow:
 #
@@ -222,65 +240,69 @@ jobs:
         run: |
           echo '{}' > encore.app
 
-      - name: provision local secrets for encore emulator
-        # Every `encore test` invocation boots the local emulator and
-        # therefore needs the five secrets declared at apps/api/auth/
-        # secrets.go to be non-empty (mcp/transport.go fail-fasts on
-        # APIKeyHMACSecret == ""; auth/secrets.go init() fail-fasts on
-        # GitHubOAuthRedirectURI == ""; mirrors the values shipped to
-        # developers via the local .secrets.local.cue template). This
-        # file is .gitignored and is NEVER persisted past the runner.
+      - name: secrets SoT drift-check (secrets.go ↔ secrets.nonprod.cue)
+        # Bead unblock-f6z deliverable #4. Assert that EVERY field of
+        # `var secrets struct` in apps/api/auth/secrets.go has a matching
+        # entry in the committed source of truth, apps/api/
+        # secrets.nonprod.cue. This catches "added the Go field + boot
+        # guard but forgot to provision" at PR time — the failure mode
+        # that left GitHubOAuthRedirectURI unprovisioned and crashed the
+        # deploy.
         #
-        # SOURCING (tv8.67): the values are now SOURCED from GitHub
-        # Actions secrets rather than baked inline as plaintext. The
-        # previous heredoc printed the literal placeholders into the
-        # workflow file (and thus into any log capture / `set -x` trace
-        # of the step verbatim). By piping them through `env:` from
-        # `${{ secrets.* }}`, GitHub masks them in logs (`***`) and the
-        # SOURCE of truth moves out of the committed YAML.
+        # BOUNDARY (honest scope): this validates the code ↔ SoT contract
+        # ONLY. It does NOT and CANNOT validate the Encore Platform secret
+        # matrix — CI unlinks encore.app and has no platform auth. Platform
+        # parity is enforced by scripts/secrets-provision.sh + SECRETS.md +
+        # the deploy-time boot fail-fast.
         #
-        # These remain NEVER-production placeholders (the local emulator
-        # only needs non-empty, well-shaped values), so to keep CI green
-        # BEFORE the repo secrets exist, each var falls back to the
-        # documented placeholder default via `${VAR:-<default>}`. Once a
-        # human adds the repo/Org secrets listed below, those values
-        # take over with zero workflow change. Repo secrets the workflow
-        # now reads (add via Settings → Secrets and variables → Actions,
-        # or `gh secret set <NAME>`):
-        #   CI_MEMORY_DEK
-        #   CI_API_KEY_HMAC_SECRET
-        #   CI_GITHUB_OAUTH_CLIENT_ID
-        #   CI_GITHUB_OAUTH_CLIENT_SECRET
-        #   CI_GITHUB_OAUTH_REDIRECT_URI  (optional — falls back to the
-        #     http://localhost:4321/auth/callback placeholder when the
-        #     repo secret is absent, so no new secret is required for CI)
-        # If unset, the placeholders below are used and CI still passes.
-        env:
-          CI_MEMORY_DEK: ${{ secrets.CI_MEMORY_DEK }}
-          CI_API_KEY_HMAC_SECRET: ${{ secrets.CI_API_KEY_HMAC_SECRET }}
-          CI_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.CI_GITHUB_OAUTH_CLIENT_ID }}
-          CI_GITHUB_OAUTH_CLIENT_SECRET: ${{ secrets.CI_GITHUB_OAUTH_CLIENT_SECRET }}
-          CI_GITHUB_OAUTH_REDIRECT_URI: ${{ secrets.CI_GITHUB_OAUTH_REDIRECT_URI }}
+        # Extraction is text-based (no Go build needed, runs before any
+        # compile step):
+        #   - struct fields: leading PascalCase identifier of each
+        #     `<Field> string` line inside the `var secrets struct { … }`
+        #     block.
+        #   - SoT fields: leading identifier of each `<Field>: "…"` line
+        #     (comment lines start with `//` and never match).
         run: |
-          # CUE string values must be quoted; build the file from masked
-          # env vars with documented placeholder fallbacks. The here-doc
-          # is NOT quoted ('CUE' → CUE) so ${...:-default} expands.
-          mem_dek="${CI_MEMORY_DEK:-ci-memory-dek-32-bytes-of-zeroes-for-tests-only}"
-          api_hmac="${CI_API_KEY_HMAC_SECRET:-ci-api-key-hmac-secret-32-bytes-of-zeroes-tests}"
-          gh_id="${CI_GITHUB_OAUTH_CLIENT_ID:-ci-github-oauth-client-id}"
-          gh_secret="${CI_GITHUB_OAUTH_CLIENT_SECRET:-ci-github-oauth-client-secret}"
-          gh_redirect="${CI_GITHUB_OAUTH_REDIRECT_URI:-http://localhost:4321/auth/callback}"
-          cat > .secrets.local.cue <<CUE
-          // CI-only secrets. Mirrors the dev template shape declared at
-          // apps/api/auth/secrets.go. NEVER production values. Sourced
-          // from GitHub Actions secrets (masked) with placeholder
-          // fallbacks; written fresh on every CI run; .gitignored.
-          MemoryDEK:               "${mem_dek}"
-          APIKeyHMACSecret:        "${api_hmac}"
-          GitHubOAuthClientID:     "${gh_id}"
-          GitHubOAuthClientSecret: "${gh_secret}"
-          GitHubOAuthRedirectURI:  "${gh_redirect}"
-          CUE
+          go_fields="$(awk '
+            /^var secrets struct \{/ { f=1; next }
+            f && /^\}/             { f=0 }
+            f && /^[[:space:]]+[A-Z][A-Za-z0-9_]*[[:space:]]+string/ { print $1 }
+          ' auth/secrets.go | sort -u)"
+
+          sot_fields="$(grep -oE '^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*"[^"]*"' \
+            secrets.nonprod.cue | sed -E 's/[[:space:]]*:.*//' | sort -u)"
+
+          if [ -z "${go_fields}" ]; then
+            echo "::error::could not parse any fields from 'var secrets struct' in auth/secrets.go"
+            exit 1
+          fi
+
+          # Every Go field MUST be present in the SoT. (Extra SoT fields are
+          # allowed in principle, but `comm -23` below reports any Go field
+          # with no SoT match — that is the drift we fail on.)
+          missing="$(comm -23 <(printf '%s\n' "${go_fields}") <(printf '%s\n' "${sot_fields}"))"
+          if [ -n "${missing}" ]; then
+            echo "::error::secrets.go declares fields absent from apps/api/secrets.nonprod.cue:"
+            echo "${missing}"
+            echo "Add a placeholder line for each to secrets.nonprod.cue and run scripts/secrets-provision.sh (see apps/api/SECRETS.md)."
+            exit 1
+          fi
+          echo "secrets SoT drift-check OK — all $(printf '%s\n' "${go_fields}" | grep -c .) secrets.go field(s) present in secrets.nonprod.cue"
+
+      - name: provision local secrets for encore emulator
+        # Bead unblock-f6z: the local emulator needs the five secrets
+        # declared at apps/api/auth/secrets.go to be non-empty (mcp/
+        # transport.go fail-fasts on APIKeyHMACSecret == ""; auth/
+        # secrets.go init() fail-fasts on the four auth secrets). The
+        # values come from the SINGLE committed source of truth,
+        # apps/api/secrets.nonprod.cue, which is already valid CUE in the
+        # exact `<GoField>: "<value>"` shape Encore expects — so we copy
+        # it verbatim to the .gitignored .secrets.local.cue. No CI_*
+        # GitHub secrets, no `${VAR:-default}` fallback, no inline
+        # plaintext: one source of truth, zero masking. The destination
+        # is .gitignored and NEVER persisted past the runner.
+        run: |
+          cp secrets.nonprod.cue .secrets.local.cue
 
       # ------------------------------------------------------------------
       # Gate 1 — go fmt

--- a/.github/workflows/apps-api-ci.yml
+++ b/.github/workflows/apps-api-ci.yml
@@ -240,27 +240,50 @@ jobs:
         run: |
           echo '{}' > encore.app
 
-      - name: secrets SoT drift-check (secrets.go ↔ secrets.nonprod.cue)
-        # Bead unblock-f6z deliverable #4 (+ follow-up: BIDIRECTIONAL).
-        # Assert an EXACT BIJECTION between the fields of `var secrets struct`
-        # in apps/api/auth/secrets.go and the keys of the committed source of
-        # truth, apps/api/secrets.nonprod.cue. Two failure modes, BOTH a hard
-        # FAIL (no soft warnings — an ignorable check would re-open the same
+      - name: secrets SoT drift-check (all apps/api secret structs ↔ secrets.nonprod.cue)
+        # Bead unblock-f6z deliverable #4 (+ follow-ups: BIDIRECTIONAL, then
+        # ALL-PACKAGES). Assert an EXACT BIJECTION between the UNION of the
+        # fields of EVERY `var secrets struct` declared anywhere in apps/api
+        # and the keys of the committed source of truth,
+        # apps/api/secrets.nonprod.cue. Two failure modes, BOTH a hard FAIL
+        # (no soft warnings — an ignorable check would re-open the same
         # false-green gap that crashed the deploy):
-        #   Direction 1 (comm -23): a secrets.go field MISSING from the SoT —
+        #   Direction 1 (comm -23): a declared field MISSING from the SoT —
         #     "added the Go field + boot guard but forgot to provision" (the
         #     failure mode that left GitHubOAuthRedirectURI unprovisioned and
         #     crashed the deploy).
-        #   Direction 2 (comm -13): a SoT key NOT declared in secrets.go —
+        #   Direction 2 (comm -13): a SoT key NOT declared in ANY struct —
         #     a STALE/EXTRA SoT entry (e.g. a placeholder left behind after a
         #     Go secret was removed). This would silently over-provision a
         #     dead secret and rot the SoT.
         #
-        # WHY auth/secrets.go IS THE CANONICAL SET: per SPEC §3.5 and the
-        # secrets.go doc-comment, the auth service is the canonical consumer
-        # and declares the SUPERSET of all secrets. Other packages (e.g.
-        # mcp/transport.go) declare their own SUBSET `var secrets struct`. The
-        # SoT must therefore be an exact bijection with auth/secrets.go.
+        # WHY THE UNION OF ALL PACKAGES, not just auth/secrets.go: SPEC §3.5
+        # treats auth as the canonical consumer that SHOULD declare the
+        # superset, and today it does (mcp/cursor.go, exitcriteriontest/
+        # secrets.go, perftest/secrets.go each declare only the
+        # APIKeyHMACSecret subset). But "auth is the superset" is an
+        # INVARIANT we must ENFORCE, not assume: if a future secret were added
+        # to a non-auth struct ONLY (e.g. an mcp-only secret) and not to auth,
+        # parsing auth alone would make it invisible to BOTH the SoT and this
+        # check — re-opening a narrower version of the masking gap. Discovering
+        # every struct and unioning closes that hole: any secret declared
+        # anywhere in apps/api must have a SoT placeholder, period. NB: the
+        # superset invariant itself (every non-auth field ⊆ auth) is NOT
+        # asserted here — the bijection guarantees union ↔ SoT, which is the
+        # property that actually prevents an unprovisioned secret.
+        #
+        # DISCOVERY (robust, package-agnostic): we do NOT hardcode the four
+        # files known today. We walk every NON-`_test.go` Go file under
+        # apps/api and, per file, awk out the fields inside each
+        # `var secrets struct { … }` block, then sort -u the union. Scoping to
+        # non-`_test.go` files avoids picking up mock/fixture structs from unit
+        # tests; the four real secret structs (auth, mcp, exitcriteriontest,
+        # perftest) all live in plain `.go` files (the *test packages are
+        # Encore test-HELPER packages on the normal build path, not `_test.go`
+        # files), so they are correctly in scope. If a legitimate secret is
+        # ever declared in a `_test.go` file, this check would not see it —
+        # declare Encore secrets in a non-`_test.go` file (the existing
+        # convention) so the boot guards and this gate both apply.
         #
         # BOUNDARY (honest scope): this validates the code ↔ SoT contract
         # ONLY. It does NOT and CANNOT validate the Encore Platform secret
@@ -271,49 +294,56 @@ jobs:
         # Extraction is text-based (no Go build needed, runs before any
         # compile step):
         #   - struct fields: leading PascalCase identifier of each
-        #     `<Field> string` line inside the `var secrets struct { … }`
-        #     block of auth/secrets.go (the canonical superset).
+        #     `<Field> string` line inside any `var secrets struct { … }`
+        #     block, unioned across every discovered file.
         #   - SoT fields: leading identifier of each `<Field>: "…"` line
         #     (comment lines start with `//` and never match).
         run: |
-          go_fields="$(awk '
-            /^var secrets struct \{/ { f=1; next }
-            f && /^\}/             { f=0 }
-            f && /^[[:space:]]+[A-Z][A-Za-z0-9_]*[[:space:]]+string/ { print $1 }
-          ' auth/secrets.go | sort -u)"
+          # Union the fields of every `var secrets struct` across all
+          # non-_test.go Go files under apps/api. -print0/-0 is filename-safe;
+          # awk receives many files and resets its in-block flag per file via
+          # FNR==1 so a struct left "open" at EOF cannot bleed into the next.
+          go_fields="$(find . -type f -name '*.go' ! -name '*_test.go' -print0 \
+            | xargs -0 awk '
+                FNR==1                  { f=0 }
+                /^var secrets struct \{/ { f=1; next }
+                f && /^\}/              { f=0 }
+                f && /^[[:space:]]+[A-Z][A-Za-z0-9_]*[[:space:]]+string/ { print $1 }
+              ' \
+            | sort -u)"
 
           sot_fields="$(grep -oE '^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*:[[:space:]]*"[^"]*"' \
             secrets.nonprod.cue | sed -E 's/[[:space:]]*:.*//' | sort -u)"
 
           if [ -z "${go_fields}" ]; then
-            echo "::error::could not parse any fields from 'var secrets struct' in auth/secrets.go"
+            echo "::error::could not parse any fields from any 'var secrets struct' under apps/api"
             exit 1
           fi
 
           fail=0
 
-          # Direction 1: every Go field MUST be present in the SoT.
+          # Direction 1: every declared field MUST be present in the SoT.
           missing="$(comm -23 <(printf '%s\n' "${go_fields}") <(printf '%s\n' "${sot_fields}"))"
           if [ -n "${missing}" ]; then
-            echo "::error::secrets.go declares fields absent from apps/api/secrets.nonprod.cue:"
+            echo "::error::a 'var secrets struct' under apps/api declares fields absent from apps/api/secrets.nonprod.cue:"
             echo "${missing}"
             echo "Add a placeholder line for each to secrets.nonprod.cue and run scripts/secrets-provision.sh (see apps/api/SECRETS.md)."
             fail=1
           fi
 
-          # Direction 2: every SoT key MUST be declared in secrets.go.
+          # Direction 2: every SoT key MUST be declared in some struct.
           extra="$(comm -13 <(printf '%s\n' "${go_fields}") <(printf '%s\n' "${sot_fields}"))"
           if [ -n "${extra}" ]; then
-            echo "::error::apps/api/secrets.nonprod.cue declares keys absent from 'var secrets struct' in auth/secrets.go:"
+            echo "::error::apps/api/secrets.nonprod.cue declares keys absent from every 'var secrets struct' under apps/api:"
             echo "${extra}"
-            echo "Remove the stale placeholder line(s) from secrets.nonprod.cue, or add the missing field + boot guard to auth/secrets.go (see apps/api/SECRETS.md)."
+            echo "Remove the stale placeholder line(s) from secrets.nonprod.cue, or add the missing field + boot guard to a service's secret struct (see apps/api/SECRETS.md)."
             fail=1
           fi
 
           if [ "${fail}" -ne 0 ]; then
             exit 1
           fi
-          echo "secrets SoT drift-check OK — exact bijection: all $(printf '%s\n' "${go_fields}" | grep -c .) secrets.go field(s) ↔ secrets.nonprod.cue key(s)"
+          echo "secrets SoT drift-check OK — exact bijection: all $(printf '%s\n' "${go_fields}" | grep -c .) declared secret field(s) (unioned across every apps/api secret struct) ↔ secrets.nonprod.cue key(s)"
 
       - name: provision local secrets for encore emulator
         # Bead unblock-f6z: the local emulator needs the five secrets

--- a/apps/api/SECRETS.md
+++ b/apps/api/SECRETS.md
@@ -1,0 +1,151 @@
+# `apps/api` secrets runbook
+
+Owner: Olive (infra). Bead `unblock-f6z`. Cross-references SPEC §3.5
+(`docs/specs/01-spec-backend-mvp.md`).
+
+This is the operational contract for the Encore backend's secrets. It explains
+the one source of truth, the two registries that exist, how they map, and the
+exact procedure to add a secret without recreating the deploy panic that
+motivated this runbook.
+
+---
+
+## The five secrets
+
+Declared once, in `apps/api/auth/secrets.go` (`var secrets struct`). The
+`auth` service is the canonical consumer.
+
+| Spec logical name           | Go field (manifest + CUE key) | Purpose                                                                 | Consumer                |
+|-----------------------------|-------------------------------|-------------------------------------------------------------------------|-------------------------|
+| `MEMORY_DEK`                | `MemoryDEK`                   | pgcrypto symmetric DEK for `*_enc` columns                              | `auth` (P01), all (P02) |
+| `API_KEY_HMAC_SECRET`       | `APIKeyHMACSecret`            | `HMAC-SHA256` for MCP Bearer-key hashing + paginated cursor signing     | `auth`, `mcp`           |
+| `GITHUB_OAUTH_CLIENT_ID`    | `GitHubOAuthClientID`         | OAuth2+PKCE client id                                                    | `auth.ExchangeOAuthCode`|
+| `GITHUB_OAUTH_CLIENT_SECRET`| `GitHubOAuthClientSecret`     | OAuth2+PKCE client secret                                               | `auth.ExchangeOAuthCode`|
+| `GITHUB_OAUTH_REDIRECT_URI` | `GitHubOAuthRedirectURI`      | OAuth2+PKCE registered callback (prevents `redirect_uri_mismatch`)      | `auth.ExchangeOAuthCode`|
+
+Each Go field has a boot-time fail-fast guard (`auth.init()` for the four auth
+secrets, `mcp/transport.go` for `APIKeyHMACSecret`). A missing value surfaces
+as a startup panic at deploy — **never weaken these guards** (bead constraint).
+
+---
+
+## Name mapping: Encore ↔ GitHub ↔ CUE
+
+There are two places a value can live. **Only one of them is a source of
+truth, and the other no longer exists for non-prod.**
+
+| Layer                        | Naming convention                  | Source of truth?                          |
+|------------------------------|------------------------------------|-------------------------------------------|
+| `var secrets struct` field   | Go PascalCase (`GitHubOAuthClientID`) | Defines the contract (what must exist) |
+| `secrets.nonprod.cue` key    | Go PascalCase, verbatim            | ✅ **non-prod SoT** (committed)           |
+| `.secrets.local.cue` key     | Go PascalCase, verbatim            | derived (copy of the SoT; gitignored)     |
+| Encore Platform secret name  | Go PascalCase, verbatim            | ✅ **prod/dev SoT** (human-set, on platform)|
+| GitHub Actions repo secret   | `CI_` + SCREAMING_SNAKE            | ❌ **RETIRED** (bead `unblock-f6z`)        |
+
+The old GitHub `CI_*` registry (`CI_MEMORY_DEK`, etc.) was a second,
+uncoordinated registry with a different naming convention and a
+`${VAR:-default}` CI fallback that **masked** a missing secret — CI stayed
+green while the platform deploy panicked. It is retired. CI now reads non-prod
+values straight from the committed `secrets.nonprod.cue`.
+
+### Boundary (be honest about what is enforced where)
+
+- **CI drift-check** (`apps-api-ci.yml` "secrets SoT drift-check" gate)
+  validates `secrets.go` ↔ `secrets.nonprod.cue` **only**. CI unlinks
+  `encore.app` and has no platform auth, so it **cannot** see the Encore
+  Platform secret matrix.
+- **Platform parity** (prod / dev / local / pr all populated) relies on:
+  1. `scripts/secrets-provision.sh` for the `local` + `pr` placeholders,
+  2. a human setting real `prod` + `dev` values on the platform,
+  3. the deploy-time boot fail-fast as the last line of defence.
+
+There is no automated check that the platform matrix is complete. The
+fail-fast at deploy is the safety net; this runbook is the procedure.
+
+---
+
+## Source of truth: `secrets.nonprod.cue`
+
+`apps/api/secrets.nonprod.cue` holds the **non-production placeholder values**
+for every declared secret. These are deterministic, public, fake values
+(`nonprod-…-placeholder`) — safe to commit and safe to print in logs. They are
+valid CUE in the exact shape Encore expects, so they are consumed without any
+translation:
+
+- **Local dev**: `cp secrets.nonprod.cue .secrets.local.cue` (or run the
+  provisioning script — see below). `.secrets.local.cue` is gitignored.
+- **CI**: `apps-api-ci.yml` copies the SoT to `.secrets.local.cue` before
+  `encore test`.
+- **Platform `local` + `pr`**: `scripts/secrets-provision.sh` pipes each value
+  into `encore secret set --type local,pr <Field>`.
+
+**Real prod/dev values are NEVER committed.** They are set by a human on the
+Encore Platform only.
+
+---
+
+## Provisioning script
+
+`apps/api/scripts/secrets-provision.sh`:
+
+```bash
+./scripts/secrets-provision.sh
+```
+
+- Reads `secrets.nonprod.cue`, runs `encore secret set --type local,pr <Field>`
+  for each entry (value piped via stdin).
+- **Idempotent** — `encore secret set` overwrites, so re-running converges to
+  the SoT.
+- **Never touches `prod` or `dev`** — those carry real credentials.
+- Requires the `encore` CLI authenticated (`encore auth login`) and the
+  workspace linked (committed `apps/api/encore.app`).
+
+---
+
+## Procedure: add a new secret
+
+Do all of these in one change so a Go guard never ships ahead of its value:
+
+1. **Code**: add the field to `var secrets struct` in `apps/api/auth/secrets.go`
+   and add a boot fail-fast guard in `auth.init()` (or the relevant service).
+2. **SoT**: add a matching `FieldName: "nonprod-…-placeholder"` line to
+   `apps/api/secrets.nonprod.cue`. (The CI drift-check fails the PR if you
+   skip this.)
+3. **Spec**: extend the SPEC §3.5 mapping table if the secret is contract-level.
+4. **Local/pr platform**: run `./scripts/secrets-provision.sh`.
+5. **prod/dev platform** (human, real value):
+   ```bash
+   encore secret set --type prod,dev <FieldName>
+   # enter the real value at the prompt
+   ```
+6. **Update this runbook's five-secrets table.**
+
+The CI drift-check guarantees step 2 cannot be forgotten silently; steps 4–5
+are the platform side it cannot see — the deploy-time panic is the backstop.
+
+---
+
+## Orphan GitHub repo-secret cleanup (handoff to Miguel)
+
+The retired `CI_*` registry plus a stale test token must be deleted from the
+GitHub repo secrets. **Run these AFTER the workflow change in this bead has
+merged to `main`** (so no in-flight run references them). Miguel executes —
+the implementing agent does NOT run these.
+
+Repo: `websublime/unblock`.
+
+```bash
+gh secret delete CI_MEMORY_DEK              --repo websublime/unblock
+gh secret delete CI_API_KEY_HMAC_SECRET     --repo websublime/unblock
+gh secret delete CI_GITHUB_OAUTH_CLIENT_ID  --repo websublime/unblock
+gh secret delete CI_GITHUB_OAUTH_CLIENT_SECRET --repo websublime/unblock
+gh secret delete UNBLOCK_TEST_TOKEN         --repo websublime/unblock
+```
+
+Notes:
+- `CI_GITHUB_OAUTH_REDIRECT_URI` was never created, so there is nothing to
+  delete for it.
+- `UNBLOCK_TEST_TOKEN` has zero references anywhere in the repo (verified via
+  grep) — stale.
+- After deletion, `gh secret list --repo websublime/unblock` should show no
+  `CI_*` entries and no `UNBLOCK_TEST_TOKEN`.

--- a/apps/api/SECRETS.md
+++ b/apps/api/SECRETS.md
@@ -51,19 +51,27 @@ values straight from the committed `secrets.nonprod.cue`.
 ### Boundary (be honest about what is enforced where)
 
 - **CI drift-check** (`apps-api-ci.yml` "secrets SoT drift-check" gate)
-  validates `secrets.go` ↔ `secrets.nonprod.cue` **only**. CI unlinks
-  `encore.app` and has no platform auth, so it **cannot** see the Encore
-  Platform secret matrix. The check is **bidirectional** — it enforces an
-  exact bijection and hard-FAILs on either drift direction:
-  - a `secrets.go` field missing from the SoT (forgot to provision), and
-  - a SoT key not declared in `secrets.go` (a stale/extra placeholder left
+  validates the Go secret structs ↔ `secrets.nonprod.cue` **only**. CI
+  unlinks `encore.app` and has no platform auth, so it **cannot** see the
+  Encore Platform secret matrix. The check is **bidirectional** — it enforces
+  an exact bijection and hard-FAILs on either drift direction:
+  - a declared struct field missing from the SoT (forgot to provision), and
+  - a SoT key not declared in any struct (a stale/extra placeholder left
     behind after a Go secret was removed).
 
-  `auth/secrets.go` is the canonical set: per SPEC §3.5 the auth service
-  declares the **superset** of every secret, while other packages (e.g.
-  `mcp/transport.go`) declare a subset. Both directions are a hard failure,
-  never a warning — an ignorable check would re-open the same false-green gap
-  that crashed the deploy.
+  The check scans **every `var secrets struct` in every (non-`_test.go`)
+  package under `apps/api`** — today `auth/secrets.go`, `mcp/cursor.go`,
+  `exitcriteriontest/secrets.go`, and `perftest/secrets.go` — discovering
+  them dynamically (no hardcoded file list) and **unioning** their field
+  names before comparing against the SoT. Per SPEC §3.5 the `auth` service is
+  the canonical consumer and *should* declare the superset (the other three
+  declare only the `APIKeyHMACSecret` subset today), but the check does not
+  rely on that: it unions all packages so that a secret added to a non-`auth`
+  struct **only** still must have a SoT placeholder. That closes the gap where
+  a future non-`auth`-only secret would otherwise be invisible to both the SoT
+  and the check. Both directions are a hard failure, never a warning — an
+  ignorable check would re-open the same false-green gap that crashed the
+  deploy.
 - **Platform parity** (prod / dev / local / pr all populated) relies on:
   1. `scripts/secrets-provision.sh` for the `local` + `pr` placeholders,
   2. a human setting real `prod` + `dev` values on the platform,

--- a/apps/api/SECRETS.md
+++ b/apps/api/SECRETS.md
@@ -53,7 +53,17 @@ values straight from the committed `secrets.nonprod.cue`.
 - **CI drift-check** (`apps-api-ci.yml` "secrets SoT drift-check" gate)
   validates `secrets.go` ↔ `secrets.nonprod.cue` **only**. CI unlinks
   `encore.app` and has no platform auth, so it **cannot** see the Encore
-  Platform secret matrix.
+  Platform secret matrix. The check is **bidirectional** — it enforces an
+  exact bijection and hard-FAILs on either drift direction:
+  - a `secrets.go` field missing from the SoT (forgot to provision), and
+  - a SoT key not declared in `secrets.go` (a stale/extra placeholder left
+    behind after a Go secret was removed).
+
+  `auth/secrets.go` is the canonical set: per SPEC §3.5 the auth service
+  declares the **superset** of every secret, while other packages (e.g.
+  `mcp/transport.go`) declare a subset. Both directions are a hard failure,
+  never a warning — an ignorable check would re-open the same false-green gap
+  that crashed the deploy.
 - **Platform parity** (prod / dev / local / pr all populated) relies on:
   1. `scripts/secrets-provision.sh` for the `local` + `pr` placeholders,
   2. a human setting real `prod` + `dev` values on the platform,

--- a/apps/api/auth/secrets.go
+++ b/apps/api/auth/secrets.go
@@ -17,6 +17,15 @@ package auth
 //	GITHUB_OAUTH_CLIENT_SECRET ↔ GitHubOAuthClientSecret
 //	GITHUB_OAUTH_REDIRECT_URI  ↔ GitHubOAuthRedirectURI
 //
+// SOURCE OF TRUTH (bead unblock-f6z): the NON-PRODUCTION placeholder
+// values for every field below live ONCE at apps/api/secrets.nonprod.cue
+// (committed). CI copies it to .secrets.local.cue; apps/api/scripts/
+// secrets-provision.sh pushes it to the platform `local`+`pr` env types.
+// Real prod/dev values are human-set on the Encore Platform and NEVER
+// committed. A CI drift-check (apps-api-ci.yml) fails the build if any
+// field here is absent from secrets.nonprod.cue. Full runbook + the
+// Encore↔GitHub name mapping: apps/api/SECRETS.md. See SPEC §3.5.
+//
 // Provisioning policy across Encore Cloud env types (per tv8.56):
 //
 //	--type prod   — real production values (Olive seeds before prod deploy).

--- a/apps/api/scripts/secrets-provision.sh
+++ b/apps/api/scripts/secrets-provision.sh
@@ -72,7 +72,7 @@ while IFS= read -r line; do
   if [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*:[[:space:]]*\"(.*)\"[[:space:]]*$ ]]; then
     field="${BASH_REMATCH[1]}"
     value="${BASH_REMATCH[2]}"
-    echo "→ encore secret set --type ${types} ${field}"
+    echo "-> encore secret set --type ${types} ${field}"
     # printf (no trailing newline) — encore strips trailing newlines anyway,
     # but this keeps the piped value byte-exact with the SoT.
     printf '%s' "${value}" | encore secret set --type "${types}" "${field}"
@@ -85,5 +85,5 @@ if [[ "${count}" -eq 0 ]]; then
   exit 1
 fi
 
-echo "✓ provisioned ${count} non-prod secret(s) for types: ${types}"
+echo "[ok] provisioned ${count} non-prod secret(s) for types: ${types}"
 echo "  (prod/dev untouched — set those on the Encore Platform manually)"

--- a/apps/api/scripts/secrets-provision.sh
+++ b/apps/api/scripts/secrets-provision.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# secrets-provision.sh — provision the NON-PRODUCTION Encore Platform secrets
+# for the `local` and `pr` (preview) environment types from the single
+# committed source of truth, apps/api/secrets.nonprod.cue.
+#
+# Bead unblock-f6z. See apps/api/SECRETS.md for the full runbook.
+#
+# WHAT THIS DOES
+# -------------------------------------------------------------------------
+# Reads every `<GoField>: "<value>"` line from secrets.nonprod.cue and runs
+#   encore secret set --type local,pr <GoField>
+# piping the placeholder value via stdin. This makes the Encore Platform's
+# local + pr secret matrix match the committed SoT in one idempotent command,
+# so a preview-environment deploy boots without tripping the auth.init() /
+# mcp/transport.go fail-fast guards.
+#
+# WHAT THIS DOES NOT DO (by design)
+# -------------------------------------------------------------------------
+#   - Does NOT touch `--type prod` or `--type dev`. Those carry REAL
+#     credentials and are set by a human on the Encore Platform ONLY. This
+#     script would clobber them with placeholders — so it refuses to.
+#   - Does NOT write apps/api/.secrets.local.cue. For local emulator runs,
+#     copy the SoT instead:  cp secrets.nonprod.cue .secrets.local.cue
+#     (the CI workflow does exactly this). `encore secret set --type local`
+#     populates the PLATFORM local env type, which is separate from the
+#     on-disk .secrets.local.cue override the local emulator reads.
+#
+# IDEMPOTENCY
+# -------------------------------------------------------------------------
+# `encore secret set` overwrites the existing value for the named types, so
+# re-running this script converges to the SoT every time with no side effects
+# beyond setting the same placeholder values again.
+#
+# PREREQUISITES
+# -------------------------------------------------------------------------
+#   - `encore` CLI on PATH, authenticated (`encore auth login`), and the
+#     workspace linked to the cloud app (committed apps/api/encore.app).
+#   - Run from anywhere — the script resolves paths relative to its own
+#     location (apps/api/scripts/), so the encore commands run in apps/api/.
+
+set -euo pipefail
+
+# Resolve apps/api/ (the encore app root) from this script's location,
+# independent of the caller's cwd.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+api_dir="$(cd "${script_dir}/.." && pwd)"
+sot_file="${api_dir}/secrets.nonprod.cue"
+
+if [[ ! -f "${sot_file}" ]]; then
+  echo "error: source of truth not found at ${sot_file}" >&2
+  exit 1
+fi
+
+if ! command -v encore >/dev/null 2>&1; then
+  echo "error: 'encore' CLI not found on PATH — install it and run 'encore auth login' first" >&2
+  exit 1
+fi
+
+cd "${api_dir}"
+
+# Non-prod types ONLY. prod/dev are human-set on the platform and MUST NOT
+# be clobbered with placeholders.
+types="local,pr"
+
+count=0
+# Match CUE lines of the form:  FieldName: "value"
+# - field: a leading identifier (Go PascalCase, matches the secrets struct).
+# - value: everything inside the first pair of double quotes.
+# Comment lines (starting with //) never match because they don't begin with
+# an identifier immediately followed by a colon at column 0.
+while IFS= read -r line; do
+  if [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*:[[:space:]]*\"(.*)\"[[:space:]]*$ ]]; then
+    field="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    echo "→ encore secret set --type ${types} ${field}"
+    # printf (no trailing newline) — encore strips trailing newlines anyway,
+    # but this keeps the piped value byte-exact with the SoT.
+    printf '%s' "${value}" | encore secret set --type "${types}" "${field}"
+    count=$((count + 1))
+  fi
+done < "${sot_file}"
+
+if [[ "${count}" -eq 0 ]]; then
+  echo "error: no secret fields parsed from ${sot_file} — check its format" >&2
+  exit 1
+fi
+
+echo "✓ provisioned ${count} non-prod secret(s) for types: ${types}"
+echo "  (prod/dev untouched — set those on the Encore Platform manually)"

--- a/apps/api/secrets.nonprod.cue
+++ b/apps/api/secrets.nonprod.cue
@@ -1,0 +1,66 @@
+// secrets.nonprod.cue — the single committed SOURCE OF TRUTH for the
+// non-production values of every Encore secret declared in
+// apps/api/auth/secrets.go (`var secrets struct`).
+//
+// WHY THIS FILE EXISTS (bead unblock-f6z, reverses tv8.67)
+// -------------------------------------------------------------------------
+// Secrets used to live in two uncoordinated registries with divergent
+// naming and no drift enforcement:
+//   1. Encore Platform secrets (Go-identifier names, e.g. GitHubOAuthRedirectURI),
+//      set via `encore secret set`.
+//   2. GitHub Actions repo secrets (CI_ prefix + SCREAMING_SNAKE, e.g.
+//      CI_GITHUB_OAUTH_REDIRECT_URI), consumed by apps-api-ci.yml which
+//      fabricated .secrets.local.cue at CI time with a `${VAR:-default}`
+//      fallback that MASKED a missing GitHub secret (CI stayed green while
+//      the platform fail-fast only surfaced at deploy). The 5th secret
+//      (GitHubOAuthRedirectURI) was added to code + spec + local but never
+//      provisioned on the platform OR in GitHub — the mask hid it until a
+//      deploy panicked (`auth: GitHubOAuthRedirectURI is empty`,
+//      apps/api/auth/secrets.go:138).
+//
+// DECISION (orchestrator + Miguel, 2026-06-03 — OPTION A): non-prod
+// placeholders are NOT real secrets — they are fake, well-shaped values the
+// local emulator and CI need only to be non-empty. Commit them here as ONE
+// source of truth and retire the split GitHub CI_* registry. Real prod/dev
+// values stay human-set on the Encore Platform ONLY and are NEVER committed.
+//
+// THESE ARE NOT SECRETS
+// -------------------------------------------------------------------------
+// Every value below is a deterministic, public placeholder (the literal
+// string "of-zeroes" / "placeholder" appears in each). They are safe to
+// commit, safe to print in CI logs, and identical for every developer and
+// every CI run. Provisioning real credentials is a separate, human-only
+// step on the Encore Platform (see apps/api/SECRETS.md).
+//
+// FORMAT
+// -------------------------------------------------------------------------
+// This file is valid CUE in the exact shape Encore expects for
+// apps/api/.secrets.local.cue (top-level `<GoFieldName>: "<value>"`), so the
+// CI workflow and the local provisioning script consume it WITHOUT any
+// translation layer:
+//   - Local dev: copy this file to apps/api/.secrets.local.cue
+//     (or run apps/api/scripts/secrets-provision.sh).
+//   - CI (apps-api-ci.yml): copies this file to apps/api/.secrets.local.cue
+//     before `encore test`.
+//   - Platform local/pr env types: apps/api/scripts/secrets-provision.sh
+//     pipes each value into `encore secret set --type local,pr <Field>`.
+//
+// FIELD NAMES ARE THE CONTRACT
+// -------------------------------------------------------------------------
+// Each key below MUST match a field of `var secrets struct` in
+// apps/api/auth/secrets.go verbatim (Go PascalCase). The CI drift-check
+// (apps-api-ci.yml "secrets SoT drift-check" gate) FAILS the build if any
+// secrets.go field is missing here — that catches "added the Go guard but
+// forgot to provision" at PR time. See SPEC §3.5 for the
+// logical-name ↔ Go-field mapping.
+//
+// ADD A SECRET: add the Go field + init guard in auth/secrets.go, then add a
+// matching placeholder line here, then run secrets-provision.sh for local/pr.
+// A human sets the real prod/dev value on the Encore Platform. Full
+// procedure in apps/api/SECRETS.md.
+
+MemoryDEK:               "nonprod-memory-dek-32-bytes-of-zeroes-placeholder"
+APIKeyHMACSecret:        "nonprod-api-key-hmac-secret-32-bytes-of-zeroes-x"
+GitHubOAuthClientID:     "nonprod-github-oauth-client-id-placeholder"
+GitHubOAuthClientSecret: "nonprod-github-oauth-client-secret-placeholder"
+GitHubOAuthRedirectURI:  "http://localhost:4321/auth/callback"

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -265,6 +265,17 @@ reads from a **CUE** file at `apps/api/.secrets.local.cue` (Encore app
 root, next to `encore.app`), per Encore official docs
 (https://encore.dev/docs/go/primitives/secrets).
 
+> **Coherence (bead `unblock-f6z`).** The non-production placeholder
+> values for these secrets live in a single committed source of truth,
+> `apps/api/secrets.nonprod.cue`, with the Go field names below as keys.
+> CI (`apps-api-ci.yml`) copies it to `.secrets.local.cue` and a
+> drift-check gate fails the build if any `secrets.go` field is missing
+> from it; `apps/api/scripts/secrets-provision.sh` pushes it to the
+> platform `local`+`pr` env types. Real `prod`/`dev` values stay human-set
+> on the Encore Platform and are NEVER committed. The split GitHub `CI_*`
+> repo-secret registry is retired. Full runbook + the Encore↔GitHub name
+> mapping: `apps/api/SECRETS.md`.
+
 > **DRIFT-1 — naming.** The five secret identifiers below
 > (`MEMORY_DEK`, `API_KEY_HMAC_SECRET`, `GITHUB_OAUTH_CLIENT_ID`,
 > `GITHUB_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_REDIRECT_URI`) are **spec-level logical names**, not


### PR DESCRIPTION
## unblock-f6z: Secrets provisioning coherence

Root-cause fix for the Encore Platform deploy panic (`auth: GitHubOAuthRedirectURI is empty`, apps/api/auth/secrets.go:138). Secrets lived in two uncoordinated registries (Encore Go-identifier names vs GitHub `CI_` SCREAMING_SNAKE) with a CI `${VAR:-default}` fallback that masked a missing value into a green build while the platform fail-fast only surfaced at deploy.

### What was done
- **secrets.nonprod.cue** — single committed source of truth with non-prod placeholders for all 5 declared secrets (valid CUE in Encore's `.secrets.local.cue` shape).
- **scripts/secrets-provision.sh** — idempotent provisioning of the platform `local`+`pr` env types from the SoT; never touches prod/dev.
- **apps-api-ci.yml** — provision step now copies the SoT to `.secrets.local.cue`; removed the `CI_*` env block and `:-default` fallbacks; added a `secrets.go` ↔ SoT **drift-check gate**.
- **SECRETS.md** — runbook: 5 secrets, Encore↔GitHub name mapping, add-a-secret procedure, CI-vs-platform boundary, and the `gh secret delete` handoff.
- secrets.go + SPEC §3.5 cross-reference the SoT/script/runbook.

Reverses tv8.67 per the pre-decided Option A. Boot fail-fast guards unchanged.

### Files changed
apps/api/secrets.nonprod.cue (new), apps/api/scripts/secrets-provision.sh (new), apps/api/SECRETS.md (new), .github/workflows/apps-api-ci.yml, apps/api/auth/secrets.go, docs/specs/01-spec-backend-mvp.md

### Decisions / Deviations
None — implemented as scoped (Option A pre-decided).

### Follow-up (handoff to Miguel, AFTER merge)
`gh secret delete` for the 5 orphan repo secrets (4× CI_* + UNBLOCK_TEST_TOKEN) — exact commands in apps/api/SECRETS.md.