### PR TITLE
docs(spec): round-16 — P01 MCP tool surface 14→23 (promote + milestone + label tools)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -115,11 +115,11 @@ Human engineers who interact with the system through the web UI for ceremony tas
 - **FR-5.** Dependency graph stored as edges in `deps`; computed views for ready set, dependency closure, cycle detection. Recomputation on every mutation.
 - **FR-6.** Cascade on close: a successful close emits a Pub/Sub event whose subscriber promotes newly unblocked dependents to `ready` in the same logical operation.
 - **FR-7.** Atomic claim: `SELECT FOR UPDATE` transaction; exactly one agent wins; loser receives structured rejection.
-- **FR-8.** MCP server over **Streamable HTTP** per the MCP 2025-06-18 spec — single endpoint at `/mcp` accepting both `POST /mcp` (client requests; response can be a single JSON-RPC reply or an SSE stream of incremental responses for long-running tools) and `GET /mcp` (server-initiated SSE stream for resumable / long-lived sessions). Bearer `<api-key>` auth on every request, `Mcp-Session-Id` response header on `initialize`. Implementation uses `github.com/modelcontextprotocol/go-sdk` (the canonical Go SDK; not `rmcp` which is Rust-only). Exposing 18 tools at v1.0:
-  - 14 in P01 (work-item CRUD, dependencies, ready, claim, close, comment trail, prime, etc.)
+- **FR-8.** MCP server over **Streamable HTTP** per the MCP 2025-06-18 spec — single endpoint at `/mcp` accepting both `POST /mcp` (client requests; response can be a single JSON-RPC reply or an SSE stream of incremental responses for long-running tools) and `GET /mcp` (server-initiated SSE stream for resumable / long-lived sessions). Bearer `<api-key>` auth on every request, `Mcp-Session-Id` response header on `initialize`. Implementation uses `github.com/modelcontextprotocol/go-sdk` (the canonical Go SDK; not `rmcp` which is Rust-only). Exposing 27 tools at v1.0 (reconciled from the original "18 tools" figure by the P01 round-16 amendment — see `docs/specs/01-spec-backend-mvp.md` round-16 changelog):
+  - 23 in P01 (work-item CRUD, dependencies, ready, claim, **promote**, close, comment trail, prime, state accessors, the four **milestone** management tools, and the four **label-registry** tools)
   - +4 memory tools in P02 (`remember`, `recall`, `memories`, `forget`)
   - Plus the providers/sync tooling needed for bidirectional GitHub sync.
-  Exact tool inventory is pinned by the architect in `docs/SPEC.md`.
+  Exact tool inventory is pinned by the architect in `docs/SPEC.md` §5.2.2. (P01 round-16 raised P01 from 14→23 and v1.0 from 18→27: `promote` + 4 milestone tools + 4 label tools moved into P01 / were newly added.)
 - **FR-9.** State-transition validation at the MCP layer: every status change is checked against the pipeline state machine; invalid transitions are rejected with a structured error citing the missing precondition (Law 8, layer 1).
 - **FR-10.** Comment trail with **two orthogonal axes**, designed so agents can act on signal without parsing free-form text (Manifesto Principle 6):
   - **`kind`** — semantic category. Eleven values: `investigation`, `decision`, `deviation`, `completed`, `review`, `qa`, `deferred`, `pr`, `needs-human`, `override`, `general`.
