### PR TITLE
unblock-tv8.72: claim on not-Ready returns PRECONDITION_NOT_MET, not misleading ALREADY_CLAIMED

### DIFF
--- a/apps/api/exitcriteriontest/claim_not_ready_test.go
+++ b/apps/api/exitcriteriontest/claim_not_ready_test.go
@@ -1,0 +1,85 @@
+// claim_not_ready_test.go covers the §11.1.2 round-16 (bead
+// unblock-tv8.72) MCP-boundary assertion for the claim-on-not-Ready
+// precondition:
+//
+//   - claim on an item whose Status <> 'Ready' (a fresh Backlog item
+//     that was never promoted) is rejected with PRECONDITION_NOT_MET
+//     carrying data.details {status:'Backlog', required:'Ready'} per §7.2
+//     — the SAME status-extension promote defines — and NO `missing`
+//     (claim's block is the wrong status, not an unmet readiness gate).
+//     This is DISTINCT from the ALREADY_CLAIMED concurrent-loser path.
+//
+// Before bead unblock-tv8.72 the SELECT … FOR UPDATE filtered the lock
+// by (status='Ready' AND claimed_by_id IS NULL), so a never-Ready,
+// unclaimed Backlog item produced zero rows and funnelled to the
+// unconditional ALREADY_CLAIMED loser arm — mis-reporting it as already
+// claimed (with no winner info), so the agent could not tell "never
+// Ready" from "lost the race".
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md § 6.4 (atomic claim) +
+// § 7.2 ({status, required} extension, reused by claim Tool 3) +
+// § 11.1.2 L3378 (the claim-on-not-Ready functional assertion).
+
+package exitcriteriontest_test
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestExitCriterion_ClaimNotReady drives create → (do NOT promote) →
+// claim through the MCP boundary and asserts the §7.2 status-precondition
+// envelope. Single Mcp-Session-Id across the sequence.
+func TestExitCriterion_ClaimNotReady(t *testing.T) {
+	f := fx(t)
+	ctx := t.Context()
+	sessionID := initializeSession(t, f.RawKey)
+
+	// Create a fresh item. With no inline dependencies it is is_ready=true
+	// but status='Backlog' (§6.6 is_ready-on-create). We deliberately do
+	// NOT promote it, so its Status stays 'Backlog'.
+	createEnv := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+		"project_id": f.ProjectID,
+		"type":       "task",
+		"title":      "claim-not-ready-target",
+	})
+	var created createOutItem
+	if err := json.Unmarshal(expectSuccess(t, createEnv), &created); err != nil {
+		t.Fatalf("unmarshal create result: %v", err)
+	}
+	if created.Item.ID == "" {
+		t.Fatalf("create returned empty item id")
+	}
+	if created.Item.Status != "Backlog" {
+		t.Fatalf("create: status = %q, want Backlog", created.Item.Status)
+	}
+	// Belt-and-suspenders: confirm the persisted row is Backlog before the
+	// claim, so the rejection we assert is genuinely the not-Ready path.
+	assertDBStatus(t, ctx, created.Item.ID, "Backlog")
+
+	// Claim the never-promoted Backlog item. It must reject with the §7.2
+	// status extension, NOT ALREADY_CLAIMED.
+	claimEnv := callTool(t, f.RawKey, sessionID, "claim", map[string]any{
+		"item_id": created.Item.ID,
+	})
+	data := expectError(t, claimEnv)
+	if data.Kind != "PRECONDITION_NOT_MET" {
+		t.Fatalf("claim-not-Ready: kind = %q, want PRECONDITION_NOT_MET (not ALREADY_CLAIMED)", data.Kind)
+	}
+	if got, _ := data.Details["status"].(string); got != "Backlog" {
+		t.Fatalf("claim-not-Ready: details.status = %q, want Backlog; details=%+v", got, data.Details)
+	}
+	if got, _ := data.Details["required"].(string); got != "Ready" {
+		t.Fatalf("claim-not-Ready: details.required = %q, want Ready; details=%+v", got, data.Details)
+	}
+	// claim's wrong-status rejection carries NO `missing` (that is
+	// promote's is_ready disambiguator only — claim has no readiness gate,
+	// just a wrong-status block).
+	if _, present := data.Details["missing"]; present {
+		t.Fatalf("claim-not-Ready: details.missing present (%v), want absent (the block is wrong status, not unmet readiness)", data.Details["missing"])
+	}
+	// And it is NOT the ALREADY_CLAIMED loser path — no winner info.
+	if _, present := data.Details["winner_user_id"]; present {
+		t.Fatalf("claim-not-Ready: details.winner_user_id present (%v), want absent (not the ALREADY_CLAIMED path)", data.Details["winner_user_id"])
+	}
+}

