### PR TITLE
unblock-tv8.73: Require issued_to_user on every MCP API key (NOT NULL; remove broken NULL-user path)

### DIFF
--- a/apps/api/auth/auth.go
+++ b/apps/api/auth/auth.go
@@ -217,11 +217,18 @@ func validateAPIKey(ctx context.Context, rawKey string) (*ValidateResponse, erro
 	// last_used_at write is a UI hint loss, not an auth failure.
 	go touchLastUsedAt(id)
 
-	// Step 8: construct Identity.
-	uid := ""
-	if issuedToUser != nil {
-		uid = *issuedToUser
+	// Step 8: construct Identity. issued_to_user is NOT NULL at the
+	// schema level (migration 0120, bead unblock-tv8.73) and required at
+	// issuance, so a well-formed key always has an owning user. Guard
+	// defensively anyway: never emit an empty-UID Identity, which Encore's
+	// auth handler rejects with the opaque "empty uid and non-empty auth
+	// data" error. A malformed (NULL/empty-user) key is treated as an
+	// invalid key, not a 500.
+	if issuedToUser == nil || *issuedToUser == "" {
+		rlog.Error("auth: api_key has no owning user (schema invariant violated)", "key_id", id)
+		return nil, &errs.Error{Code: errs.Unauthenticated, Message: "malformed api key: no owning user"}
 	}
+	uid := *issuedToUser
 	return &ValidateResponse{
 		Identity: Identity{
 			UserID:    uid,
@@ -515,7 +522,7 @@ func splitScopes(raw string) []string {
 // IssueAPIKeyRequest is the input to IssueAPIKey. SPEC §4.1.
 type IssueAPIKeyRequest struct {
 	OrgID        string     `json:"org_id"`         // ULID
-	IssuedToUser string     `json:"issued_to_user"` // ULID; nullable (org-level service key)
+	IssuedToUser string     `json:"issued_to_user"` // ULID; REQUIRED — every key is owned by a user (no org-level service key)
 	Label        string     `json:"label"`          // human-readable, e.g. "claude-code-laptop"
 	AgentKind    string     `json:"agent_kind"`     // AgentKind value
 	Scopes       []string   `json:"scopes"`
@@ -549,6 +556,14 @@ func IssueAPIKey(ctx context.Context, req *IssueAPIKeyRequest) (*IssueAPIKeyResp
 	if req.Label == "" {
 		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "missing label"}
 	}
+	if req.IssuedToUser == "" {
+		// Every MCP API key MUST be owned by a user — there is no
+		// userless "org-level service key" (bead unblock-tv8.73). A
+		// NULL-user key is structurally unusable: validateAPIKey would
+		// build an empty-UID Identity that Encore's auth handler
+		// rejects ("empty uid and non-empty auth data").
+		return nil, &errs.Error{Code: errs.InvalidArgument, Message: "api key must be issued to a user"}
+	}
 	if _, ok := agentKindAllowed[req.AgentKind]; !ok {
 		// Catch the CHECK constraint client-side so the caller gets
 		// a clean 400 instead of a Postgres-flavoured 500.
@@ -578,16 +593,11 @@ func IssueAPIKey(ctx context.Context, req *IssueAPIKeyRequest) (*IssueAPIKeyResp
 	if scopes == nil {
 		scopes = []string{}
 	}
-	var issuedToUser any
-	if req.IssuedToUser != "" {
-		issuedToUser = req.IssuedToUser
-	}
-
 	_, err = db.Exec(ctx,
 		`INSERT INTO mcp.api_keys
 		   (id, org_id, issued_to_user, label, agent_kind, key_hash, key_prefix, scopes, expires_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-		keyID, req.OrgID, issuedToUser, req.Label, req.AgentKind, hash, prefix, scopes, req.ExpiresAt,
+		keyID, req.OrgID, req.IssuedToUser, req.Label, req.AgentKind, hash, prefix, scopes, req.ExpiresAt,
 	)
 	if err != nil {
 		// Do NOT include rawKey in the log — it has not been

--- a/apps/api/auth/authhandler.go
+++ b/apps/api/auth/authhandler.go
@@ -95,7 +95,9 @@ func AuthHandler(ctx context.Context, p *AuthParams) (auth.UID, *AuthData, error
 	// auth.UID is the canonical user identifier surface of the Encore
 	// auth context. We use Identity.UserID — a ULID for the
 	// session-token path; for API-key callers it is the
-	// `mcp.api_keys.issued_to_user` value (nullable in the schema; an
-	// empty string is acceptable for org-level service keys).
+	// `mcp.api_keys.issued_to_user` value, which is always a non-empty
+	// ULID (the column is NOT NULL and issuance requires it — bead
+	// unblock-tv8.73). Validate rejects any key lacking an owning user
+	// before reaching here, so UserID is never empty on the api-key path.
 	return auth.UID(resp.Identity.UserID), &AuthData{Identity: resp.Identity}, nil
 }

--- a/apps/api/auth/issueapikey_test.go
+++ b/apps/api/auth/issueapikey_test.go
@@ -1,0 +1,107 @@
+// Unit tests for IssueAPIKey input validation (bead unblock-tv8.73).
+//
+// Scope: the request-validation guards in IssueAPIKey that run BEFORE any
+// sqldb access — in particular the round-16 contract that every MCP API key
+// MUST be issued to a user (issued_to_user is REQUIRED; there is no userless
+// "org-level service key"). An empty IssuedToUser is rejected with
+// InvalidArgument before the function reaches db.Exec, so these assertions
+// need no live database.
+//
+// The DB-bound happy path (issue a user-linked key, then resolve it through
+// the Bearer auth handler to an Identity whose UserID is the non-empty
+// owning user) is exercised end-to-end by the integration suites that seed
+// real user-linked keys: apps/api/exitcriteriontest/, apps/api/perftest/,
+// and apps/api/shared/mcpaudittest/.
+//
+// Runner note (bead unblock-tv8.57): the auth root package panics at init()
+// on empty auth secrets (boot fail-fast in secrets.go). Plain
+// `go test ./auth/...` therefore panics on package load by design — run
+// these under `encore test ./auth/...`, which populates secrets from
+// apps/api/.secrets.local.cue. See apps/api/auth/db.go for the rationale.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"encore.dev/beta/errs"
+)
+
+// TestIssueAPIKeyInputErrors verifies the pre-DB request-validation guards of
+// IssueAPIKey. Each case fails before any sqldb call, so no live database is
+// required. errCode (defined in authhandler_test.go) reads the code by type
+// assertion to avoid the errs.Code runtime stub.
+func TestIssueAPIKeyInputErrors(t *testing.T) {
+	const (
+		validOrg   = "01J0000000000000000000ORG0"
+		validUser  = "01J0000000000000000000USR0"
+		validLabel = "claude-code-laptop"
+		validKind  = "claude-code"
+	)
+
+	t.Run("nil request returns InvalidArgument", func(t *testing.T) {
+		_, err := IssueAPIKey(context.Background(), nil)
+		if code := errCode(err); code != errs.InvalidArgument {
+			t.Fatalf("err code = %v, want InvalidArgument", code)
+		}
+	})
+
+	t.Run("empty org_id returns InvalidArgument", func(t *testing.T) {
+		_, err := IssueAPIKey(context.Background(), &IssueAPIKeyRequest{
+			IssuedToUser: validUser,
+			Label:        validLabel,
+			AgentKind:    validKind,
+		})
+		if code := errCode(err); code != errs.InvalidArgument {
+			t.Fatalf("err code = %v, want InvalidArgument", code)
+		}
+	})
+
+	t.Run("empty label returns InvalidArgument", func(t *testing.T) {
+		_, err := IssueAPIKey(context.Background(), &IssueAPIKeyRequest{
+			OrgID:        validOrg,
+			IssuedToUser: validUser,
+			AgentKind:    validKind,
+		})
+		if code := errCode(err); code != errs.InvalidArgument {
+			t.Fatalf("err code = %v, want InvalidArgument", code)
+		}
+	})
+
+	// The keystone of bead unblock-tv8.73: a key with no owning user is
+	// rejected up front. Without this guard the row would later be NULL on
+	// issued_to_user (now forbidden by the NOT NULL constraint) and resolve
+	// to an empty-UID Identity that Encore's auth handler rejects opaquely.
+	t.Run("empty issued_to_user returns InvalidArgument", func(t *testing.T) {
+		_, err := IssueAPIKey(context.Background(), &IssueAPIKeyRequest{
+			OrgID:     validOrg,
+			Label:     validLabel,
+			AgentKind: validKind,
+			// IssuedToUser intentionally omitted.
+		})
+		if code := errCode(err); code != errs.InvalidArgument {
+			t.Fatalf("err code = %v, want InvalidArgument (key must be issued to a user)", code)
+		}
+		var e *errs.Error
+		if !errors.As(err, &e) {
+			t.Fatalf("err = %v, want *errs.Error", err)
+		}
+		if e.Message != "api key must be issued to a user" {
+			t.Fatalf("err message = %q, want %q", e.Message, "api key must be issued to a user")
+		}
+	})
+
+	t.Run("invalid agent_kind returns InvalidArgument", func(t *testing.T) {
+		_, err := IssueAPIKey(context.Background(), &IssueAPIKeyRequest{
+			OrgID:        validOrg,
+			IssuedToUser: validUser,
+			Label:        validLabel,
+			AgentKind:    "not-a-real-agent",
+		})
+		if code := errCode(err); code != errs.InvalidArgument {
+			t.Fatalf("err code = %v, want InvalidArgument", code)
+		}
+	})
+}

--- a/apps/api/db/migrations/0070_mcp.up.sql
+++ b/apps/api/db/migrations/0070_mcp.up.sql
@@ -9,7 +9,7 @@ CREATE SCHEMA IF NOT EXISTS mcp;
 CREATE TABLE mcp.api_keys (
     id              text         PRIMARY KEY,                              -- ULID
     org_id          text         NOT NULL REFERENCES org.organizations(id) ON DELETE CASCADE,
-    issued_to_user  text         REFERENCES auth.users(id) ON DELETE SET NULL,
+    issued_to_user  text         REFERENCES auth.users(id) ON DELETE SET NULL, -- tightened to NOT NULL + ON DELETE CASCADE by 0120_mcp_issued_to_user_notnull (bead unblock-tv8.73)
     label           text         NOT NULL,                                 -- e.g. 'claude-code-laptop'
     agent_kind      text         NOT NULL,                                 -- AgentKind value
     key_hash        bytea        NOT NULL,                                 -- HMAC-SHA256(server_secret, key); 32 bytes raw.

--- a/apps/api/db/migrations/0120_mcp_issued_to_user_notnull.up.sql
+++ b/apps/api/db/migrations/0120_mcp_issued_to_user_notnull.up.sql
@@ -1,0 +1,34 @@
+-- Require issued_to_user on every MCP API key (bead unblock-tv8.73).
+-- Canonical DDL: docs/SPEC.md § 9.4.6 (post-migration state).
+--
+-- DECISION (Miguel, 2026-06-04): every MCP API key MUST be issued to a
+-- user — there is no userless "org-level service key". A NULL-user key was
+-- structurally unusable (auth.validateAPIKey would build an empty-UID
+-- Identity that Encore's auth handler rejects). This migration removes the
+-- broken NULL path at the schema level.
+--
+-- Pre-production: the table has no rows yet, so SET NOT NULL cannot fail and
+-- no data migration is required (CLAUDE.md pre-prod stance, spec §3.3).
+--
+-- FK direction change: because a NOT NULL column cannot be SET NULL on
+-- user-delete, the FK is swapped from ON DELETE SET NULL to ON DELETE
+-- CASCADE — deleting a user deletes that user's API keys. Tool-call audit
+-- history survives: mcp.tool_calls.api_key_id is ON DELETE SET NULL
+-- (0070_mcp.up.sql), so audit rows are kept with api_key_id nulled.
+--
+-- The original FK was declared inline (column-level, unnamed) in
+-- 0070_mcp.up.sql, so Postgres auto-named it `api_keys_issued_to_user_fkey`
+-- (verified against the live local cluster). We drop that exact constraint
+-- and re-add it with an explicit name and the new delete action.
+
+ALTER TABLE mcp.api_keys
+    ALTER COLUMN issued_to_user SET NOT NULL;
+
+ALTER TABLE mcp.api_keys
+    DROP CONSTRAINT api_keys_issued_to_user_fkey;
+
+ALTER TABLE mcp.api_keys
+    ADD CONSTRAINT api_keys_issued_to_user_fkey
+        FOREIGN KEY (issued_to_user)
+        REFERENCES auth.users(id)
+        ON DELETE CASCADE;

--- a/apps/api/shared/mcpaudittest/d1_transport_test.go
+++ b/apps/api/shared/mcpaudittest/d1_transport_test.go
@@ -49,6 +49,7 @@ import (
 
 	"encore.app/auth"
 	"encore.app/mcp"
+	"encore.app/shared/ulid"
 )
 
 // mcpInitializeBody is a minimal JSON-RPC 2.0 initialize request per
@@ -134,15 +135,37 @@ func mcpEndpoint() string {
 // rawKey); IssueAPIKey performs the full key-format dance so we
 // exercise the real production path.
 //
+// Every MCP API key MUST be owned by a user (bead unblock-tv8.73:
+// issued_to_user is NOT NULL and IssueAPIKey rejects an empty owner),
+// so the helper first seeds a throwaway auth.users row and binds the
+// key to it via IssuedToUser. The user is cleaned up after the test.
+//
 // Each test calls seedAPIKey with its own org id so tests run
 // independently (no cross-test fixture coupling).
 func seedAPIKey(t *testing.T, orgID string) (rawKey, keyID string) {
 	t.Helper()
-	resp, err := auth.IssueAPIKey(context.Background(), &auth.IssueAPIKeyRequest{
-		OrgID:     orgID,
-		Label:     "d1-transport-test",
-		AgentKind: "claude-code",
-		Scopes:    []string{},
+	ctx := context.Background()
+
+	userID, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid userID: %v", err)
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO auth.users (id, primary_provider, primary_provider_id, email, display_name)
+		 VALUES ($1, 'github', $2, $3, $4)`,
+		userID, "d1-"+userID[len(userID)-8:],
+		strings.ToLower(userID[len(userID)-8:])+"@d1.local", "d1-user",
+	); err != nil {
+		t.Fatalf("insert auth.users: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(ctx, `DELETE FROM auth.users WHERE id = $1`, userID) })
+
+	resp, err := auth.IssueAPIKey(ctx, &auth.IssueAPIKeyRequest{
+		OrgID:        orgID,
+		IssuedToUser: userID,
+		Label:        "d1-transport-test",
+		AgentKind:    "claude-code",
+		Scopes:       []string{},
 	})
 	if err != nil {
 		t.Fatalf("auth.IssueAPIKey: %v", err)

--- a/apps/api/shared/rbactest/seed.go
+++ b/apps/api/shared/rbactest/seed.go
@@ -377,11 +377,14 @@ func seedSide(ctx context.Context, db *sqldb.Database, fx *Fixture, orgLabel str
 	// UNIQUE index even if both ULIDs were minted in the same
 	// millisecond (the timestamp-based prefix would).
 	keyPrefix := apiKeyID[len(apiKeyID)-8:]
+	// issued_to_user is NOT NULL (bead unblock-tv8.73): every key is
+	// owned by exactly one user. Bind to the org owner already seeded
+	// above (also the comment author_id) so the FK chain is satisfied.
 	if _, err := db.Exec(ctx,
 		`INSERT INTO mcp.api_keys
-		   (id, org_id, label, agent_kind, key_hash, key_prefix, scopes)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-		apiKeyID, orgID,
+		   (id, org_id, issued_to_user, label, agent_kind, key_hash, key_prefix, scopes)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		apiKeyID, orgID, ownerID,
 		fmt.Sprintf("rbactest-%s-key", orgLabel),
 		"claude-code",
 		[]byte("rbactest-key-hash-placeholder"),

--- a/docs/plans/01-plan-backend-mvp.md
+++ b/docs/plans/01-plan-backend-mvp.md
@@ -269,7 +269,7 @@ into bd.
 |---|---|---|
 | A-1 | Initialise Encore app at `apps/api/encore.app` (Go module, build, dev-loop sanity) | go-supervisor (Greta) |
 | A-2 | Bootstrap migration: `pgcrypto`, `pg_trgm`, eight schemas declared (per SPEC §9.4.0) | go-supervisor (Greta) |
-| A-3 | Migrations §9.4.1–§9.4.8 in canonical order; **round-16: + `0110_mcp_issued_to_user_notnull.up.sql`** (`issued_to_user` NOT NULL + FK `ON DELETE CASCADE`, bead `unblock-tv8.73`, spec §3.2) | go-supervisor (Greta) |
+| A-3 | Migrations §9.4.1–§9.4.8 in canonical order; **round-16: + `0120_mcp_issued_to_user_notnull.up.sql`** (`issued_to_user` NOT NULL + FK `ON DELETE CASCADE`, bead `unblock-tv8.73`, spec §3.2; slot `0110` is held by the committed `0110_mcp_warning_codes`) | go-supervisor (Greta) |
 | A-4 | `pkg/rbac` typed query helper + per-service DB binding | go-supervisor (Greta) |
 | A-5 | Tracing + JSON-Lines logging scaffold (NFR-12) — ULID `trace_id` minted at MCP entry, propagated via `context.Context` per SPEC §10.2 Option B (no `X-Unblock-Trace-Id` header) | go-supervisor (Greta) |
 | A-6 | CI workflow + lint gates + NFR-1 latency harness scaffold + NFR-2 RBAC suite scaffold (per-language gates wired into `.github/workflows/`) | infra-supervisor (Olive) |


### PR DESCRIPTION
## unblock-tv8.73: Require issued_to_user on every MCP API key

Every MCP API key MUST be owned by a user — there is no userless "org-level service key". A NULL-user key was structurally unusable: `validateAPIKey` built an empty-UID `Identity` that Encore's auth handler rejects ("empty uid and non-empty auth data").

### What was done
- **migration `0120_mcp_issued_to_user_notnull`**: `issued_to_user SET NOT NULL`; FK swapped `ON DELETE SET NULL` → `ON DELETE CASCADE` (deleting a user deletes their keys; `mcp.tool_calls` audit rows survive via their own `ON DELETE SET NULL`). Up-only, pre-prod (no rows). Slot 0120 because 0110 is held by the committed `0110_mcp_warning_codes`.
- **`IssueAPIKey`**: rejects empty `IssuedToUser` with `InvalidArgument` ("api key must be issued to a user"); drops the NULL-bind and INSERTs the required user directly; struct doc-comment updated to REQUIRED.
- **`validateAPIKey`**: defensive guard — a key with no owning user is rejected `Unauthenticated` ("malformed api key: no owning user") instead of yielding an empty-UID identity.
- **`authhandler.go`**: fixed the stale "nullable / org-level service key" comment.
- **`0070_mcp.up.sql`**: notes the tightening migration on the column.
- **tests**: new `auth/issueapikey_test.go` (empty owner → InvalidArgument); seed paths in `mcpaudittest` (d1) and `rbactest` now bind a real user under the NOT NULL contract.
- **docs**: plan A-3 row renumbered `0110` → `0120`.

### Files changed
`apps/api/db/migrations/0120_mcp_issued_to_user_notnull.up.sql` (new), `apps/api/db/migrations/0070_mcp.up.sql`, `apps/api/auth/auth.go`, `apps/api/auth/authhandler.go`, `apps/api/auth/issueapikey_test.go` (new), `apps/api/shared/mcpaudittest/d1_transport_test.go`, `apps/api/shared/rbactest/seed.go`, `docs/plans/01-plan-backend-mvp.md`

### Decisions
- Split test coverage by data dependency: input-validation guard in a pure unit suite; DB-bound happy path via existing integration suites.
- Fixed two test seed paths (mcpaudittest d1, rbactest) that relied on the removed NULL-user path — beyond the investigation's enumerated files.

### Deviations
None — implemented as spec. Spec was pre-patched drift-free (root `SPEC.md` §9.4.6 and phase spec already reflect 0120 + NOT NULL + CASCADE).

### Verification
`encore test ./...` full suite green; `encore check` passes (migration 0120 applied). Live schema confirmed: `issued_to_user` NOT NULL, FK `api_keys_issued_to_user_fkey` = CASCADE. `go fmt`/`vet` clean, JSON-tag gate clean.