@@ -179,7 +179,7 @@ The AST CLI carries forward verbatim from the approved `docs/code-cli/{plan,spec
 | FR-5 (dependency graph + cycle detection) | H | H | H | Must-have |
 | FR-6 (cascade on close) | H | H | M | Must-have |
 | FR-7 (atomic claim) | H | H | L | Must-have |
-| FR-8 (MCP Streamable HTTP, 18 tools) | H | H | H | Must-have |
+| FR-8 (MCP Streamable HTTP, 27 tools — P01 round-16; was 18) | H | H | H | Must-have |
 | FR-9 (state-transition validation, layer 1) | H | H | M | Must-have |
 | FR-11 (GitHub webhooks + bidirectional sync) | H | M | H | Must-have |
 | FR-13 (memory service) | H | M | M | Performance |
@@ -549,14 +549,14 @@ The project ships in four sequential phases plus a renderer phase. The AST CLI s
 
 - Encore Go on a single Postgres (8 schemas).
 - Services: `auth`, `org`, `workitems`, `deps`, `memory`.
-- Minimal MCP server with **14 tools** over Streamable HTTP (per FR-8).
+- MCP server with **23 tools** over Streamable HTTP (per FR-8; P01 round-16 raised this from 14 — adds `promote`, the four milestone tools, and the four label-registry tools).
 - Public Encore endpoints: `POST /webhooks/github`, `POST /mcp` + `GET /mcp` (single logical MCP endpoint, Streamable HTTP per FR-12). OAuth callback is on Astro origin per FR-12.
 - Exit criterion: an agent can authenticate via Bearer API key and complete `prime → ready → claim → close` against a manually-seeded graph; cascade fires; cycle detection rejects offending edges.
 
 ### P02 — Backend complete
 
 - `providers` service: GitHub webhook ingestion + bidirectional sync.
-- Remaining MCP tools, totalling **18 tools** at end of P02 (including the 4 memory tools).
+- Remaining MCP tools, totalling **27 tools** at end of P02 (the 23 P01 tools + the 4 memory tools; figure reconciled from the original 18 by the P01 round-16 amendment).
 - Pipeline enforcement layer 1: MCP state-transition validation per Manifesto Law 8.
 - Exit criterion: a GitHub repository can be linked, webhooks normalise events into canonical work items, and an attempt to mark a work item `done` without the required comment trail is rejected at the MCP boundary.
 
@@ -707,8 +707,8 @@ None at PRD time. All eight discovery questions are resolved in §1–§12 and t
 
 | Phase | Deliverable | Ships at | Carries forward verbatim from |
 |---|---|---|---|
-| P01 | Backend MVP (Encore Go + Postgres + 14 MCP tools) | v1.0 | New work, `docs/SPEC.md` (architect) |
-| P02 | Backend complete (providers + 18 MCP tools + Layer 1 enforcement) | v1.0 | New work, `docs/SPEC.md` (architect) |
+| P01 | Backend MVP (Encore Go + Postgres + 23 MCP tools — P01 round-16; was 14) | v1.0 | New work, `docs/SPEC.md` (architect) |
+| P02 | Backend complete (providers + 27 MCP tools total + Layer 1 enforcement) | v1.0 | New work, `docs/SPEC.md` (architect) |
 | P03 | AST CLI v1.0.0 | v1.0 | `docs/code-cli/{plan,spec,research}.md` |
 | P04 | mister-anderson plugin renderer (Layer 2 + 3) | v1.0 | New work, `docs/SPEC.md` (architect) |
 | P05 | Astro web (kanban + graph + roadmap + comments) | **v1.1** (line-ui-blocked) | New work, `docs/SPEC.md` (architect) |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -6,6 +6,7 @@
 **Changelog:**
 - 2026-05-08 — §9.4.10 corrected the local-secrets file path/format from `.encore/local-secrets.toml` (TOML) to `apps/api/.secrets.local.cue` (CUE) per Encore official docs; added parallel mapping note (`MEMORY_DEK` → Go field `MemoryDEK`) referencing P01 spec §3.5 for the full mapping table.
 - 2026-05-12 — §9.4.4 `deps.cascade_events.kind` CHECK enum extended to four first-class values (`'close'`, `'edge_added'`, `'edge_removed'`, `'state_change'`); the round-2 framing of two kinds with a "future" `state_change` was retired. The four kinds are P01-active and partition the cascade write path into two propagation regimes (Regime A: writer-inline `is_ready` writes by Tool 12; Regime B: subscriber-only `pipeline_stage` writes plus subscriber-driven `is_ready` writes for `close` / `edge_added` / `state_change`). Canonical model lives in phase spec [§6.3.0 "Propagation regimes"](./specs/01-spec-backend-mvp.md); this document records *what exists* at architectural level, the phase spec records *how it is implemented*. Status flipped to DRAFT pending re-approval.
+- 2026-06-04 — §5.2.2 + §1 + §6.2 contracts table + §3.x repo-tree + §11 traceability: the v1.0 MCP tool inventory is reconciled from **18 → 27** in lockstep with the **P01 round-16 amendment** (`docs/specs/01-spec-backend-mvp.md`, beads `unblock-tv8.71` / `.74` / `.75`). P01 grows from 14 → 23 (adds `promote`, four milestone tools, four label tools); v1.0 grows to 27 (23 P01 + 4 memory at P02). Provenance: this edit exists solely to keep the Stage-1 architecture inventory identical to the P01 phase spec — no architectural decision changed, only the tool count and names. The P01-round-16 `0110_mcp_issued_to_user_notnull` migration is noted in the §11 P01 row.
 **Source PRD:** [docs/PRD.md](./PRD.md) (APPROVED, 2026-05-07)
 **Companion:** [docs/MANIFESTO.md](./MANIFESTO.md) (APPROVED, 2026-05-07)
 **Carries forward verbatim:** [docs/code-cli/plan.md](./code-cli/plan.md), [docs/code-cli/spec.md](./code-cli/spec.md), [docs/code-cli/research.md](./code-cli/research.md)
@@ -100,9 +101,11 @@ from the Manifesto, the PRD, or the locked code-cli artefacts.
 
 - Single Postgres database with **8 schemas**: `auth`, `org`, `workitems`,
   `deps`, `providers`, `mcp`, `boards`, `memory` (FR-1).
-- **18 MCP tools** at v1.0 over **Streamable HTTP** (per MCP spec 2025-06-18)
-  with `Bearer <api-key>` auth (FR-8). 14 ship in P01, +4 memory tools in
-  P02, plus the providers/sync tooling required for FR-11.
+- **27 MCP tools** at v1.0 over **Streamable HTTP** (per MCP spec 2025-06-18)
+  with `Bearer <api-key>` auth (FR-8; raised from 18 by the P01 round-16
+  amendment). 23 ship in P01 (incl. `promote`, four milestone tools, four
+  label tools), +4 memory tools in P02, plus the providers/sync tooling
+  required for FR-11.
 - **Two public Encore endpoints at v1.0** (`POST /webhooks/github`,
   `POST /mcp` + `GET /mcp` — the latter pair is **one logical endpoint at
   one path** per the Streamable HTTP convention) and **+1 at v1.1**
@@ -213,7 +216,7 @@ runtime coupling is permitted (Manifesto Law 6).
 
 | Contract | Producer | Consumer | Surface |
 |---|---|---|---|
-| **MCP wire protocol** (`modelcontextprotocol/go-sdk`, JSON-RPC over Streamable HTTP) | Encore backend | AI agents | Bearer auth, 18 tools at v1.0; transport per MCP 2025-06-18 spec — see §5.3 |
+| **MCP wire protocol** (`modelcontextprotocol/go-sdk`, JSON-RPC over Streamable HTTP) | Encore backend | AI agents | Bearer auth, 27 tools at v1.0 (P01 round-16; was 18); transport per MCP 2025-06-18 spec — see §5.3 |
 | **Astro Actions ↔ Encore RPC** (private API) | Encore backend (private services) | Astro Actions BFF | Encore-generated TypeScript clients; not reachable from the browser; auth via forwarded session id (`Authorization: Bearer <session_id>` + `X-Unblock-BFF-Origin: astro`) per §5.3.1 |
 | **GitHub webhook payload** | GitHub | Encore backend `providers` service | `POST /webhooks/github`, signature-verified |
 | **OAuth callback (Astro origin)** | GitHub / GitLab | Astro Action `auth/[provider]/callback` → private RPC `auth.exchangeOAuthCode` | Browser redirect target on `unblock.websublime.com`; PKCE-validated; HttpOnly cookie set on Astro origin |
@@ -244,7 +247,7 @@ unblock/
 │   │   ├── workitems/              # work items, comments, labels, milestones
 │   │   ├── deps/                   # dependency graph engine, ready/cycle/cascade
 │   │   ├── providers/              # GitHub webhook ingestion + bidirectional sync
-│   │   ├── mcp/                    # MCP server (SSE transport, 18 tools)
+│   │   ├── mcp/                    # MCP server (Streamable HTTP transport, 27 tools at v1.0 — 23 in P01 per round-16)
 │   │   │   └── catalogue.json      # canonical state-machine + tool catalogue export
 │   │   ├── boards/                 # kanban / saved-view persistence
 │   │   ├── memory/                 # scoped memory service (4 MCP tools)
@@ -437,18 +440,27 @@ The user reviewed and locked this 8:8 decomposition. Isolation > RPC overhead:
   stop the rest of the product. A separate service isolates webhook-handler
   failures and reconciliation jobs from the hot path.
 
-#### 5.2.2 18-tool MCP inventory at v1.0 (CONFIRMED)
+#### 5.2.2 27-tool MCP inventory at v1.0 (CONFIRMED — P01 round-16 reconciliation)
 
-PRD FR-8 promises 18 tools at v1.0. The inventory below pins names and
-one-line descriptions. P01 ships **14**, P02 adds the **4** memory tools.
+> **P01 round-16 reconciliation (2026-06-04).** The original "18-tool"
+> inventory was raised to **27** by the P01 round-16 amendment
+> (`docs/specs/01-spec-backend-mvp.md` round-16 changelog, beads
+> `unblock-tv8.71` / `.74` / `.75`): P01 grows from **14 → 23** by adding
+> `promote`, the four milestone management tools, and the four
+> label-registry tools; v1.0 grows from 18 → **27** (23 P01 + 4 memory at
+> P02). The inventory below is updated to match.
+
+PRD FR-8 promises 27 tools at v1.0. The inventory below pins names and
+one-line descriptions. P01 ships **23**, P02 adds the **4** memory tools.
 The state-machine accessors (`set_state`, `get_state`, `verify_can_transition`)
 and `meta_catalogue` are **operational primitives** that count as part of
-the 18 — they are first-class agent-facing tools, not internal helpers.
+the inventory — they are first-class agent-facing tools, not internal helpers.
 Reconciliation note: PRD FR-8 lists the categories ("work-item CRUD,
-dependencies, ready, claim, close, comment trail, prime, etc.") and PRD §8
-P02 says "+4 memory tools = 18 total". This list reconciles the two.
+dependencies, ready, claim, close, comment trail, prime, etc.") plus the
+round-16 additions; PRD §8 P02 says "+4 memory tools = 27 total". This list
+reconciles the two.
 
-##### P01 — 14 tools (work item core, graph, claim, comments, state, prime)
+##### P01 — 23 tools (work item core, graph, claim, promote, comments, state, prime, milestones, labels)
 
 | # | Tool | One-liner |
 |---|---|---|
@@ -466,32 +478,42 @@ P02 says "+4 memory tools = 18 total". This list reconciles the two.
 | 12 | `remove_dependency` | Remove an edge; fires cascade subscriber (the "to" side may flip to ready) |
 | 13 | `set_state` | Mutate one or more of `impl_state`, `review_state`, `qa_state`, `pipeline_state` — **gated by Layer-1 BLOCK conditions** (§7.5) |
 | 14 | `get_state` | Return the four state columns + the derived `pipeline_stage` + the most recent `(kind, status)` per the comment trail |
+| 15 | `promote` | (P01 round-16, bead `unblock-tv8.71`) Transition a Backlog item to Ready; precondition `status='Backlog' AND is_ready=true`. The canonical Ready writer (closes round-12 DRIFT-2) |
+| 16 | `create_milestone` | (P01 round-16, bead `unblock-tv8.74`) Create a milestone (org- or project-scoped); facade over `workitems.CreateMilestone` |
+| 17 | `update_milestone` | (P01 round-16, bead `unblock-tv8.74`) Update a milestone's name/description/dates/cancellation; reparenting rejected in P01 |
+| 18 | `assign_item` | (P01 round-16, bead `unblock-tv8.74`) Assign an item to a milestone (or unassign via empty `milestone_id`); enforces M-INV-7 |
+| 19 | `milestone_tree` | (P01 round-16, bead `unblock-tv8.74`) Return the recursive milestone tree (depth bound M-INV-6 = 4) |
+| 20 | `create_label` | (P01 round-16, bead `unblock-tv8.75`) Create a user-facing label (org- or project-scoped) over `workitems.labels` |
+| 21 | `list_labels` | (P01 round-16, bead `unblock-tv8.75`) List labels in scope (project labels + inherited org labels; project wins on name) |
+| 22 | `update_label` | (P01 round-16, bead `unblock-tv8.75`) Rename and/or recolor an existing label (scope immutable) |
+| 23 | `delete_label` | (P01 round-16, bead `unblock-tv8.75`) Delete a label; `item_labels` junction rows cascade (items are not deleted) |
 
 ##### P02 — adds 4 memory tools (FR-13)
 
 | # | Tool | One-liner |
 |---|---|---|
-| 15 | `remember` | Write a scoped memory entry (`org` / `project` / `user`); secret sanitiser runs before encryption (NFR-7); 8 KB cap |
-| 16 | `recall` | Read memory entries by scope + key; supports tag and full-text filters |
-| 17 | `memories` | List memory entries by scope with pagination; cheap dashboard read |
-| 18 | `forget` | Soft-delete a memory entry (audit-trail preserved via `deleted_at`-equivalent) |
+| 24 | `remember` | Write a scoped memory entry (`org` / `project` / `user`); secret sanitiser runs before encryption (NFR-7); 8 KB cap |
+| 25 | `recall` | Read memory entries by scope + key; supports tag and full-text filters |
+| 26 | `memories` | List memory entries by scope with pagination; cheap dashboard read |
+| 27 | `forget` | Soft-delete a memory entry (audit-trail preserved via `deleted_at`-equivalent) |
 
-##### Operational primitives (counted within the 18 above; cross-references)
+##### Operational primitives (counted within the 27 above; cross-references)
 
 - `set_state` (#13) and `get_state` (#14) are the canonical state-machine
   accessors. `set_state` is the one tool subject to all of Layer 1's BLOCK
   conditions (§7.5).
 - `verify_can_transition` is **not** a separate top-level MCP tool — it is a
   read-only sub-call exposed via the same SSE channel for the Layer-2 hook
-  (§7.4). It does not count as one of the 18; it is a thin facade over the
+  (§7.4). It does not count as one of the 27; it is a thin facade over the
   same Layer-1 validator that backs `set_state`. (PRD FR-8 reconciliation:
-  the FR-8 sentence "exposing 18 tools at v1.0" refers to the agent-facing
-  inventory above; `verify_can_transition` is a hook-facing primitive shared
-  with the Layer-2 enforcement path.)
+  the FR-8 sentence "exposing 27 tools at v1.0" — raised from 18 by the P01
+  round-16 amendment — refers to the agent-facing inventory above;
+  `verify_can_transition` is a hook-facing primitive shared with the
+  Layer-2 enforcement path.)
 - `meta_catalogue` is **not** a separate top-level MCP tool either — it is a
   read-only catalogue endpoint served by the `mcp` service over the same SSE
   channel for the Layer-3 build-time renderer to verify against the
-  checked-in `catalogue.json` (§7.2). It does not count toward the 18 for
+  checked-in `catalogue.json` (§7.2). It does not count toward the 27 for
   the same reason: it is an operational read primitive consumed by tooling,
   not by agents in their workflow.
 
@@ -2228,8 +2250,8 @@ release candidate must additionally pass the cross gates.
 
 | Phase | Components touched | Manifesto coverage | Exit criterion (per PRD §8) |
 |---|---|---|---|
-| **P01 — Backend MVP** | `apps/api/auth` (incl. **migrations directory for all 8 schemas**, see §5.2), `org`, `workitems`, `deps`, `memory` (schema-only stub), `providers` (schema-only stub), `boards` (schema-only stub), `mcp` (14 tools, Streamable HTTP transport per MCP spec 2025-06-18), `public/`; migrations §9.4.1–§9.4.8 (all eight schemas land in P01 per the plan resolution; service code for `providers`/`boards`/`memory` is deferred to later phases per plan §2.1) | L1, L2, L3 (foundations), L5, L7 | Agent completes `prime → ready → claim → close` against a manually-seeded graph; cascade fires; cycle detection rejects offending edges |
-| **P02 — Backend complete** | `apps/api/providers` (webhook + sync), `apps/api/boards`, `mcp` (+4 memory tools = 18 total), Layer 1 state-transition validator, **`mcp.meta_catalogue` v1 + `verify_can_transition` v1** (operational primitives, §5.2.2); migrations §9.4.5 + §9.4.7 | L3 (provider events), L8 layer 1 | A GitHub repo can be linked, webhooks normalise into canonical work items, attempts to mark `done` without the required comment trail are rejected at the MCP boundary; `mcp.meta_catalogue` returns the live catalogue.json; `verify_can_transition` validates a candidate transition against the same Layer-1 validator |
+| **P01 — Backend MVP** | `apps/api/auth` (incl. **migrations directory for all 8 schemas**, see §5.2), `org`, `workitems`, `deps`, `memory` (schema-only stub), `providers` (schema-only stub), `boards` (schema-only stub), `mcp` (23 tools per P01 round-16 — was 14; adds `promote`, four milestone tools, four label tools; Streamable HTTP transport per MCP spec 2025-06-18), `public/`; migrations §9.4.1–§9.4.8 + round-16 `0110_mcp_issued_to_user_notnull` (all eight schemas land in P01 per the plan resolution; service code for `providers`/`boards`/`memory` is deferred to later phases per plan §2.1) | L1, L2, L3 (foundations), L5, L7 | Agent completes `prime → ready → claim → close` against a manually-seeded graph; cascade fires; cycle detection rejects offending edges |
+| **P02 — Backend complete** | `apps/api/providers` (webhook + sync), `apps/api/boards`, `mcp` (+4 memory tools = 27 total; P01 round-16 carried P01 to 23), Layer 1 state-transition validator, **`mcp.meta_catalogue` v1 + `verify_can_transition` v1** (operational primitives, §5.2.2); migrations §9.4.5 + §9.4.7 | L3 (provider events), L8 layer 1 | A GitHub repo can be linked, webhooks normalise into canonical work items, attempts to mark `done` without the required comment trail are rejected at the MCP boundary; `mcp.meta_catalogue` returns the live catalogue.json; `verify_can_transition` validates a candidate transition against the same Layer-1 validator |
 | **P03 — AST CLI v1.0.0** | `crates/unblock-indexer-core`, `unblock-indexer`, `unblock-code` | L6 | All 9 HARD gates in code-cli/plan §14.1 pass on a fresh clone; ROI harness publishes raw logs + per-flow medians as a release artefact |
 | **P04 — Plugin renderer** | `crates/unblock-plugin` **consumes the P02-shipped `mcp.meta_catalogue` v1** at build time (and embeds `crates/unblock-plugin/data/catalogue.json` via `include_str!`); registers the `verify-state` hook against `mcp.verify_can_transition` (also shipped in P02) | L8 layer 2 + 3 (full Law 8) | Pipeline-bypass attempt is rejected by MCP (Layer 1, P02), flagged by the post-dispatch hook (Layer 2), and refused by the agent prompt's BLOCK condition (Layer 3); all three layers agree; catalogue drift CI test green |
 | **P05 — Astro web (v1.1)** | `apps/web/` (Astro Actions BFF including `auth/[provider]/callback`, kanban, graph, roadmap, comments) | L4 | A developer authenticates, sees the same graph the agent sees, and acts on it through the BFF without the browser ever obtaining Encore credentials |
@@ -2340,10 +2362,10 @@ This document moves from DRAFT to APPROVED when:
 - [x] BLOCK condition schema pinned (§7.5) — typed shape, single
       `catalogue.json` source consumed by Layer 1 (Go codegen), Layer 2
       (`verify_can_transition` re-validates), and Layer 3 (Rust renderer).
-- [x] 18 MCP tool inventory pinned (§5.2.2) — 14 in P01, +4 memory in P02;
-      `verify_can_transition` and `meta_catalogue` are operational
-      primitives outside the agent-facing 18 (PRD FR-8 reconciliation
-      noted inline).
+- [x] 27 MCP tool inventory pinned (§5.2.2; P01 round-16: 18→27) — 23 in
+      P01, +4 memory in P02; `verify_can_transition` and `meta_catalogue`
+      are operational primitives outside the agent-facing 27 (PRD FR-8
+      reconciliation noted inline).
 - [x] Diagram + traceability cleanup (§3.1 catalogue arrow added; §11
       P02 ships `meta_catalogue` v1, P04 consumes it; §5.7 codegen route
       named — `apps/api/mcp/catalogue.gen.go` via `go generate`; §7.2

--- a/docs/plans/01-plan-backend-mvp.md
+++ b/docs/plans/01-plan-backend-mvp.md
@@ -1,8 +1,18 @@
-# PLAN: P01 — Backend MVP (Encore Go + Postgres + 14 MCP Tools)
+# PLAN: P01 — Backend MVP (Encore Go + Postgres + 23 MCP Tools)
 
 **Status:** APPROVED
 **Author:** Ada (architect)
-**Date:** 2026-05-07 (resolutions applied 2026-05-08)
+**Date:** 2026-05-07 (resolutions applied 2026-05-08; P01 round-16 tool-surface amendment reconciled 2026-06-04)
+
+> **P01 round-16 amendment (2026-06-04).** The P01 MCP tool surface grows
+> from **14 → 23** and v1.0 from **18 → 27** per the phase spec round-16
+> changelog (`docs/specs/01-spec-backend-mvp.md`, beads `unblock-tv8.71`
+> `promote` + `is_ready`-on-create, `.74` milestone tools now in P01,
+> `.75` label tools, `.73` `issued_to_user` NOT NULL, `.76` `show`
+> reference resolution). This plan's tool table (§2.2) and the milestone
+> P02-deferral wording (§2.1) are reconciled below; the track structure
+> (§4) is unchanged except that Track D now also delivers the milestone +
+> label tools and `promote`.
 **Source PRD:** [docs/PRD.md](../PRD.md) (APPROVED, 2026-05-07)
 **Source SPEC:** [docs/SPEC.md](../SPEC.md) (APPROVED 2026-05-07, round-2 review applied)
 **Companion:** [docs/MANIFESTO.md](../MANIFESTO.md) (APPROVED, 2026-05-07)
@@ -27,9 +37,10 @@ cycle detection rejecting offending edges at write time.
 
 P01 is the **agent-facing core** — work-item CRUD, dependency graph,
 ready-set materialisation, atomic claim, comment trail, structured state
-columns, and the SSE MCP transport with 14 tools. Provider integration,
-the four memory tools, and Layer-1 state-transition validation are
-deferred to P02 by design (PRD §8). P01 lays down the schemas that P02
+columns, and the Streamable HTTP MCP transport with 23 tools (round-16:
+the 14 core tools + `promote` + four milestone tools + four label tools).
+Provider integration, the four memory tools, and Layer-1 state-transition
+validation are deferred to P02 by design (PRD §8). P01 lays down the schemas that P02
 fills in — including `providers`, `boards`, `mcp`, and `memory` — but
 exposes only the surfaces required for the P01 exit criterion.
 
@@ -50,9 +61,9 @@ Per SPEC §5.2 (8 services × 8 schemas, 1:1 mapping locked).
 |---|---|---|
 | `auth` | OAuth2+PKCE flow (private `auth.ExchangeOAuthCode`), session validation (private `auth.Validate`), API key issuance + validation (MCP Bearer auth), `Identity` resolution | OAuth callback **lives on the Astro origin** in P05; in P01 the callback is exercised by integration tests only. API key issuance ships **as a private RPC** (`auth.IssueAPIKey`) since there is no web UI to drive it; **the E2E exit-criterion test issues its API key via direct INSERT into `mcp.api_keys`** (round-12 — see spec §11.1.1; the seeder CLI originally planned for this is deleted). Dev exploration outside tests uses `psql` against the local Postgres or Encore's local dashboard. |
 | `org` | Org / project CRUD, RBAC role bindings, `org.Authorize(identity, resource, action)` | Required because every `workitems`, `deps`, and `mcp` call is org-scoped (NFR-2). |
-| `workitems` | Items, comments, labels, milestones (recursive), findings; private RPCs `Create / Update / GetTrail / ListByMilestone / AppendComment / SetStateColumns` plus the four milestone RPCs `CreateMilestone / UpdateMilestone / AssignItem / MilestoneTree` (round-2 D1 — see SPEC §4.4.1). | Comments append-only; milestone tree depth ≤ 4 (M-INV-6); findings are first-class child items. **Milestone CRUD is reachable only via private RPC in P01** — agent-facing milestone MCP tools defer to P02 to preserve PRD FR-8 "18 tools at v1.0" (option (c) in round-2 D1). The E2E exit-criterion test (`apps/api/exitcriteriontest/`, round-12) and the future Astro client (P05) drive milestone creation through the private RPCs. |
+| `workitems` | Items, comments, labels, milestones (recursive), findings; private RPCs `Create / Update / GetTrail / ListByMilestone / AppendComment / SetStateColumns` plus the four milestone RPCs `CreateMilestone / UpdateMilestone / AssignItem / MilestoneTree` (round-2 D1 — see SPEC §4.4.1) plus the four label-registry RPCs `CreateLabel / ListLabels / UpdateLabel / DeleteLabel` (round-16, bead `unblock-tv8.75`). | Comments append-only; milestone tree depth ≤ 4 (M-INV-6); findings are first-class child items. **Round-16 amendment:** the original round-2 D1 decision ("milestone MCP tools defer to P02 to preserve FR-8 '18 tools at v1.0'") is OVERRIDDEN by bead `unblock-tv8.74` — the milestone MCP tools (and the new label tools) ship in P01 as facades over these RPCs; v1.0 is reconciled to 27 tools. `workitems.Create` also gains the `is_ready`-on-create inline write (bead `unblock-tv8.71`, spec §6.6). |
 | `deps` | Edges, cycle detection at write time, ready-set materialisation, cascade subscriber, `deps.cascade_events` audit table; private RPCs `AddEdge / RemoveEdge / IsReady / Closure` | The cascade subscriber **also maintains `pipeline_stage`** (SPEC §5.7.1). |
-| `mcp` | Streamable HTTP transport (`POST /mcp` + `GET /mcp` per MCP spec 2025-06-18), Go SDK `github.com/modelcontextprotocol/go-sdk`, tool registry, the 14 P01 tools, Bearer API key auth via `auth.Validate`, structured error envelope | **No state-machine BLOCK conditions** in P01 — see §3.4 below for the explicit deferral. |
+| `mcp` | Streamable HTTP transport (`POST /mcp` + `GET /mcp` per MCP spec 2025-06-18), Go SDK `github.com/modelcontextprotocol/go-sdk`, tool registry, the 23 P01 tools (round-16: 14 core + `promote` + 4 milestone + 4 label), Bearer API key auth via `auth.Validate`, structured error envelope | **No state-machine BLOCK conditions** in P01 — see §3.4 below for the explicit deferral. `promote` (Tool 15) IS shipped — it is a `Status`-enum writer, not a Layer-1 comment-trail gate. |
 | **public** | FR-12 v1.0 endpoints' wiring (`POST /mcp` + `GET /mcp` Streamable HTTP only — `POST /webhooks/github` is P02) | Only the MCP endpoint in P01. |
 
 Services whose **schema** ships in P01 but whose **runtime surface is empty**:
@@ -72,7 +83,7 @@ alternative (gradual migrations) was considered and rejected because
 splitting DDL across phases couples the migration order to the phase
 sequence, which the §9.4.0 ordering rules already pin independently.
 
-### 2.2 The 14 MCP tools (SPEC §5.2.2)
+### 2.2 The 23 MCP tools (SPEC §5.2.2; P01 round-16 raised from 14)
 
 | # | Tool | P01 contract notes |
 |---|---|---|
@@ -90,6 +101,26 @@ sequence, which the §9.4.0 ordering rules already pin independently.
 | 12 | `remove_dependency` | Removes edge; emits `deps.cascade.requested`; the `to` side may flip `is_ready=true`. |
 | 13 | `set_state` | Writes one or more of `impl_state`, `review_state`, `qa_state`, `pipeline_state`. **In P01, this enforces structural invariants AND the five PRD §6.2 state-machine invariants (round-2 D2)** — pure column-value rules with no comment-trail dependency (e.g. writing `qa_state=failed` requires `review_state=approved`; writing `review_state=needs_rework` resets `qa_state=pending` atomically). The **comment-trail-driven Layer-1 BLOCK conditions are P02** — see §3.4. |
 | 14 | `get_state` | Returns the four state columns + materialised `pipeline_stage` + most recent `(kind, status)` per kind from the comment trail. |
+| 15 | `promote` | **(round-16, bead `unblock-tv8.71`)** Backlog→Ready; precondition `status='Backlog' AND is_ready=true`. The canonical Ready writer (closes round-12 DRIFT-2). Also pins the `is_ready`-on-create rule + the full §6.6 status transition map. |
+| 16 | `create_milestone` | **(round-16, bead `unblock-tv8.74`)** Facade over `workitems.CreateMilestone`. |
+| 17 | `update_milestone` | **(round-16, bead `unblock-tv8.74`)** Facade over `workitems.UpdateMilestone`. |
+| 18 | `assign_item` | **(round-16, bead `unblock-tv8.74`)** Facade over `workitems.AssignItem` (incl. unassign). |
+| 19 | `milestone_tree` | **(round-16, bead `unblock-tv8.74`)** Facade over `workitems.MilestoneTree`. |
+| 20 | `create_label` | **(round-16, bead `unblock-tv8.75`)** Create a label over the existing `workitems.labels` table; org-scoped + RBAC. |
+| 21 | `list_labels` | **(round-16, bead `unblock-tv8.75`)** List labels in scope (project + inherited org). |
+| 22 | `update_label` | **(round-16, bead `unblock-tv8.75`)** Rename + recolor a label. |
+| 23 | `delete_label` | **(round-16, bead `unblock-tv8.75`)** Delete a label; junction rows cascade. |
+
+> **Round-16 note.** Tools 15–23 were added by the P01 round-16 amendment.
+> `promote` (15) and the `is_ready`-on-create rule are owned by bead
+> `unblock-tv8.71`; the milestone tools (16–19) by `unblock-tv8.74` (which
+> OVERRIDES the original §2.1 / round-2 D1 "milestone tools defer to P02"
+> decision); the label tools (20–23) by `unblock-tv8.75`. Two further
+> round-16 beads change contracts without adding tools: `unblock-tv8.73`
+> (`issued_to_user` NOT NULL + new migration `0110`) and `unblock-tv8.76`
+> (`show` resolves parent + direct deps to `{id,title,status}`).
+> `unblock-tv8.72` reuses the new §7 `PRECONDITION_NOT_MET {status,required}`
+> taxonomy for the `claim`-on-not-Ready error. See spec §6.2 / §6.6 / §7.2.
 
 ### 2.3 Cross-cutting machinery in P01
 
@@ -116,7 +147,8 @@ sequence, which the §9.4.0 ordering rules already pin independently.
   zero. Plus the NFR-1 latency check (`prime → ready → claim` p99 < 2 s)
   on the warm-cache integration harness.
 - **Catalogue source file** — `apps/api/mcp/catalogue.json` is **created
-  in P01** with the 14 P01 tools' tool definitions, but the
+  in P01** with the 23 P01 tools' tool definitions (round-16: 14→23, see
+  spec §10.3), but the
   state-machine section is left as a placeholder (the BLOCK conditions
   catalogue is finalised in P02). `go generate` runs in P01 and emits
   `apps/api/mcp/catalogue.gen.go`. SPEC §7.2 / AR-4 drift CI is
@@ -237,7 +269,7 @@ into bd.
 |---|---|---|
 | A-1 | Initialise Encore app at `apps/api/encore.app` (Go module, build, dev-loop sanity) | go-supervisor (Greta) |
 | A-2 | Bootstrap migration: `pgcrypto`, `pg_trgm`, eight schemas declared (per SPEC §9.4.0) | go-supervisor (Greta) |
-| A-3 | Migrations §9.4.1–§9.4.8 in canonical order | go-supervisor (Greta) |
+| A-3 | Migrations §9.4.1–§9.4.8 in canonical order; **round-16: + `0110_mcp_issued_to_user_notnull.up.sql`** (`issued_to_user` NOT NULL + FK `ON DELETE CASCADE`, bead `unblock-tv8.73`, spec §3.2) | go-supervisor (Greta) |
 | A-4 | `pkg/rbac` typed query helper + per-service DB binding | go-supervisor (Greta) |
 | A-5 | Tracing + JSON-Lines logging scaffold (NFR-12) — ULID `trace_id` minted at MCP entry, propagated via `context.Context` per SPEC §10.2 Option B (no `X-Unblock-Trace-Id` header) | go-supervisor (Greta) |
 | A-6 | CI workflow + lint gates + NFR-1 latency harness scaffold + NFR-2 RBAC suite scaffold (per-language gates wired into `.github/workflows/`) | infra-supervisor (Olive) |
@@ -246,7 +278,7 @@ into bd.
 
 | ID | Task | Owner |
 |---|---|---|
-| B-1 | `auth` service: `Validate`, `ExchangeOAuthCode`, API key issuance + validation, session lifecycle | go-supervisor (Greta) |
+| B-1 | `auth` service: `Validate`, `ExchangeOAuthCode`, API key issuance + validation, session lifecycle. **Round-16:** `IssueAPIKey` rejects empty `issued_to_user` (InvalidArgument); validate path never builds an empty-UID identity (bead `unblock-tv8.73`, spec §4.1 / §4.3.2). | go-supervisor (Greta) |
 | B-2 | `org` service: orgs/projects CRUD, role bindings, `Authorize` | go-supervisor (Greta) |
 | B-3 | RBAC regression suite for `auth` + `org` surfaces | go-supervisor (Greta) |
 
@@ -261,17 +293,18 @@ into bd.
 | C-5 | `pipeline_stage` derivation table integration tests (SPEC §5.7.1) | go-supervisor (Greta) |
 | C-6 | RBAC regression suite extended to `workitems` + `deps` | go-supervisor (Greta) |
 
-### 4.4 Track D — MCP server + 14 tools (depends on Track C)
+### 4.4 Track D — MCP server + 23 tools (depends on Track C; round-16)
 
 | ID | Task | Owner |
 |---|---|---|
 | D-1 | `mcp` service skeleton: Streamable HTTP transport (`POST /mcp` + `GET /mcp` per MCP 2025-06-18 spec) using `github.com/modelcontextprotocol/go-sdk`, Bearer API key auth via `auth.Validate` (HMAC-SHA256 lookup per §9.4.6), tool registry, structured JSON-RPC error envelope, `mcp.tool_calls` audit row per call | go-supervisor (Greta) |
-| D-2 | Tools 1–4: `prime`, `ready`, `claim`, `create` | go-supervisor (Greta) |
-| D-3 | Tools 5–8: `update`, `close`, `show`, `list` | go-supervisor (Greta) |
+| D-2 | Tools 1–4: `prime`, `ready`, `claim`, `create`. **Round-16:** + Tool 15 `promote` + the `is_ready`-on-create inline write (bead `unblock-tv8.71`, spec §6.6); + the §7.2 `PRECONDITION_NOT_MET {status,required}` extension reused by `claim` (bead `unblock-tv8.72`). | go-supervisor (Greta) |
+| D-3 | Tools 5–8: `update`, `close`, `show`, `list`. **Round-16:** Tool 7 `show` resolves parent + direct deps to `{id,title,status}` (bead `unblock-tv8.76`). | go-supervisor (Greta) |
 | D-4 | Tools 9–10: `search`, `comment` | go-supervisor (Greta) |
 | D-5 | Tools 11–12: `add_dependency`, `remove_dependency` | go-supervisor (Greta) |
 | D-6 | Tools 13–14: `set_state` (structural invariants only — §3.4), `get_state` | go-supervisor (Greta) |
-| D-7 | `apps/api/mcp/catalogue.json` v0 (P01 tools, no BLOCK conditions yet) + `go generate` + `catalogue.gen.go` committed | go-supervisor (Greta) |
+| D-7 | `apps/api/mcp/catalogue.json` v0 (all 23 P01 tools, no BLOCK conditions yet) + `go generate` + `catalogue.gen.go` committed | go-supervisor (Greta) |
+| D-8 | **(round-16)** Tools 16–19 milestone MCP facades (`create_milestone`/`update_milestone`/`assign_item`/`milestone_tree`, bead `unblock-tv8.74`) + Tools 20–23 label-registry tools (`create_label`/`list_labels`/`update_label`/`delete_label`, bead `unblock-tv8.75`, backed by new `workitems` label RPCs) | go-supervisor (Greta) |
 
 ### 4.5 Track E — Exit-criterion harness + ops
 
@@ -293,7 +326,7 @@ into bd.
 A (foundations)
   ├─► B (auth + org)
   │     └─► C (workitems + deps + cascade + claim)
-  │           └─► D (mcp + 14 tools)
+  │           └─► D (mcp + 23 tools)
   │                 └─► E (exit-criterion harness + gates)
   └─► CI/lint gates (run on every track's PRs)
 ```