--- a/apps/api/exitcriteriontest/claim_not_ready_test.go
+++ b/apps/api/exitcriteriontest/claim_not_ready_test.go
@@ -38,6 +38,12 @@ func TestExitCriterion_ClaimNotReady(t *testing.T) {
 	// Create a fresh item. With no inline dependencies it is is_ready=true
 	// but status='Backlog' (§6.6 is_ready-on-create). We deliberately do
 	// NOT promote it, so its Status stays 'Backlog'.
+	//
+	// NOTE: this MCP create path yields is_ready=true, whereas the
+	// workitems-level createBacklogItem helper seeds is_ready=false. Both
+	// are intentional — is_ready is irrelevant to claim's status gate, which
+	// keys only on Status<>'Ready', so either is_ready value drives the same
+	// PRECONDITION_NOT_MET rejection asserted below.
 	createEnv := callTool(t, f.RawKey, sessionID, "create", map[string]any{
 		"project_id": f.ProjectID,
 		"type":       "task",

--- a/apps/api/workitems/integration_test.go
+++ b/apps/api/workitems/integration_test.go
@@ -153,6 +153,28 @@ func createReadyItem(t *testing.T, ctx context.Context, fx *fixture) string {
 	return id
 }
 
+// createBacklogItem inserts a Backlog, unclaimed task directly via SQL.
+// Used by the claim-not-Ready precondition tests (bead unblock-tv8.72):
+// a fresh Backlog item is the demo case that was mis-reported as
+// ALREADY_CLAIMED. is_ready is irrelevant to claim's status precondition,
+// so it is left at its column default (false).
+func createBacklogItem(t *testing.T, ctx context.Context, fx *fixture) string {
+	t.Helper()
+	id, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	if _, err := encoredb.DB.Exec(ctx,
+		`INSERT INTO workitems.items
+		   (id, org_id, project_id, type, title, status, is_ready)
+		 VALUES ($1, $2, $3, 'task', 'test task', 'Backlog', false)`,
+		id, fx.OrgID, fx.ProjectID,
+	); err != nil {
+		t.Fatalf("insert item: %v", err)
+	}
+	return id
+}
+
 // setItemState sets state columns + claim columns directly. Used only
 // by state-machine invariant tests that need a known starting state.
 // Does NOT touch is_ready or pipeline_stage (lint-protected).
@@ -456,6 +478,66 @@ func TestClaimLoserPath(t *testing.T) {
 	e := err.(*errs.Error)
 	if e.Meta["winner_user_id"] != fx.UserID {
 		t.Fatalf("meta[winner_user_id] = %v, want %q", e.Meta["winner_user_id"], fx.UserID)
+	}
+}
+
+// TestClaimRejectsNotReady asserts a fresh, unclaimed Backlog item is
+// rejected with PRECONDITION_NOT_MET (errs.FailedPrecondition) carrying
+// Meta{status:'Backlog', required:'Ready'} and NO winner_user_id — the
+// regression fixed by bead unblock-tv8.72 (§7.2). Previously this case
+// funnelled to the unconditional alreadyClaimedError loser arm and was
+// mis-reported as ALREADY_CLAIMED with no winner info.
+func TestClaimRejectsNotReady(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+	itemID := createBacklogItem(t, ctx, fx)
+
+	_, err := workitems.Claim(ctx, &workitems.ClaimRequest{
+		ItemID: itemID, ClaimerUserID: fx.UserID, ClaimerAgent: "claude-code",
+	})
+	if err == nil {
+		t.Fatalf("expected FailedPrecondition, got nil")
+	}
+	if errs.Code(err) != errs.FailedPrecondition {
+		t.Fatalf("err code = %v, want FailedPrecondition", errs.Code(err))
+	}
+	e := err.(*errs.Error)
+	if e.Meta["status"] != "Backlog" {
+		t.Fatalf("meta[status] = %v, want Backlog", e.Meta["status"])
+	}
+	if e.Meta["required"] != "Ready" {
+		t.Fatalf("meta[required] = %v, want Ready", e.Meta["required"])
+	}
+	// §7.2 / bead unblock-tv8.72: claim's wrong-status rejection carries
+	// NO "missing" (that is promote's is_ready disambiguator only) and is
+	// NOT the ALREADY_CLAIMED loser path (no winner meta).
+	if _, ok := e.Meta["missing"]; ok {
+		t.Fatalf("meta[missing] must be absent for claim wrong-status, got %v", e.Meta["missing"])
+	}
+	if _, ok := e.Meta["winner_user_id"]; ok {
+		t.Fatalf("meta[winner_user_id] must be absent (not the ALREADY_CLAIMED path), got %v", e.Meta["winner_user_id"])
+	}
+}
+
+// TestClaimRejectsNotFound asserts claiming a non-existent item returns
+// NOT_FOUND (errs.NotFound), distinct from the loser / not-Ready arms
+// (§6.4 + bead unblock-tv8.72).
+func TestClaimRejectsNotFound(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+
+	missingID, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid: %v", err)
+	}
+	_, err = workitems.Claim(ctx, &workitems.ClaimRequest{
+		ItemID: missingID, ClaimerUserID: fx.UserID, ClaimerAgent: "claude-code",
+	})
+	if err == nil {
+		t.Fatalf("expected NotFound, got nil")
+	}
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("err code = %v, want NotFound", errs.Code(err))
 	}
 }
 

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1484,8 +1484,18 @@ func Close(ctx context.Context, req *CloseRequest) (*Item, error) {
 	return readItem(ctx, req.ItemID)
 }
 
-// Claim performs the SPEC §6.4 atomic claim transaction. On loser
-// path returns errs.AlreadyExists with Meta carrying winner info.
+// Claim performs the SPEC §6.4 atomic claim transaction. The row is
+// locked with SELECT … FOR UPDATE and the precondition
+// (status='Ready' AND claimed_by_id IS NULL) is evaluated in Go on the
+// locked row, so the three zero-row causes are reported distinctly
+// (§7.2, bead unblock-tv8.72):
+//   - item absent                      → errs.NotFound (NOT_FOUND)
+//   - claimed_by_id IS NOT NULL        → errs.AlreadyExists (ALREADY_CLAIMED)
+//     with Meta carrying winner info
+//   - status <> 'Ready' (unclaimed)    → errs.FailedPrecondition
+//     (PRECONDITION_NOT_MET) with
+//     Meta{status:<current>, required:'Ready'}
+//
 // Enforces invariant I-3 (qa_state=failed → review_state and qa_state
 // both reset to 'pending' in the same transaction).
 //
@@ -1509,46 +1519,88 @@ func Claim(ctx context.Context, req *ClaimRequest) (*Item, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// SELECT FOR UPDATE: only succeeds if status='Ready' AND not yet
-	// claimed. Zero rows means the loser path. We also project org_id
-	// and project_id here so the I-3-path cascade publish (post-commit,
-	// below) has the scope fields it needs without a second read.
-	var lockedID, orgID, projectID, qaState string
+	// SELECT FOR UPDATE on the BARE row (no status/claimed predicate),
+	// mirroring Promote's read-then-branch shape (§6.4 + §7.2, bead
+	// unblock-tv8.72). The §6.4 SQL filters the lock by
+	// (status='Ready' AND claimed_by_id IS NULL); doing the SAME filter
+	// in SQL collapses three DISTINCT zero-row causes into one ErrNoRows
+	// arm and mis-reports a never-Ready item as ALREADY_CLAIMED. Instead
+	// we lock the row unconditionally and discriminate the three cases in
+	// Go AFTER the lock (TOCTOU-safe — the FOR UPDATE serialises claim
+	// against a concurrent promote/add_dependency/claim):
+	//   - ErrNoRows                          → NOT_FOUND
+	//   - claimed_by_id IS NOT NULL          → ALREADY_CLAIMED (winner meta)
+	//   - status <> 'Ready' (and unclaimed)  → PRECONDITION_NOT_MET
+	//                                          {status:<current>, required:'Ready'}
+	// Only (status='Ready' AND claimed_by_id IS NULL) proceeds to the
+	// I-3/UPDATE path below.
+	//
+	// We also project org_id and project_id here so the I-3-path cascade
+	// publish (post-commit, below) has the scope fields it needs without a
+	// second read.
+	var lockedID, orgID, projectID, currentStatus, qaState string
+	var claimedByID *string
 	err = tx.QueryRow(ctx,
-		`SELECT id, org_id, COALESCE(project_id, ''), qa_state
+		`SELECT id, org_id, COALESCE(project_id, ''), status, claimed_by_id, qa_state
 		   FROM workitems.items
-		  WHERE id = $1 AND status = 'Ready' AND claimed_by_id IS NULL
+		  WHERE id = $1
 		  FOR UPDATE`,
 		req.ItemID,
-	).Scan(&lockedID, &orgID, &projectID, &qaState)
+	).Scan(&lockedID, &orgID, &projectID, &currentStatus, &claimedByID, &qaState)
 	if err != nil {
 		if errors.Is(err, sqldb.ErrNoRows) {
-			// Loser path — fetch winner info.
-			//
-			// Concurrency hazard: we MUST release the SELECT FOR
-			// UPDATE transaction (and its underlying pgxpool conn)
-			// BEFORE calling alreadyClaimedError, which opens a
-			// fresh pool conn via db.QueryRow. The deferred
-			// tx.Rollback above runs only at function-return, which
-			// is too late: at function entry under high concurrent
-			// claim load (N > pgxpool MaxConns), every goroutine
-			// already holds one conn for its own losing SELECT FOR
-			// UPDATE tx and the pool has zero free conns. Each
-			// loser would then queue forever for the second conn
-			// alreadyClaimedError needs, deadlocking N-way on the
-			// pool (no losers can release their first conn until
-			// they've returned from Claim, but they can't return
-			// until alreadyClaimedError completes, which can't run
-			// without a second conn). Explicit early-rollback here
-			// frees the conn back to the pool BEFORE the second
-			// acquisition is attempted, so the loser path scales
-			// linearly with N under any pool size. The deferred
-			// rollback is harmless after an explicit one — pgx
-			// treats double-rollback as a no-op (ErrTxClosed).
-			_ = tx.Rollback()
-			return nil, alreadyClaimedError(ctx, req.ItemID)
+			return nil, &errs.Error{Code: errs.NotFound, Message: "item not found"}
 		}
 		return nil, &errs.Error{Code: errs.Internal, Message: "claim lock failed"}
+	}
+
+	// Discriminate on the LOCKED row (§6.4 loser path + §7.2, bead
+	// unblock-tv8.72). This MUST run BEFORE the I-3 reset / UPDATE block
+	// below — a not-Ready or already-claimed item must never reach the
+	// claim UPDATE.
+	if claimedByID != nil {
+		// Genuine concurrent-loser path — fetch winner info and return
+		// ALREADY_CLAIMED unchanged (§6.4).
+		//
+		// Concurrency hazard: we MUST release the SELECT FOR UPDATE
+		// transaction (and its underlying pgxpool conn) BEFORE calling
+		// alreadyClaimedError, which opens a fresh pool conn via
+		// db.QueryRow. The deferred tx.Rollback above runs only at
+		// function-return, which is too late: at function entry under
+		// high concurrent claim load (N > pgxpool MaxConns), every
+		// goroutine already holds one conn for its own SELECT FOR
+		// UPDATE tx and the pool has zero free conns. Each loser would
+		// then queue forever for the second conn alreadyClaimedError
+		// needs, deadlocking N-way on the pool (no losers can release
+		// their first conn until they've returned from Claim, but they
+		// can't return until alreadyClaimedError completes, which can't
+		// run without a second conn). Explicit early-rollback here frees
+		// the conn back to the pool BEFORE the second acquisition is
+		// attempted, so the loser path scales linearly with N under any
+		// pool size. The deferred rollback is harmless after an explicit
+		// one — pgx treats double-rollback as a no-op (ErrTxClosed).
+		_ = tx.Rollback()
+		return nil, alreadyClaimedError(ctx, req.ItemID)
+	}
+	if currentStatus != statusReady {
+		// Item exists and is unclaimed but is not in Ready (e.g. a fresh
+		// Backlog item that was never promoted). §7.2 status-precondition
+		// extension: emit PRECONDITION_NOT_MET carrying the item's CURRENT
+		// status + the required status. NO "missing" — claim's block is a
+		// wrong-status, not an unmet structural readiness gate ("missing"
+		// is promote's Backlog-but-is_ready=false disambiguator only).
+		// errmap surfaces Meta[status]/[required] inside data.details.
+		// This arm opens no second pool conn, so the deferred rollback
+		// suffices (no early-rollback needed).
+		return nil, &errs.Error{
+			Code:    errs.FailedPrecondition,
+			Message: "claim requires status='Ready'",
+			Meta: errs.Metadata{
+				"invariant": "claim_requires_ready_item",
+				"status":    currentStatus,
+				"required":  statusReady,
+			},
+		}
 	}
 
 	// I-3: when claimed item has qa_state='failed', reset


### PR DESCRIPTION
## unblock-tv8.72: claim on not-Ready item returns misleading ALREADY_CLAIMED

Claim's `SELECT … FOR UPDATE` filtered the lock by `status='Ready' AND claimed_by_id IS NULL`, funnelling three distinct zero-row causes into one unconditional `ALREADY_CLAIMED` arm. A fresh, unclaimed Backlog item was mis-reported as already-claimed (with no winner info), so an agent could not distinguish "never Ready" from "lost the race".

### What was done
Approach (A), Promote-symmetric: lock the bare row unconditionally, discriminate in Go on the locked row:
- `ErrNoRows` -> `NOT_FOUND`
- `claimed_by_id IS NOT NULL` -> `ALREADY_CLAIMED` (winner meta, unchanged)
- `status <> 'Ready'` -> `PRECONDITION_NOT_MET` with `data.details {status:<current>, required:'Ready'}` per SPEC §7.2 (no `missing`)

The pool-deadlock early-rollback guard is preserved on the `ALREADY_CLAIMED` arm. `errmap` already surfaces `Meta[status]/[required]` into `data.details` (shipped by .71) — no errmap/handler change.

### Files changed
- `apps/api/workitems/workitems.go` — Claim widened SELECT + Go-side 3-way discrimination + doc-comment
- `apps/api/workitems/integration_test.go` — createBacklogItem + TestClaimRejectsNotReady + TestClaimRejectsNotFound
- `apps/api/exitcriteriontest/claim_not_ready_test.go` — new MCP-boundary assertion TestExitCriterion_ClaimNotReady

### Decisions
- Approach (A) widen-and-branch over a second bare-row read: TOCTOU-safe, single round-trip, mirrors Promote.
- Optional `Meta[invariant]='claim_requires_ready_item'` (audit parity with promote); NO `Meta[missing]` for the wrong-status case.

### Deviations
None — implemented as spec (§7.2 + §11.1.2 L3378).