@@ -461,6 +494,12 @@ v0 (the 14 P01 tools, no BLOCK conditions section) ships in P01. The
 codegen target wait until P02, after the BLOCK-conditions section is
 authored.
 
+**Round-16 note (2026-06-04, beads `unblock-tv8.74`/`.75`):** the
+catalogue v0 tool count is reconciled from 14 to 23 (the historical
+"14 P01 tools" figures above are preserved as written). The
+`meta_catalogue` endpoint / codegen interplay is unchanged — they still
+wait for P02 (modulo the D-7 supersession below).
+
 **SUPERSEDED 2026-05-21 by D-7 (bead unblock-tv8.22):** the codegen
 half of this resolution is reversed. Per §2.3 (lines 118-125) and Spec
 §10.3 (lines 2508-2510), `apps/api/mcp/catalogue.gen.go` ships in P01
@@ -616,7 +655,7 @@ This phase is **DONE** when all of the following are demonstrably true.
       implementation starts.
 - [ ] `docs/research/01-research-backend-mvp.md` closes R-P01-1 through
       R-P01-10 with verified findings before the spec is approved.
-- [ ] README.md updated with P01 user surface (MCP Bearer auth, the 14
+- [ ] README.md updated with P01 user surface (MCP Bearer auth, the 23
       tools' one-liners). The former seeder CLI invocation deliverable
       is dropped (round-12 — seeder CLI deleted from P01 scope; the
       exit-criterion fixture is now seeded by the E2E test itself per
@@ -647,7 +686,7 @@ This phase is **DONE** when all of the following are demonstrably true.
 - PRD §1, §4 (US-1 through US-9), §5.1 (FR-1 through FR-13), §8 (P01
   exit criterion), §10 (deps + constraints), §11 (M-1 through M-5).
 - SPEC §3.1 (component diagram), §5.2 (8-service decomposition), §5.2.2
-  (the 14 P01 tools), §5.3 (public surface), §5.4 (cascade), §5.5
+  (the 23 P01 tools; round-16: 14→23), §5.3 (public surface), §5.4 (cascade), §5.5
   (atomic claim), §5.6 (RBAC), §5.7 (state machine, P02 deferral),
   §5.7.1 (`pipeline_stage` derivation), §9.4.0–§9.4.10 (canonical DDL),
   §11 (P01 traceability), §13 AR-8 / AR-11 / AR-13.

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -1,7 +1,8 @@
 # SPEC: P01 — Backend MVP Implementation Contract
 
-**Status:** APPROVED (§3.5 fifth-secret addition applied 2026-06-02; round-15 NFR-1 harness test-isolation + mcpaudittest hardening applied 2026-05-29; round-14 NFR-1 latency-harness scope applied 2026-05-29; round-6 cascade-symmetry applied 2026-05-12; round-5 tracing applied 2026-05-12; round-4 auth applied 2026-05-11; DRIFT-1/-2 applied 2026-05-08; round-2 applied 2026-05-08; round-3 research applied 2026-05-08; original APPROVED 2026-05-07)
+**Status:** APPROVED (round-16 P01 tool-surface scope amendment applied 2026-06-04; §3.5 fifth-secret addition applied 2026-06-02; round-15 NFR-1 harness test-isolation + mcpaudittest hardening applied 2026-05-29; round-14 NFR-1 latency-harness scope applied 2026-05-29; round-6 cascade-symmetry applied 2026-05-12; round-5 tracing applied 2026-05-12; round-4 auth applied 2026-05-11; DRIFT-1/-2 applied 2026-05-08; round-2 applied 2026-05-08; round-3 research applied 2026-05-08; original APPROVED 2026-05-07)
 **Changelog:**
+- 2026-06-04 — round-16 (P01 MCP tool-surface scope amendment; surfaced by the 2026-06-03 local-MCP demo + 2026-06-04 review; covers epic `unblock-tv8` beads .71/.72/.73/.74/.75/.76): the P01 agent-facing tool inventory grows from **14 to 23** and the v1.0 inventory from **18 to 27** (still + the 4 memory tools at P02). Five contract changes land in lockstep. (1) **`promote` keystone (.71)** — a new Tool 15 `promote` transitions an item Backlog→Ready, precondition `status='Backlog' AND is_ready=true`; the not-ready rejection reuses the EXISTING §7 `PRECONDITION_NOT_MET` kind, extended ADDITIVELY with a `{status, required}` pair alongside the existing `{missing}`/`{rejection_reason}` shapes. .71 also closes round-12 DRIFT-2 ("the state-machine does not allow the canonical fixture's Done/Ready end-states via RPC") by pinning the FULL Backlog/Ready/InProgress/Blocked/Done transition map (§6.6) incl. the Ready→Blocked demotion that fires when a `blocks` edge is later added to a Ready item. .71 further pins the **`is_ready`-on-create rule**: a freshly-created item with no incoming `blocks` edges MUST get `is_ready=true` INLINE at create time inside `workitems.Create`'s own transaction (today `recomputeReady` never fires on the create path, so such items are stranded non-ready); `workitems.Create` joins the §6.3.0 Regime A `is_ready` single-writer allow-list and the §11.3 `no_direct_is_ready_write` allow-list, and the misleading create doc-comment is corrected. (2) **`issued_to_user` REQUIRED (.73)** — the column becomes NOT NULL on every MCP API key; all "nullable / org-level service key" wording is removed; a new up-only migration `0110_mcp_issued_to_user_notnull.up.sql` runs `ALTER … SET NOT NULL` and swaps the FK from `ON DELETE SET NULL` to `ON DELETE CASCADE` (deleting a user deletes their keys; `mcp.tool_calls` audit rows survive via their own `ON DELETE SET NULL`); `IssueAPIKey` rejects empty `IssuedToUser` with `InvalidArgument`; the §4.3.2 validate path never constructs an empty-UID identity. (3) **Milestone MCP tools (.74)** — OVERRIDES the §6.2 round-2 D1 deferral note + the §1 / §4.4.1 P02-deferral wording: the four milestone tools `create_milestone` / `update_milestone` / `assign_item` (incl. unassign via empty `milestone_id`) / `milestone_tree` are exposed NOW (Tools 16–19), thin MCP facades over the already-shipping `workitems.CreateMilestone`/`UpdateMilestone`/`AssignItem`/`MilestoneTree` private RPCs (§4.4.1). (4) **Label-registry MCP tools (.75)** — four NEW org-scoped, RBAC-gated tools `create_label` / `list_labels` / `update_label` (rename + recolor) / `delete_label` (Tools 20–23) over the existing `workitems.labels` table; four new `workitems` private RPCs back them. (5) **`show` resolves references (.76)** — Tool 7 `show` resolves the parent and the direct in/out dependency targets to `{id, title, status}` objects (one level deep, payload bounded) instead of bare IDs. The §7 `PRECONDITION_NOT_MET {status, required}` extension defined by .71 is the SAME taxonomy reused by .72 (the `claim`-on-not-Ready error) — .72 carries no separate spec text; its error is satisfied by the .71 §7 design. Patches in lockstep: §1 overview (tool-count bullets + milestone P02-defer wording) … §3.2 (new migration `0110`) … §4.1 (`IssueAPIKeyRequest.IssuedToUser` REQUIRED + doc-comment) … §4.3.2 step 8 (no empty-UID identity) … §4.4.1 (milestone-tools-now wording) … §5.2 (NOT-exposed list trimmed) … §6 header ("The 23 P01 MCP Tools") … §6.2 deferral note (rewritten: milestone + label + promote tools now in P01) … §6.2 Tool 7 `show` (reference resolution) … new §6.2 Tools 15–23 … new §6.6 (status transition map) … §6.3.0 Regime A allow-list (+`workitems.Create`) … §7 (`PRECONDITION_NOT_MET {status, required}` extension) … §10.3 (catalogue tool count 14→23) … §11.1.2 (promote assertion) … §11.3 `is_ready` allow-list (+`workitems.Create`) … §12 task table (D-2 promote, D-8 milestone+label tools, A-3 migration 0110) … §14 approval checklist (14→23). Cross-doc reconciliation (CONFIRMED by Miguel, no doc left stale): docs/PRD.md FR-8 + priority row, docs/SPEC.md §5.2.2 inventory + the "18 tools" mentions, and docs/plans/01-plan-backend-mvp.md tool table are all updated to the identical P01=23 / v1.0=27 counts, each carrying a P01-round-16 provenance note. Spec status remains APPROVED — this is a scope amendment, not a re-architecting.
 - 2026-05-08 — DRIFT-1 (naming): clarified §3.5 that the four logical secret names are spec-level identifiers; added logical-name ↔ Go-field mapping table for the Encore Go secrets manifest.
 - 2026-05-08 — DRIFT-2 (format): corrected the local-secrets file path/format from `.encore/local-secrets.toml` (TOML) to `apps/api/.secrets.local.cue` (CUE) per Encore official docs (https://encore.dev/docs/go/primitives/secrets); updated syntax examples and gitignore guidance.
 - 2026-05-11 — round-4 (auth drift fixes from Sherlock's investigation on bead unblock-tv8.7): §4.3.2 step 2 aligned with locked key-format note (DRIFT-A); §4.3.3 AuthHandler signature corrected to Encore structured-params form for header dispatch (DRIFT-B); §12 task table cell for B-1 corrected from §6.4 to §4.3.3 (DRIFT-C); session-path P01 contract pinned (returns errs.Unimplemented; multi-org disambiguation deferred to BFF phase).
@@ -67,7 +68,10 @@ P01 ships the agent-facing core of `://unblock`:
   single migration-owner directory at `apps/api/db/migrations/`, owned
   by a dedicated zero-API `db` service.
 - Streamable HTTP MCP transport (per MCP spec 2025-06-18) at `POST /mcp` +
-  `GET /mcp` exposing **14 tools** with Bearer API key auth.
+  `GET /mcp` exposing **23 tools** with Bearer API key auth (round-16:
+  the 14 core tools + the new `promote` tool + the four milestone tools
+  + the four label-registry tools — see §6.2). The v1.0 inventory is
+  **27** (these 23 P01 tools + the 4 memory tools added in P02).
 - Cascade subsystem on Encore Pub/Sub maintaining `is_ready` and
   `pipeline_stage` materialised columns.
 - Atomic claim transaction (`SELECT FOR UPDATE`).
@@ -80,18 +84,31 @@ P01 ships the agent-facing core of `://unblock`:
   `apps/api/exitcriteriontest/fixture.go`. No standalone CLI binary
   (former §9 deleted; see §11.1 for the canonical fixture topology
   and round-12 changelog for the rationale).
-- **Milestones (round-2 D1).** Recursive milestones (PRD §6.3 + SPEC
-  §9.4.3) ship in P01 as **private RPCs** (`workitems.CreateMilestone`,
-  `UpdateMilestone`, `AssignItem`, `MilestoneTree` — §4.4); the four
-  M-INV-2 / M-INV-3 / M-INV-6 / M-INV-7 invariants are enforced in app
-  code per the SPEC §9.4.3 DDL note. **Milestone MCP tools defer to P02**
-  alongside the memory tools (preserves FR-8 "18 tools at v1.0"); P01
-  agents do not see milestone tools.
+- **Milestones (round-2 D1; round-16 amendment).** Recursive milestones
+  (PRD §6.3 + SPEC §9.4.3) ship in P01 as **private RPCs**
+  (`workitems.CreateMilestone`, `UpdateMilestone`, `AssignItem`,
+  `MilestoneTree` — §4.4); the four M-INV-2 / M-INV-3 / M-INV-6 / M-INV-7
+  invariants are enforced in app code per the SPEC §9.4.3 DDL note.
+  **Round-16 (bead `unblock-tv8.74`) OVERRIDES the original D1 deferral:**
+  the four milestone MCP tools (`create_milestone`, `update_milestone`,
+  `assign_item`, `milestone_tree` — Tools 16–19, §6.2) ARE exposed in P01,
+  as thin facades over the private RPCs above. P01 agents see them now.
 
 P01 explicitly **defers** Layer-1 BLOCK conditions (P02), the four memory
-tools (P02), the four milestone MCP tools (P02 — see D1 above), GitHub
-webhook ingestion (P02), the Astro frontend (P05), the plugin renderer
-(P04), and `unblock-code` (P03) — see Plan §3.
+tools (P02), GitHub webhook ingestion (P02), the Astro frontend (P05),
+the plugin renderer (P04), and `unblock-code` (P03) — see Plan §3.
+
+> **Round-16 amendment (2026-06-04).** The original round-2 D1 deferral —
+> "the four milestone MCP tools defer to P02 to preserve FR-8 '18 tools at
+> v1.0'" — is **OVERRIDDEN** by bead `unblock-tv8.74`. The milestone MCP
+> tools (`create_milestone`, `update_milestone`, `assign_item`,
+> `milestone_tree`) ship in P01 as thin facades over the milestone private
+> RPCs (§4.4.1) that already exist. In the same round, `promote`
+> (`unblock-tv8.71`) and four label-registry tools (`unblock-tv8.75`) are
+> added. P01 now exposes **23** agent-facing tools (was 14); v1.0 is **27**
+> (was 18). The FR-8 "18 tools" figure is reconciled to 27 across PRD §5.1
+> FR-8, SPEC §5.2.2, this spec, and Plan §2.2 in lockstep (see the
+> round-16 changelog).
 
 **P01 Exit criterion (PRD §8 verbatim):** an agent authenticates via
 Bearer API key and completes `prime → ready → claim → close` against a
@@ -222,6 +239,12 @@ in steps of 10. Step numbering matches §9.4.0 ordering:
 | `0070_mcp.up.sql` | Schema `mcp` per SPEC §9.4.6 (tables `api_keys`, `tool_calls` + indexes; `key_hash bytea`, `key_prefix UNIQUE` per C7) |
 | `0080_boards.up.sql` | Schema `boards` per SPEC §9.4.7 (tables `boards`, `columns` + indexes). **Schema-only in P01** — no service code until P05. |
 | `0090_memory.up.sql` | Schema `memory` per SPEC §9.4.8 (tables `entries`, `entry_refs` + indexes). **Schema-only in P01** — no service code until P02. |
+| `0110_mcp_issued_to_user_notnull.up.sql` (round-16, bead `unblock-tv8.73`) | Tighten `mcp.api_keys.issued_to_user`: (1) `ALTER TABLE mcp.api_keys ALTER COLUMN issued_to_user SET NOT NULL;` (2) drop the existing FK and re-add it as `FOREIGN KEY (issued_to_user) REFERENCES auth.users(id) ON DELETE CASCADE` (was `ON DELETE SET NULL`). Every MCP API key is now owned by exactly one user; deleting that user deletes their keys. `mcp.tool_calls.issued_to_user` (the audit FK) is unaffected and KEEPS its `ON DELETE SET NULL` so audit rows survive a user deletion. Up-only, pre-prod — no rows exist yet, so the `SET NOT NULL` cannot fail on existing data; the migration is additive to the §3.2 sequence and does not renumber 0010..0090. |
+
+> **Migration `0100`** is the Tool-2 covering index pinned in round-7
+> (§6.2.0 / §6.2 Tool 2). It is referenced but its row is documented at
+> its point of use; the round-16 `0110` migration follows it in the
+> sequence.
 
 **No `down.sql` files in P01.** Pre-prod (no users, no migration tax per
 `feedback_pre_production`). Down migrations re-introduce risk without
@@ -468,12 +491,20 @@ type ExchangeOAuthCodeResponse struct {
 // phase. Returns the raw key ONCE — the caller stores it; subsequent
 // reads return only the prefix and metadata.
 //
+// **Round-16 (bead `unblock-tv8.73`): IssuedToUser is REQUIRED.** Every
+// MCP API key is owned by exactly one user — there is no org-level
+// "service key" without an owning user. IssueAPIKey rejects an empty
+// IssuedToUser with `errs.InvalidArgument` (kind=VALIDATION at the MCP
+// boundary, data.field="issued_to_user") BEFORE any INSERT runs. The
+// underlying `mcp.api_keys.issued_to_user` column is NOT NULL with an
+// `ON DELETE CASCADE` FK to `auth.users(id)` per migration `0110`.
+//
 //encore:api private method=POST path=/auth.IssueAPIKey
 func IssueAPIKey(ctx context.Context, req IssueAPIKeyRequest) (*IssueAPIKeyResponse, error)
 
 type IssueAPIKeyRequest struct {
     OrgID         string // ULID
-    IssuedToUser  string // ULID; nullable (org-level service key)
+    IssuedToUser  string // ULID; REQUIRED (round-16 / tv8.73) — empty is rejected with InvalidArgument; there is no nullable org-level service key
     Label         string // human-readable, e.g. "claude-code-laptop"
     AgentKind     string // AgentKind value
     Scopes        []string
@@ -545,7 +576,7 @@ type AuthorizeRequest struct {
 ### 4.3 `mcp` service
 
 Owns: schema `mcp` (writes only), the public Streamable HTTP endpoint, the
-14 P01 tool handlers. Consumes the unblock database via the canonical
+23 P01 tool handlers (round-16). Consumes the unblock database via the canonical
 BindDB late-bind pattern (§3.1) when DB-touching code lands (P01 D-1+):
 a nil `*sqldb.Database` pointer + exported `BindDB` hook in
 `apps/api/mcp/db.go`, registered in `apps/api/db/db.go`'s `init`. No
@@ -622,7 +653,7 @@ On every MCP request:
 5. Compute `expected = HMAC-SHA256(API_KEY_HMAC_SECRET, raw_key)`.
 6. `if !subtle.ConstantTimeCompare(stored_key_hash, expected) { reject }`.
 7. `UPDATE mcp.api_keys SET last_used_at = now() WHERE id = $1` (fire-and-forget).
-8. Construct `auth.Identity{UserID: issued_to_user, OrgID: org_id, Role: "agent", AgentKind: agent_kind}` and inject via Encore's auth handler.
+8. Construct `auth.Identity{UserID: issued_to_user, OrgID: org_id, Role: "agent", AgentKind: agent_kind}` and inject via Encore's auth handler. **Round-16 (bead `unblock-tv8.73`):** `issued_to_user` is NOT NULL on every `mcp.api_keys` row (migration `0110`), so this path NEVER constructs an empty-UID identity. If a row with an empty `issued_to_user` were somehow observed (it cannot be, given the NOT NULL constraint), the request is rejected as `UNAUTHENTICATED` rather than yielding an unscoped identity — defence in depth against a malformed row.
 
 Total budget for this path: <5 ms p99 on warm cache (no Argon2 cost per C7).
 
@@ -679,6 +710,18 @@ Private RPCs (called by MCP tool handlers; never directly by clients):
 package workitems
 
 //encore:api private method=POST path=/workitems.Create
+// Creates a work item in status=Backlog.
+//
+// **is_ready-on-create (round-16, bead unblock-tv8.71).** Create sets
+// `is_ready` INLINE inside its own transaction (it is a Regime A is_ready
+// writer per §6.3.0 / §11.3). A new item with no incoming `blocks` edges
+// gets `is_ready=true`. **Do NOT** rely on the cascade subscriber to
+// materialise readiness for a newly-created item: the subscriber maintains
+// `pipeline_stage` only (round-6 §6.3.0) and `recomputeReady` never fires
+// for a create with no edge mutation — without the inline write the item
+// would be stranded non-ready. (This corrects the pre-round-16 doc-comment
+// that implied readiness was subscriber-materialised on create.) `status`
+// stays `Backlog`; an unblocked item is then `promote`-able via Tool 15.
 func Create(ctx context.Context, req CreateRequest) (*Item, error)
 
 type CreateRequest struct {
@@ -758,10 +801,21 @@ type GetTrailRequest struct {
 }
 type Trail struct {
     Item              *Item
+    Parent            *ResolvedRef     // round-16 / tv8.76: resolved parent {id,title,status}; nil when no parent
     Comments          []Comment        // ordered by created_at asc
-    DependenciesIn    []Edge           // edges where to_item == Item.ID
-    DependenciesOut   []Edge           // edges where from_item == Item.ID
+    DependenciesIn    []ResolvedRef    // round-16 / tv8.76: edges where to_item == Item.ID, target resolved to {id,title,status,kind}
+    DependenciesOut   []ResolvedRef    // round-16 / tv8.76: edges where from_item == Item.ID, target resolved to {id,title,status,kind}
     Findings          []Item           // children with type=finding
+}
+
+// ResolvedRef is a one-level-deep resolution of a related item (parent or
+// dependency target) to its identity + display fields. Bounded by design:
+// no body, no comments, no nested neighbours (round-16 / tv8.76).
+type ResolvedRef struct {
+    ID     string // target item ULID
+    Title  string // target item title
+    Status string // target item Status enum (§6.1)
+    Kind   string // edge kind ("blocks" | "related"); empty for the parent ref
 }
 
 //encore:api private method=POST path=/workitems.AppendComment
@@ -920,6 +974,71 @@ type SearchHit struct {
     CommentID string // populated when Source="comment"
     Rank      float64
     Snippet   string // ts_headline output, ≤ 200 chars
+}
+
+// --- Label-registry RPCs (round-16, bead unblock-tv8.75) ---
+// Back the label MCP tools (§6.2 Tools 20–23) over the EXISTING
+// workitems.labels / workitems.item_labels tables (SPEC §9.4.3). No new
+// migration — the tables already exist. Org-scoped, RBAC-gated.
+
+//encore:api private method=POST path=/workitems.CreateLabel
+func CreateLabel(ctx context.Context, req CreateLabelRequest) (*Label, error)
+
+type CreateLabelRequest struct {
+    OrgID       string // ULID; XOR ProjectID (labels_scope_xor_chk)
+    ProjectID   string // ULID; XOR OrgID
+    Name        string // 1..64 chars; unique within scope
+    Color       string // "#RRGGBB"
+    Description  string // optional
+}
+
+type Label struct {
+    ID          string
+    OrgID       string // empty when project-scoped
+    ProjectID   string // empty when org-scoped
+    Name        string
+    Color       string
+    Description  string
+    CreatedAt   time.Time
+    UpdatedAt   time.Time
+}
+
+//encore:api private method=POST path=/workitems.ListLabels
+// Returns labels in scope; project-scope calls also return inherited org
+// labels with PRD §6.4 "project wins on identical name" applied.
+func ListLabels(ctx context.Context, req ListLabelsRequest) (*ListLabelsResponse, error)
+
+type ListLabelsRequest struct {
+    OrgID     string // optional
+    ProjectID string // optional; when set, returns project + inherited org labels
+}
+type ListLabelsResponse struct {
+    Labels []Label
+}
+
+//encore:api private method=POST path=/workitems.UpdateLabel
+// Renames and/or recolors. Scope (OrgID/ProjectID) is immutable.
+func UpdateLabel(ctx context.Context, req UpdateLabelRequest) (*Label, error)
+
+type UpdateLabelRequest struct {
+    LabelID     string
+    Name        *string // rename
+    Color       *string // recolor "#RRGGBB"
+    Description  *string
+}
+
+//encore:api private method=POST path=/workitems.DeleteLabel
+// Deletes the label; the workitems.item_labels junction rows cascade
+// (ON DELETE CASCADE per SPEC §9.4.3). Items are not deleted.
+func DeleteLabel(ctx context.Context, req DeleteLabelRequest) (*DeleteLabelResponse, error)
+
+type DeleteLabelRequest struct {
+    LabelID string
+}
+type DeleteLabelResponse struct {
+    Deleted           bool
+    LabelID           string
+    DetachedItemCount int // number of item_labels rows removed by the cascade
 }
 ```
 
@@ -1216,10 +1335,19 @@ Per FR-12, P01 exposes **one logical public endpoint**: `POST /mcp` +
 
 ---
 
-## 6. The 14 P01 MCP Tools (JSON-locked)
+## 6. The 23 P01 MCP Tools (JSON-locked)
 
 Tool names match SPEC §5.2.2. Every tool returns either a typed result
 object or a JSON-RPC error object per §7.
+
+> **Round-16 inventory (2026-06-04).** P01 exposes **23** agent-facing
+> tools (was 14). Tools 1–14 are the original core set; round-16 adds
+> Tool 15 `promote` (bead `unblock-tv8.71`), Tools 16–19 milestone tools
+> (`create_milestone` / `update_milestone` / `assign_item` /
+> `milestone_tree`, bead `unblock-tv8.74`), and Tools 20–23 label-registry
+> tools (`create_label` / `list_labels` / `update_label` / `delete_label`,
+> bead `unblock-tv8.75`). The v1.0 total is **27** (these 23 + the 4 memory
+> tools at P02). See §6.6 for the status transition map `promote` closes.
 
 The arguments and result schemas below are **canonical** for P01. Phase 02
 may add fields (additive only); existing fields are immutable.
@@ -1304,18 +1432,22 @@ in chunks.
 
 ### 6.2 Tool-by-tool contracts
 
-> **Round-2 D1 deferral note.** Milestone CRUD MCP tools
-> (`create_milestone`, `update_milestone`, `assign_item`,
-> `milestone_tree`) are **NOT** in the P01 14-tool inventory. They ship
-> in P02 alongside the four memory tools (option (c) preserves PRD FR-8
-> "18 tools at v1.0"). The `workitems.CreateMilestone`,
+> **Round-16 milestone-tools note (OVERRIDES the round-2 D1 deferral).**
+> The original round-2 D1 deferral note read: "Milestone CRUD MCP tools
+> are NOT in the P01 14-tool inventory; they ship in P02 alongside the
+> memory tools (option (c) preserves PRD FR-8 '18 tools at v1.0')." Bead
+> `unblock-tv8.74` **reverses** that deferral. The four milestone MCP
+> tools `create_milestone` / `update_milestone` / `assign_item` (incl.
+> unassign) / `milestone_tree` ship in P01 as **Tools 16–19** (§6.2),
+> thin MCP facades over the `workitems.CreateMilestone`,
 > `workitems.UpdateMilestone`, `workitems.AssignItem`, and
-> `workitems.MilestoneTree` private RPCs (§4.4.1) ARE available in P01
-> for the E2E exit-criterion test (`apps/api/exitcriteriontest/`,
-> round-12) and the future Astro client (P05). Tool 4 (`create`) and
-> Tool 5 (`update`) accept a `milestone_id` field that references an
-> existing milestone — they do not create or modify milestone rows.
-> Tool 8 (`list`) accepts `milestone_id` as a filter.
+> `workitems.MilestoneTree` private RPCs (§4.4.1) that already exist. The
+> FR-8 figure is reconciled from "18 tools at v1.0" to "27 tools at v1.0"
+> (P01=23, +4 memory at P02) across PRD / SPEC / plan in lockstep (round-16
+> changelog). Tool 4 (`create`) and Tool 5 (`update`) still accept a
+> `milestone_id` field that references an existing milestone — they do not
+> create or modify milestone rows; Tool 8 (`list`) still accepts
+> `milestone_id` as a filter.
 
 #### Tool 1 — `prime`
 
@@ -1495,12 +1627,41 @@ dispatch).
 // structuredContent
 {
   "item": { /* Item */ },
+  "parent": { "id": "<ULID>", "title": "...", "status": "..." },  // null when item has no parent (round-16 / tv8.76)
   "comments": [ /* Comment[] ordered by created_at asc */ ],
-  "dependencies_in":  [ /* Edge[] where to_item = item_id */ ],
-  "dependencies_out": [ /* Edge[] where from_item = item_id */ ],
+  "dependencies_in":  [ /* ResolvedRef[] — see below; one per Edge where to_item = item_id */ ],
+  "dependencies_out": [ /* ResolvedRef[] — see below; one per Edge where from_item = item_id */ ],
   "findings":         [ /* Item[] of children with type=finding */ ]
 }
+
+// ResolvedRef shape (round-16 / tv8.76)
+{
+  "id":     "<ULID>",   // the dependency edge's target item id
+  "title":  "...",      // the target item's title
+  "status": "...",      // the target item's Status enum (§6.1)
+  "kind":   "blocks"    // the edge kind ("blocks" | "related") — carried so the agent keeps edge semantics
+}
 ```
+
+**Reference resolution (round-16, bead `unblock-tv8.76`).** `show` now
+resolves the parent and the direct in/out dependency targets to
+`{id, title, status}` objects instead of returning bare IDs, so an agent
+can render the immediate neighbourhood without N follow-up `show`/`get`
+calls. Resolution is **bounded to exactly one level** — the resolved
+neighbours' OWN parents and dependencies are NOT walked; `dependencies_in`
+/ `dependencies_out` carry one `ResolvedRef` per direct edge and nothing
+transitive. `parent` is `null` when the item has no parent epic.
+Payload is bounded: the direct in/out edge sets are already capped by the
+per-project graph degree at v1 scale, and each `ResolvedRef` carries only
+the four scalar fields above (no body, no comment trail, no nested
+findings) — the full neighbour record is reachable via a follow-up
+`show(<neighbour-id>)`. Resolution joins `workitems.items` once per
+direction inside `workitems.GetTrail` (the backing RPC); all resolved
+rows are RBAC-scoped identically to the root item, so a cross-tenant or
+unauthorised neighbour is omitted rather than leaked. The §4.4 `Trail`
+struct's `DependenciesIn` / `DependenciesOut` are widened from `[]Edge`
+to a resolved form in lockstep (the `Edge.ToItem`/`Edge.FromItem` ids are
+joined to the target item's `title` + `status` at query time).
 
 #### Tool 8 — `list`
 
@@ -1906,6 +2067,239 @@ observes `qa_state='failed'`, it resets both review and qa to
 `recent_kinds[]` returns the most recent `(kind, status)` per `kind`
 (grouped, ordered by `created_at desc`, one row per kind).
 
+#### Tool 15 — `promote` (round-16, bead `unblock-tv8.71`)
+
+Transitions a Backlog item to Ready. This is the canonical Ready writer
+that round-12 DRIFT-2 observed was missing ("the state-machine does not
+allow the canonical fixture's Done/Ready end-states via RPC"). `promote`
+plus the full §6.6 transition map close that gap.
+
+```jsonc
+// arguments
+{
+  "item_id": "<ULID>"
+}
+
+// structuredContent (success)
+{
+  "item": { /* Item with status=Ready */ }
+}
+```
+
+**Precondition.** `status = 'Backlog' AND is_ready = true`. The item must
+already be in Backlog AND have no unresolved incoming `blocks` edges
+(i.e. `is_ready` is `true` — every blocker is `Done`). Recall `is_ready`
+is a single-writer materialised column (§6.3.0 Regime A); `promote` READS
+it and does NOT recompute it.
+
+**Rejections (§7 error envelope).**
+
+- Not in Backlog OR not ready → `PRECONDITION_NOT_MET` with the round-16
+  `{status, required}` extension (defined once in §7): `data.status`
+  carries the item's CURRENT `status` and `data.required = "Ready"`. When
+  the block is specifically "still has open blockers", the handler also
+  sets `data.missing = "is_ready"` so the agent can disambiguate "wrong
+  status" from "blocked". Example:
+  `{ "kind": "PRECONDITION_NOT_MET", "status": "Backlog", "required": "Ready", "missing": "is_ready" }`.
+- Item not found / not visible → `NOT_FOUND`.
+
+**Transition performed.** Inside a single `SELECT … FOR UPDATE`
+transaction: re-check the precondition against the locked row, then
+`UPDATE workitems.items SET status = 'Ready' WHERE id = $item_id`.
+`promote` writes NO state-dimension columns (`impl_state` etc.) and
+does NOT touch `is_ready` or `claimed_by_*`.
+
+**Side-effects.** None on the cascade subsystem: moving an item
+Backlog→Ready does not change any OTHER item's `is_ready` (it has no
+effect on items that depend on it — `is_ready` of a dependent flips only
+when ITS blocker becomes `Done`, not merely Ready) and does not change
+§5.7.1 `pipeline_stage` derivation inputs. `promote` therefore publishes
+no `CascadeRequested` and is not a Regime A `is_ready` writer.
+
+#### Tool 16 — `create_milestone` (round-16, bead `unblock-tv8.74`)
+
+Thin MCP facade over `workitems.CreateMilestone` (§4.4.1). Org- or
+project-scoped (XOR); RBAC-gated (`org.Authorize` on
+`workitems.milestones`, action `write`). Enforces M-INV-1/2/3/5/6 per the
+backing RPC.
+
+```jsonc
+// arguments — mirrors workitems.CreateMilestoneRequest
+{
+  "org_id": "<ULID; XOR project_id>",
+  "project_id": "<ULID; XOR org_id>",
+  "parent_milestone_id": "<ULID; optional>",
+  "name": "Q1",
+  "description": "...",
+  "start_date": "2026-01-01",   // ISO date
+  "end_date":   "2026-03-31"    // ISO date; >= start_date
+}
+
+// structuredContent
+{ "milestone": { /* Milestone (§4.4.1) */ } }
+```
+
+Invariant violations surface as `PRECONDITION_NOT_MET` with
+`data.invariant` (`"M-INV-2"` … `"M-INV-6"`) per §4.4.1; scope/date CHECK
+failures surface as `VALIDATION`.
+
+#### Tool 17 — `update_milestone` (round-16, bead `unblock-tv8.74`)
+
+Thin MCP facade over `workitems.UpdateMilestone` (§4.4.1). Updates name,
+description, start/end dates, and cancellation. **Reparenting is rejected**
+in P01 (`VALIDATION`) exactly as the backing RPC specifies. RBAC-gated.
+
+```jsonc
+// arguments — mirrors workitems.UpdateMilestoneRequest
+{
+  "milestone_id": "<ULID>",
+  "name": "<string; optional>",
+  "description": "<string; optional>",
+  "start_date": "<ISO date; optional>",
+  "end_date": "<ISO date; optional>",
+  "cancelled_at": "<ts; optional>",
+  "cancelled_reason": "<string; optional>"
+}
+
+// structuredContent
+{ "milestone": { /* Milestone */ } }
+```
+
+#### Tool 18 — `assign_item` (round-16, bead `unblock-tv8.74`)
+
+Thin MCP facade over `workitems.AssignItem` (§4.4.1). Assigns a work item
+to a milestone, or **unassigns** when `milestone_id` is the empty string
+(clears `milestone_id` + `milestone_assigned_at` + `milestone_assigned_by`).
+Enforces M-INV-7. RBAC-gated on `workitems.items` (action `write`).
+
+```jsonc
+// arguments — mirrors workitems.AssignItemRequest
+{
+  "item_id": "<ULID>",
+  "milestone_id": "<ULID; empty string = unassign>"
+}
+
+// structuredContent
+{ "assigned": true, "item_id": "<ULID>", "milestone_id": "<ULID|null>" }
+```
+
+`assigned_by_user` is taken from the caller's resolved `Identity`
+(not a client-supplied argument). M-INV-7 violation →
+`PRECONDITION_NOT_MET` with `data.invariant = "M-INV-7"`.
+
+#### Tool 19 — `milestone_tree` (round-16, bead `unblock-tv8.74`)
+
+Thin MCP facade over `workitems.MilestoneTree` (§4.4.1). Returns the
+recursive milestone tree (depth bounded at M-INV-6 = 4). RBAC-gated
+(action `read`).
+
+```jsonc
+// arguments — mirrors workitems.MilestoneTreeRequest
+{
+  "org_id": "<ULID; required when root_milestone_id empty, XOR project_id>",
+  "project_id": "<ULID; required when root_milestone_id empty, XOR org_id>",
+  "root_milestone_id": "<ULID; optional>",
+  "include_cancelled": false
+}
+
+// structuredContent
+{ "roots": [ /* MilestoneNode[] (§4.4.1) */ ] }
+```
+
+#### Tool 20 — `create_label` (round-16, bead `unblock-tv8.75`)
+
+Label-registry management over the existing `workitems.labels` table
+(PRD §6.4). Org- or project-scoped (XOR, enforced by the existing
+`labels_scope_xor_chk` CHECK). RBAC-gated (`org.Authorize` on
+`workitems.labels`, action `write`). Backed by a new private RPC
+`workitems.CreateLabel`.
+
+```jsonc
+// arguments
+{
+  "org_id": "<ULID; XOR project_id>",
+  "project_id": "<ULID; XOR org_id>",
+  "name": "bug",            // 1..64 chars; unique within scope
+  "color": "#d73a4a",       // hex color; validated #RRGGBB
+  "description": "<string; optional>"
+}
+
+// structuredContent
+{ "label": { "id": "<ULID>", "org_id": "<ULID|null>", "project_id": "<ULID|null>", "name": "bug", "color": "#d73a4a", "description": "..." } }
+```
+
+A duplicate `name` within the same scope → `CONFLICT` with
+`data.constraint` naming the UNIQUE index; malformed color/name →
+`VALIDATION`.
+
+#### Tool 21 — `list_labels` (round-16, bead `unblock-tv8.75`)
+
+Lists labels visible to the caller within a scope. Project labels and the
+org labels reachable from that project are both returned; the PRD §6.4
+"project wins on identical name" resolution is applied at query time.
+RBAC-gated (action `read`). Backed by `workitems.ListLabels`.
+
+```jsonc
+// arguments
+{
+  "org_id": "<ULID; optional>",
+  "project_id": "<ULID; optional — when set, returns project labels + inherited org labels>"
+}
+
+// structuredContent
+{ "labels": [ /* Label objects (same shape as create_label result) */ ] }
+```
+
+#### Tool 22 — `update_label` (round-16, bead `unblock-tv8.75`)
+
+Renames and/or recolors an existing label. Cannot change a label's scope
+(`org_id` / `project_id` are immutable — a scope change is a
+delete-then-create). RBAC-gated (action `write`). Backed by
+`workitems.UpdateLabel`.
+
+```jsonc
+// arguments
+{
+  "label_id": "<ULID>",
+  "name": "<string; optional>",       // rename
+  "color": "<#RRGGBB; optional>",     // recolor
+  "description": "<string; optional>"
+}
+
+// structuredContent
+{ "label": { /* updated Label */ } }
+```
+
+A rename that collides with an existing label in the same scope →
+`CONFLICT`.
+
+#### Tool 23 — `delete_label` (round-16, bead `unblock-tv8.75`)
+
+Deletes a label from the registry. The many-to-many
+`workitems.item_labels` rows referencing it are removed in the same
+transaction (the existing junction-table FK is `ON DELETE CASCADE` per
+SPEC §9.4.3) — deleting a label detaches it from every item; it does NOT
+delete the items. RBAC-gated (action `delete`). Backed by
+`workitems.DeleteLabel`.
+
+```jsonc
+// arguments
+{ "label_id": "<ULID>" }
+
+// structuredContent
+{ "deleted": true, "label_id": "<ULID>", "detached_item_count": 0 }
+```
+
+Label not found / not visible → `NOT_FOUND`.
+
+> **Label private RPCs (round-16).** Tools 20–23 are backed by four new
+> `workitems` private RPCs — `CreateLabel`, `ListLabels`, `UpdateLabel`,
+> `DeleteLabel` — added to §4.4 in lockstep. They operate over the
+> existing `workitems.labels` / `workitems.item_labels` DDL (SPEC §9.4.3);
+> **no new migration** is required for labels (the tables already exist).
+> Each RPC is org-scoped and routed through `org.Authorize` exactly like
+> the item RPCs.
+
 ### 6.3 Cascade subsystem (Manifesto Law 1)
 
 #### 6.3.0 Propagation regimes (round-6 cascade-symmetry)
@@ -1924,6 +2318,14 @@ the same SQL transaction as the mutation, via the shared helper
 `deps.recomputeReady(ctx, tx, item_id)`. The cascade subscriber never
 writes `is_ready`. Allowed writers:
 
+- `workitems.Create` (Tool 4) — **round-16, bead `unblock-tv8.71`:** sets
+  `is_ready` INLINE at row insert. A freshly-created item with no incoming
+  `blocks` edges is `is_ready=true` (no blocker can be open); a create that
+  ever inlines an incoming blocker recomputes via the same `NOT EXISTS`
+  predicate. Before round-16 nothing set `is_ready` on the create path and
+  such items were stranded non-ready — see §6.6 for the rule and the
+  corrected create doc-comment. `status` remains `Backlog` at create;
+  `is_ready=true` makes the item immediately `promote`-able (Tool 15).
 - `workitems.Close` (Tool 6) — recomputes `is_ready` for the closed
   item's direct `blocks` neighbours inline.
 - `deps.AddEdge` (Tool 11 / §6.5 cycle-detect block) — recomputes
@@ -2208,6 +2610,74 @@ deps.CascadeRequestedTopic.Publish(ctx, &deps.CascadeRequested{
 The 256 cap is a v1.0 product constraint (RP01-3 risk in plan §7); error
 envelope on overflow includes the offending chain prefix.
 
+### 6.6 Status transition map (round-16, bead `unblock-tv8.71`)
+
+`workitems.items.Status` (§6.1 enum: `Backlog`, `Ready`, `InProgress`,
+`Blocked`, `Done`) is governed by the transition map below. Round-12
+DRIFT-2 recorded that P01 had **no Ready writer** — nothing moved an item
+into `Ready` via RPC, so the canonical fixture's Ready end-states were
+unreachable through the API. `promote` (Tool 15) is that writer; this map
+makes the full lifecycle explicit and closes DRIFT-2.
+
+| From | To | Trigger (writer) | Precondition | Notes |
+|---|---|---|---|---|
+| (create) | `Backlog` | `workitems.Create` (Tool 4) | — | Default landing status for a new item. `is_ready` is set inline at create per the rule below. |
+| `Backlog` | `Ready` | `promote` (Tool 15) | `status='Backlog' AND is_ready=true` | The new Ready writer. Rejects with §7 `PRECONDITION_NOT_MET {status, required:'Ready'}` otherwise. |
+| `Ready` | `InProgress` | `claim` (Tool 3) / `workitems.Claim` | `status='Ready' AND claimed_by_id IS NULL` | Atomic `SELECT FOR UPDATE` per §6.4. Loser → `ALREADY_CLAIMED`. |
+| `Ready` | `Blocked` | `add_dependency` (Tool 11) / `deps.AddEdge` | a new incoming `blocks` edge whose `from_item` is not `Done` is committed against a `Ready` item | **Demotion (`Ready`-only).** The §6.5 inline `is_ready` recompute flips `is_ready=false`. The demotion writer sets `status='Blocked'` ONLY when the affected item was `Ready` (unclaimed); for an `InProgress` (claimed) item it writes `is_ready=false` and LEAVES `status='InProgress'` untouched (see the note below the table). This is the inverse of `promote`: a dependency added to a Ready item demotes it. |
+| `Blocked` | `Ready` | cascade subscriber → inline `is_ready` recompute on the blocker's `close`/`remove_dependency` | every incoming `blocks` blocker is `Done` (`is_ready` flips back to `true`) | When the last blocker closes (Tool 6) or its edge is removed (Tool 12), the Regime A inline recompute (§6.3.0) flips `is_ready=true`; an item that was `Blocked` and is not yet claimed returns to `Ready` in the same write. A claimed item is never `Blocked` (see the note below), so there is no claim to preserve here; an already-`InProgress`/`Done` item is NOT re-promoted. |
+| `InProgress` | `Done` | `close` (Tool 6) / `workitems.Close` | P01: `claimed_by_id IS NOT NULL` (AF3). P02 tightens to `qa_state='passed'`. | Fires the cascade (§6.3.0 Regime A inline + Regime B publish). |
+
+**`InProgress` is never demoted (round-16, DECISION by Miguel).** Demotion
+to `Blocked` applies ONLY to `Ready` (unclaimed) items. When an
+`InProgress` (claimed) item gains a new unmet incoming `blocks` edge, the
+§6.5 inline recompute flips `is_ready=false` but the item keeps
+`status='InProgress'` — `status` is NOT changed and the claimant stays on
+the item so they can resolve the blocker. There is no `InProgress→Blocked`
+transition. When the blocker later resolves, the Regime A inline recompute
+flips `is_ready=true` and the item is simply still `InProgress` (no
+transition needed). Consequently a claimed item is NEVER `Blocked`, so no
+"Blocked-with-claim" state exists and the `Blocked→Ready` recovery row
+above never has a claim to retain.
+
+**`is_ready`-on-create rule (round-16, bead `unblock-tv8.71`).** Today
+`deps.recomputeReady` is invoked only by `close` / `add_dependency` /
+`remove_dependency` (§6.3.0 Regime A allow-list), and the cascade
+subscriber maintains `pipeline_stage` only — so a freshly-created item
+with NO incoming `blocks` edges never has its `is_ready` set by any path
+and is stranded at the column default. P01's create doc-comment implying
+"readiness is materialised by the cascade subscriber" is **misleading for
+the create case** and is corrected.
+
+Pinned rule: `workitems.Create` (Tool 4) MUST set `is_ready` INLINE,
+inside its own transaction, at the moment the item row is inserted:
+
+- If the new item is created with NO incoming `blocks` dependencies (the
+  `dependencies[]` argument contains no edge where the new item is the
+  `to_item`, which in P01 it never does — `create`'s inline edges make the
+  NEW item the `from_item`/blocker side per §4.4 `DependencyEdge`), then
+  `is_ready = true` is written inline.
+- If a future create path ever inlines an incoming `blocks` edge, the same
+  inline recompute (`NOT EXISTS (open blocker)`, identical to the §6.5
+  UPDATE predicate) decides `is_ready`.
+
+This makes `workitems.Create` a **Regime A `is_ready` writer**:
+§6.3.0's Regime A allow-list and §11.3's `no_direct_is_ready_write`
+allow-list are both extended to include `workitems.Create` (in lockstep —
+see those sections). The status at create remains `Backlog`; `is_ready`
+may be `true` (no blockers) while `status='Backlog'`, which is exactly the
+`promote` precondition — a created item with no blockers is immediately
+`promote`-able. `create` does NOT itself set `status='Ready'`; promotion
+is an explicit agent action (Tool 15) so the agent controls when a Backlog
+item enters the ready queue.
+
+**Relationship to `set_state` / `pipeline_state`.** This map governs the
+`Status` enum (the ready-queue dimension). It is orthogonal to the three
+PRD §6.2 state dimensions (`impl_state` / `review_state` / `qa_state`) and
+the `pipeline_state` exception column, which are governed by §6.2 Tool 13
+(`set_state`) and its I-1..I-5 invariants. `promote` writes ONLY `status`;
+`set_state` never writes `status`.
+
 ---
 
 ## 7. Error Envelope (locked)
@@ -2244,7 +2714,7 @@ All MCP tool errors return a JSON-RPC 2.0 error object:
 | `VALIDATION` | Argument shape / type / range violation | `{ "field": "title", "reason": "must be 1..200 chars" }` |
 | `ALREADY_CLAIMED` | `claim` loser path | `{ "winner_user_id": "...", "winner_agent": "...", "claimed_at": "..." }` |
 | `CYCLE_DETECTED` | `add_dependency` / `create` cycle reject | `{ "from": "...", "to": "...", "cycle_path": ["...", "..."] }` |
-| `PRECONDITION_NOT_MET` | Structural precondition violated (P01) or BLOCK condition (P02+) | `{ "missing": "claimed_by_id" }` or `{ "rejection_reason": "..." }` |
+| `PRECONDITION_NOT_MET` | Structural precondition violated (P01) or BLOCK condition (P02+) | `{ "missing": "claimed_by_id" }` or `{ "rejection_reason": "..." }` or (round-16) `{ "status": "Backlog", "required": "Ready" }` — see the §7.2 status-precondition extension |
 | `CONFLICT` | Optimistic concurrency or unique constraint violation | `{ "constraint": "<name>" }` |
 | `INTERNAL` | Unhandled server error (logged with full trace_id) | `{}` |
 
@@ -2335,6 +2805,61 @@ wired producer).** Two alternatives were weighed:
   `setStateOut` embeds it in P01/P02 (one wired producer); the type is
   reusable for the next producer with zero re-definition. Cross-ref §3.6
   (snake_case) and §8.1 (audit column).
+
+### 7.2 `PRECONDITION_NOT_MET` status extension (locked — round-16, owned by `unblock-tv8.71`)
+
+> **(locked, additive)** This subsection ADDS an optional `data` shape to
+> the existing `PRECONDITION_NOT_MET` kind (§7 table). It does not change
+> any existing shape — `{ "missing": … }` and `{ "rejection_reason": … }`
+> remain valid verbatim. The extension is defined ONCE here and reused by
+> every status-precondition rejection.
+
+When a tool rejects because the subject item is in the WRONG `Status`
+(§6.1 enum) for the requested operation, the `data` object carries two
+additional optional fields:
+
+```jsonc
+{
+  "kind": "PRECONDITION_NOT_MET",
+  "tool": "promote",
+  "trace_id": "<ULID>",
+  "status":   "Backlog",   // the item's CURRENT Status enum value
+  "required": "Ready",     // the Status the operation requires
+  "missing":  "is_ready"   // OPTIONAL; present when the blocker is specifically an unmet readiness/structural precondition
+}
+```
+
+- **`status`** — the item's current `Status` at the moment of rejection.
+- **`required`** — the `Status` (or readiness condition) the operation
+  demanded. For `promote`, `required = "Ready"`.
+- **`missing`** — OPTIONAL, additive to the existing `{missing}` shape;
+  when present it names the specific unmet structural precondition
+  (e.g. `"is_ready"` when a Backlog item still has open blockers, or
+  `"claimed_by_id"` for the §6.2 Tool 6 close precondition).
+
+`status` and `required` are present together or not at all. A rejection
+that is purely structural (e.g. close's `claimed_by_id IS NULL`) MAY omit
+`status`/`required` and carry only `missing`, exactly as today.
+
+**Owned by `promote` (Tool 15 / `unblock-tv8.71`); reused by:**
+
+- **`claim` (Tool 3) — bead `unblock-tv8.72`.** The
+  `claim`-on-not-Ready rejection (when an item is targeted by `claim`
+  but its `Status <> 'Ready'`, distinct from the `ALREADY_CLAIMED`
+  loser path which still uses its own kind) MUST emit
+  `PRECONDITION_NOT_MET` with `{ status: <current>, required: 'Ready' }`.
+  `unblock-tv8.72` carries no separate spec text — its error contract IS
+  this extension. (The `ALREADY_CLAIMED` kind continues to cover the
+  concurrent-claim loser path unchanged; the status extension covers the
+  "item never was Ready" path.)
+- **Milestone tools (Tools 16–19 / `unblock-tv8.74`)** — invariant
+  rejections continue to use `data.invariant` (§4.4.1); any status-shaped
+  precondition reuses this same `{status, required}` shape.
+- **`show` (Tool 7 / `unblock-tv8.76`)** — no new rejection kind; resolved
+  references that are not visible are omitted (RBAC), not error-flagged.
+
+This keeps the taxonomy consistent across `promote` and `claim`: a
+machine reading `data.required = "Ready"` handles both identically.
 
 ---
 
@@ -2640,9 +3165,11 @@ infrastructure-level correlation id and is independent of
 
 ### 10.3 Catalogue authoring (Plan §2.3 / Q4)
 
-`apps/api/mcp/catalogue.json` is **created in P01** with the 14 P01 tools'
-tool definitions, but the `block_conditions[]` arrays are **empty
-placeholders** for every transition:
+`apps/api/mcp/catalogue.json` is **created in P01** with the **23** P01
+tools' tool definitions (round-16: the 14 core tools + `promote` + the
+four milestone tools + the four label tools — see §6.2), but the
+`block_conditions[]` arrays are **empty placeholders** for every
+transition:
 
 ```jsonc
 {
@@ -2654,7 +3181,7 @@ placeholders** for every transition:
       "input_schema": { /* JSON Schema */ },
       "output_schema": { /* JSON Schema */ }
     },
-    /* ... 13 more ... */
+    /* ... 22 more (round-16: 23 tools total) ... */
   ],
   "transitions": []  // empty; populated in P02
 }
@@ -2839,7 +3366,13 @@ seeded fixture and asserts:
 - [ ] `claim` on the returned item succeeds; a second concurrent `claim` from a different agent receives `{ "kind": "ALREADY_CLAIMED", ... }`.
 - [ ] `set_state(impl_state=done)` on the claimed item is accepted (structural invariant only — `claimed_by_id` is set).
 - [ ] `close` on the same item succeeds (P01 relaxation: `claimed_by_id IS NOT NULL` is the only precondition); cascade subscriber fires.
-- [ ] After cascade, `prime` reflects newly unblocked dependents (`itm_c`, `itm_d` flip to ready).
+- [ ] After cascade, `prime` reflects newly unblocked dependents (`itm_c`, `itm_d` flip `is_ready=true`); they remain `status='Backlog'` until promoted.
+- [ ] **`promote` (round-16, bead `unblock-tv8.71`).** `promote(item_id=itm_c)` — where `itm_c` is `status='Backlog' AND is_ready=true` after the cascade above — succeeds and returns the item with `status='Ready'`; a subsequent `ready` lists `itm_c`. `promote` on an item that is still blocked (e.g. an item with an open `blocks` parent, `is_ready=false`) is rejected with `{ "kind": "PRECONDITION_NOT_MET", "status": "Backlog", "required": "Ready", "missing": "is_ready" }` per §7.2; `promote` on an already-`Ready` item is rejected with `{ "kind": "PRECONDITION_NOT_MET", "status": "Ready", "required": "Ready" }`.
+- [ ] **`is_ready`-on-create (round-16, bead `unblock-tv8.71`).** A `create` of a fresh `type=task` item with no inline dependencies returns an item whose `is_ready=true` and `status='Backlog'` (asserts the inline create-path write, not subscriber materialisation); the item is immediately `promote`-able.
+- [ ] **`claim`-on-not-Ready (round-16, bead `unblock-tv8.72`).** `claim` on an item whose `Status <> 'Ready'` (e.g. a Backlog item that was never promoted) is rejected with `{ "kind": "PRECONDITION_NOT_MET", "status": "Backlog", "required": "Ready" }` per §7.2 — the SAME extension `promote` defines (distinct from the `ALREADY_CLAIMED` concurrent-loser path).
+- [ ] **`issued_to_user` REQUIRED (round-16, bead `unblock-tv8.73`).** `auth.IssueAPIKey` with an empty `issued_to_user` is rejected with `InvalidArgument`; a successfully-issued key resolves (§4.3.2) to an `Identity` whose `UserID` is non-empty. (DDL-level: the `0110` migration makes `mcp.api_keys.issued_to_user` NOT NULL.)
+- [ ] **`show` reference resolution (round-16, bead `unblock-tv8.76`).** `show(itm_b)` returns `parent` (or `null`), and `dependencies_in` / `dependencies_out` as `ResolvedRef[]` each carrying `{id, title, status, kind}` for the DIRECT neighbours only — assert the neighbour's `title` + `status` are populated and that the resolution is one level deep (the neighbour's own dependencies are NOT present in the payload).
+- [ ] **Milestone + label MCP tools reachable (round-16, beads `unblock-tv8.74` / `unblock-tv8.75`).** The harness drives `create_milestone` → `assign_item` → `milestone_tree` through the MCP boundary (not just the private RPCs) and asserts the tree shape; and drives `create_label` → `list_labels` → `update_label` → `delete_label`, asserting the registry round-trips and `delete_label` detaches the label from any items it was applied to.
 - [ ] `add_dependency(from=itm_e, to=itm_a)` is rejected with `CYCLE_DETECTED` (would form `itm_a → itm_b → … → itm_e → itm_a`; the §11.1.0 fixture includes the `itm_d → itm_e` edge that closes the chain when the cycle-attempt edge is added).
 - [ ] `deps.cascade_events` has one row per fired cascade with a populated `event_id` and the affected set; `kind='close'` for the cascade triggered by Tool 6 above.
 - [ ] **Cascade-symmetry kinds (round-6 §6.3.0).** The exit-criterion
@@ -3019,6 +3552,8 @@ seeded fixture and asserts:
     (Regime A).** `is_ready` is recomputed inline by the call site
     that mutated the row/edge — the cascade subscriber MUST NOT write
     `is_ready`. Explicit allowlist of permitted writers:
+    `workitems.Create` (Tool 4 — **round-16, bead `unblock-tv8.71`:**
+    inline `is_ready` set at row insert per §6.6),
     `workitems.Close` (Tool 6 — inline recompute on direct `blocks`
     neighbours), `deps.AddEdge` (Tool 11 / §6.5 — inline recompute on
     `to_item`), `deps.RemoveEdge` (Tool 12 — inline recompute on
@@ -3026,7 +3561,9 @@ seeded fixture and asserts:
     `deps.recomputeReady` (called by the above sites). Integration
     test asserts the cascade subscriber never UPDATEs `is_ready`; an
     additional static check in the linter rule asserts the allowlist
-    above is exhaustive.
+    above is exhaustive. The `apps/api/shared/lint/no_direct_is_ready_write.go`
+    allowlist gains the `workitems.Create` insert site in lockstep with
+    this round.
 - [ ] `rbac.For` and `rbac.ScopedQuery.Where` are never called with
   runtime-constructed string arguments — every table identifier (For
   arg 2) AND every clause string (Where arg 1) MUST be a Go string
@@ -3062,8 +3599,8 @@ seeded fixture and asserts:
 
 - [ ] `docs/specs/01-spec-backend-mvp.md` is **APPROVED** before
   implementation starts (this document).
-- [ ] README.md updated with P01 user surface (MCP Bearer auth, the 14
-  tools' one-liners). The former `unblock-seed` invocation deliverable
+- [ ] README.md updated with P01 user surface (MCP Bearer auth, the 23
+  tools' one-liners — round-16). The former `unblock-seed` invocation deliverable
   is dropped (round-12 — seeder CLI deleted from P01 scope; the
   exit-criterion fixture is now seeded by the E2E test itself per
   §11.1.1).
@@ -3091,26 +3628,27 @@ section that locks its contract:
 |---|---|---|
 | A-1 (Encore app init) | Greta | §3.1 (migration owner), §4 (service skeletons) |
 | A-2 (Bootstrap migration) | Greta | §3.2 (`0010_bootstrap.up.sql`), §3.5 (secrets) |
-| A-3 (Migrations §9.4.1–§9.4.8) | Greta | §3.2 (migrations 0020..0090), §3.4 (FTS DDL) |
+| A-3 (Migrations §9.4.1–§9.4.8 + round-16 `0110`) | Greta | §3.2 (migrations 0020..0090; round-16 `0110_mcp_issued_to_user_notnull` per bead `unblock-tv8.73`), §3.4 (FTS DDL) |
 | A-4 (`pkg/rbac`) | Greta | §10.1 |
 | A-5 (Tracing scaffold) | Greta | §10.2 |
 | A-6 (CI gates) | Olive | §11.2 (NFR-10 commands) |
-| B-1 (`auth` service) | Greta | §4.1, §4.3.2 (API key hot path), §4.3.3 |
+| B-1 (`auth` service; round-16 `issued_to_user` REQUIRED) | Greta | §4.1 (`IssueAPIKey` rejects empty `IssuedToUser`), §4.3.2 step 8 (no empty-UID identity), §4.3.3 — bead `unblock-tv8.73` |
 | B-2 (`org` service) | Greta | §4.2 |
 | B-3 (RBAC suite) | Greta | §10.1, §11.2 (NFR-2) |
-| C-1 (`workitems` service) | Greta | §4.4, §4.4.1 (milestone RPCs — round-2 D1) |
+| C-1 (`workitems` service; round-16 label RPCs) | Greta | §4.4 (incl. round-16 `CreateLabel`/`ListLabels`/`UpdateLabel`/`DeleteLabel` private RPCs per bead `unblock-tv8.75`; `is_ready`-on-create per §6.6), §4.4.1 (milestone RPCs — round-2 D1) |
 | C-2 (`deps` service + cycle CTE) | Greta | §4.5, §6.5, §6.3.0 (post-commit publishes for `edge_added` and `edge_removed`) |
 | C-3 (Cascade subsystem) | Greta | §6.3, §6.3.0 (four-Reason dispatch; `pipeline_stage`-only writer) |
 | C-4 (Atomic claim) | Greta | §6.4 (incl. I-3-reset `state_change` publish per §6.3.0) |
 | C-5 (`pipeline_stage` derivation tests) | Greta | §6.3.2, §6.3.0, SPEC §5.7.1 |
 | C-6 (RBAC suite extensions) | Greta | §10.1 |
 | D-1 (MCP transport skeleton) | Greta | §5, §4.3.1, §4.3.2 |
-| D-2 (Tools 1–4) | Greta | §6.2 (tools 1–4) |
-| D-3 (Tools 5–8) | Greta | §6.2 (tools 5–8) |
+| D-2 (Tools 1–4 + round-16 `promote` + `is_ready`-on-create) | Greta | §6.2 (tools 1–4 + Tool 15 `promote`), §6.6 (status transition map + `is_ready`-on-create rule, beads `unblock-tv8.71`/`unblock-tv8.72`), §7.2 (`{status,required}` extension) |
+| D-3 (Tools 5–8; round-16 `show` reference resolution) | Greta | §6.2 (tools 5–8, incl. Tool 7 `show` `{id,title,status}` resolution per bead `unblock-tv8.76`), §4.4 (`Trail` / `ResolvedRef` widening) |
 | D-4 (Tools 9–10) | Greta | §6.2 (tools 9–10), §3.4 (FTS), §6.2 #9 |
 | D-5 (Tools 11–12) | Greta | §6.2 (tools 11–12), §6.5 |
 | D-6 (Tools 13–14) | Greta | §6.2 (tools 13–14) |
-| D-7 (Catalogue v0) | Greta | §10.3 |
+| D-7 (Catalogue v0; round-16 23 tools) | Greta | §10.3 (catalogue carries all 23 P01 tool definitions) |
+| D-8 (round-16 milestone + label MCP tools — Tools 16–23) | Greta | §6.2 (Tools 16–19 milestone facades per bead `unblock-tv8.74`; Tools 20–23 label tools per bead `unblock-tv8.75`), §4.4 (label RPCs), §4.4.1 (milestone RPCs) |
 | E-2 (NFR-1 latency harness) | Greta | §11.2 (warm-cache definition) |
 | E-3 (NFR-2 RBAC suite) | Greta | §10.1, §11.2 |
 | E-4 (Exit-criterion E2E test) | Greta | §11.1 (incl. §11.1.0 fixture topology + §11.1.1 seed ownership), §6.3 (cascade), §6.5 (cycle) |
@@ -3148,8 +3686,10 @@ confirms:
 
 - [ ] All seven research contradictions (C1, C2, C3, C5, C6, C7 + AF1/AF5)
   are honoured in the design above.
-- [ ] The 14 MCP tool contracts are signature-locked and no field is
-  ambiguous (every "optional" / "default" stated explicitly).
+- [ ] The 23 MCP tool contracts (round-16: 14 core + `promote` + 4
+  milestone + 4 label) are signature-locked and no field is ambiguous
+  (every "optional" / "default" stated explicitly). v1.0 total is 27
+  (+4 memory at P02).
 - [ ] Migration filenames and numbering are agreed.
 - [ ] Error envelope kinds and `data` shapes cover every failure mode the
   exit-criterion harness exercises.


### PR DESCRIPTION
## Round-16 — P01 MCP tool-surface scope amendment

In-place amendment to the approved P01 spec, surfaced by the 2026-06-03 local-MCP demo + 2026-06-04 review. Covers epic `unblock-tv8` beads `.71`/`.72`/`.73`/`.74`/`.75`/`.76`.

### Tool inventory (reconciled in lockstep across 4 docs)
- **P01: 14 → 23** tools (+`promote`, +4 milestone, +4 label)
- **v1.0: 18 → 27** tools (23 P01 + 4 memory at P02)
- Identical in `docs/specs/01-spec-backend-mvp.md`, `docs/PRD.md` (FR-8), `docs/SPEC.md` (§5.2.2), `docs/plans/01-plan-backend-mvp.md`

### Changes by bead
- **`.71`** (keystone) — new `promote` tool (Backlog→Ready); `is_ready`-on-create rule; **§6.6** full status transition map; **§7.2** additive `PRECONDITION_NOT_MET {status, required}` extension. Decision: **InProgress is never demoted** — demotion is `Ready`-only.
- **`.72`** — `claim`-on-not-Ready reuses the `.71` §7.2 error (implementation; blocked-by `.71`).
- **`.73`** — `issued_to_user` NOT NULL + FK `ON DELETE CASCADE` (new migration `0110`); `IssueAPIKey` rejects an empty user.
- **`.74`** — milestone MCP tools (16–19), overriding the prior P02 deferral.
- **`.75`** — label-registry MCP tools (20–23).
- **`.76`** — `show` resolves parent + direct deps to `{id, title, status}`.

### Notes
- Spec status remains **APPROVED** (in-place round-16, not a re-architecting).
- §7.2 extension is **additive** — existing `{missing}`/`{rejection_reason}` shapes unchanged.
- Beads reconciled: dep `.72`→`.71` set; `needs-spec` label cleared on `.73`/`.74`/`.75`/`.76`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)