### PR TITLE
unblock-tv8.78: Create-path cross-reference tenant gate (project/parent/discovered-from/milestone/labels)

### DIFF
--- a/apps/api/exitcriteriontest/write_surface_cross_tenant_test.go
+++ b/apps/api/exitcriteriontest/write_surface_cross_tenant_test.go
@@ -53,7 +53,8 @@ type foreignTenant struct {
 	UserID      string
 	ItemID      string // a foreign work item (Backlog, is_ready=true → would be promotable IN its own org)
 	ClaimedID   string // a foreign work item already claimed (would be closable IN its own org)
-	MilestoneID string // a foreign org-scoped milestone
+	MilestoneID string // a foreign org-scoped milestone (org_id set, project_id NULL)
+	ProjMilesID string // a foreign project-scoped milestone (org_id NULL, project_id set) — locks the project_id branch of the milestone org-XOR-project gate
 	EdgeID      string // a foreign edge ItemID → ClaimedID
 	LabelID     string // a foreign org-scoped label (create-path label gate, bead unblock-tv8.78)
 }
@@ -71,6 +72,7 @@ func seedForeignTenant(t *testing.T, ctx context.Context) foreignTenant {
 		ItemID:      mustULID(t, "foreign item"),
 		ClaimedID:   mustULID(t, "foreign claimed item"),
 		MilestoneID: mustULID(t, "foreign milestone"),
+		ProjMilesID: mustULID(t, "foreign project milestone"),
 		EdgeID:      mustULID(t, "foreign edge"),
 		LabelID:     mustULID(t, "foreign label"),
 	}
@@ -119,13 +121,25 @@ func seedForeignTenant(t *testing.T, ctx context.Context) foreignTenant {
 	); err != nil {
 		t.Fatalf("insert foreign claimed item: %v", err)
 	}
-	// A foreign org-scoped milestone.
+	// A foreign org-scoped milestone (org_id set, project_id NULL) — exercises
+	// the org_id = $caller branch of the milestone org-XOR-project gate.
 	if _, err := encoredb.DB.Exec(ctx,
 		`INSERT INTO workitems.milestones (id, org_id, name, start_date, end_date)
 		 VALUES ($1, $2, 'Foreign Milestone', '2026-01-01', '2026-12-31')`,
 		ft.MilestoneID, ft.OrgID,
 	); err != nil {
 		t.Fatalf("insert foreign milestone: %v", err)
+	}
+	// A foreign project-scoped milestone (org_id NULL, project_id → org B's
+	// project) — exercises the project_id IN (caller-org projects) branch of
+	// the milestone org-XOR-project gate, the subtler tenant boundary the XOR
+	// form exists for (bead unblock-tv8.78 pre-QA cleanup).
+	if _, err := encoredb.DB.Exec(ctx,
+		`INSERT INTO workitems.milestones (id, project_id, name, start_date, end_date)
+		 VALUES ($1, $2, 'Foreign Project Milestone', '2026-01-01', '2026-12-31')`,
+		ft.ProjMilesID, ft.ProjectID,
+	); err != nil {
+		t.Fatalf("insert foreign project milestone: %v", err)
 	}
 	// A foreign edge between the two foreign items.
 	if _, err := encoredb.DB.Exec(ctx,
@@ -496,6 +510,25 @@ func TestExitCriterion_CreateCrossReference_CrossTenantRejected(t *testing.T) {
 		assertNotFound(t, env, "create (foreign milestone_id)")
 		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
 			t.Fatalf("create with foreign milestone_id stored %d item(s) in caller org, want 0", n)
+		}
+	})
+
+	// --- foreign PROJECT-scoped milestone_id ⇒ NOT_FOUND, no item stored -----
+	// The org-scoped case above exercises the org_id = $caller branch of the
+	// milestone org-XOR-project gate; this case (org_id NULL, project_id → org
+	// B's project) locks the OTHER branch — project_id IN (caller-org projects)
+	// — so the full XOR predicate is covered (bead unblock-tv8.78 pre-QA cleanup).
+	t.Run("foreign_project_scoped_milestone_id", func(t *testing.T) {
+		title := "create-foreign-project-milestone"
+		env := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+			"project_id":   f.ProjectID, // caller's own valid project
+			"type":         "task",
+			"title":        title,
+			"milestone_id": ft.ProjMilesID, // foreign project-scoped milestone — the reference under test
+		})
+		assertNotFound(t, env, "create (foreign project-scoped milestone_id)")
+		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
+			t.Fatalf("create with foreign project-scoped milestone_id stored %d item(s) in caller org, want 0", n)
 		}
 	})
 

--- a/apps/api/exitcriteriontest/write_surface_cross_tenant_test.go
+++ b/apps/api/exitcriteriontest/write_surface_cross_tenant_test.go
@@ -55,6 +55,7 @@ type foreignTenant struct {
 	ClaimedID   string // a foreign work item already claimed (would be closable IN its own org)
 	MilestoneID string // a foreign org-scoped milestone
 	EdgeID      string // a foreign edge ItemID → ClaimedID
+	LabelID     string // a foreign org-scoped label (create-path label gate, bead unblock-tv8.78)
 }
 
 // seedForeignTenant inserts a complete foreign org B (org, user, project,
@@ -71,6 +72,7 @@ func seedForeignTenant(t *testing.T, ctx context.Context) foreignTenant {
 		ClaimedID:   mustULID(t, "foreign claimed item"),
 		MilestoneID: mustULID(t, "foreign milestone"),
 		EdgeID:      mustULID(t, "foreign edge"),
+		LabelID:     mustULID(t, "foreign label"),
 	}
 	foreignSlug := "foreign-" + ft.OrgID[len(ft.OrgID)-8:]
 
@@ -132,6 +134,14 @@ func seedForeignTenant(t *testing.T, ctx context.Context) foreignTenant {
 		ft.EdgeID, ft.ItemID, ft.ClaimedID, ft.UserID,
 	); err != nil {
 		t.Fatalf("insert foreign edge: %v", err)
+	}
+	// A foreign org-scoped label (the create-path label gate target, bead
+	// unblock-tv8.78). org-scoped → project_id NULL per the labels XOR check.
+	if _, err := encoredb.DB.Exec(ctx,
+		`INSERT INTO workitems.labels (id, org_id, name, color) VALUES ($1, $2, 'foreign-label', '#abcdef')`,
+		ft.LabelID, ft.OrgID,
+	); err != nil {
+		t.Fatalf("insert foreign label: %v", err)
 	}
 	return ft
 }
@@ -394,6 +404,125 @@ func TestExitCriterion_WriteSurface_CrossTenantRejected(t *testing.T) {
 		}
 		if n != 1 {
 			t.Fatalf("cross-tenant remove_dependency deleted foreign edge (count=%d, want 1)", n)
+		}
+	})
+}
+
+// countCallerItemsTitled counts items in the CALLER's org carrying the given
+// title — used to prove a rejected create stored ZERO rows (the gate rolled the
+// whole transaction back, never planting a cross-org-referencing row).
+func countCallerItemsTitled(t *testing.T, ctx context.Context, orgID, title string) int {
+	t.Helper()
+	var n int
+	if err := encoredb.DB.QueryRow(ctx,
+		`SELECT COUNT(*) FROM workitems.items WHERE org_id = $1 AND title = $2`, orgID, title,
+	).Scan(&n); err != nil {
+		t.Fatalf("count caller items titled %q: %v", title, err)
+	}
+	return n
+}
+
+// TestExitCriterion_CreateCrossReference_CrossTenantRejected drives the `create`
+// tool under the fixture's Bearer (org A) naming a FOREIGN cross-reference
+// (org B) per reference type. Each must yield NOT_FOUND and store ZERO rows in
+// the caller's org — the create-path IDOR seam closed by bead unblock-tv8.78
+// (SPEC §10.1.1 / §4.4 Create / §6.2 Tool 4). req.OrgID is the gate key; a
+// foreign-but-existing reference is indistinguishable from a missing id.
+//
+// Each case supplies the caller's OWN valid project_id (the handler requires a
+// non-empty project_id) and varies exactly one foreign reference — except the
+// foreign-project case, where the foreign project_id IS the reference under
+// test. type=task keeps parent_id / discovered_from_id OPTIONAL so they can be
+// exercised in isolation (a finding would force all of them present at once).
+func TestExitCriterion_CreateCrossReference_CrossTenantRejected(t *testing.T) {
+	f := fx(t)
+	sessionID := initializeSession(t, f.RawKey)
+	ctx := t.Context()
+	ft := seedForeignTenant(t, ctx)
+
+	// --- foreign project_id ⇒ NOT_FOUND, no item stored ------------------
+	t.Run("foreign_project_id", func(t *testing.T) {
+		title := "create-foreign-project"
+		env := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+			"project_id": ft.ProjectID, // foreign — the reference under test
+			"type":       "task",
+			"title":      title,
+		})
+		assertNotFound(t, env, "create (foreign project_id)")
+		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
+			t.Fatalf("create with foreign project_id stored %d item(s) in caller org, want 0", n)
+		}
+	})
+
+	// --- foreign parent_id ⇒ NOT_FOUND, no item stored -------------------
+	t.Run("foreign_parent_id", func(t *testing.T) {
+		title := "create-foreign-parent"
+		env := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+			"project_id": f.ProjectID, // caller's own valid project
+			"type":       "task",
+			"title":      title,
+			"parent_id":  ft.ItemID, // foreign item — the reference under test
+		})
+		assertNotFound(t, env, "create (foreign parent_id)")
+		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
+			t.Fatalf("create with foreign parent_id stored %d item(s) in caller org, want 0", n)
+		}
+	})
+
+	// --- foreign discovered_from_id ⇒ NOT_FOUND, no item stored ----------
+	t.Run("foreign_discovered_from_id", func(t *testing.T) {
+		title := "create-foreign-discovered-from"
+		env := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+			"project_id":         f.ProjectID,
+			"type":               "task",
+			"title":              title,
+			"discovered_from_id": ft.ItemID, // foreign item — the reference under test
+		})
+		assertNotFound(t, env, "create (foreign discovered_from_id)")
+		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
+			t.Fatalf("create with foreign discovered_from_id stored %d item(s) in caller org, want 0", n)
+		}
+	})
+
+	// --- foreign milestone_id ⇒ NOT_FOUND, no item stored ----------------
+	t.Run("foreign_milestone_id", func(t *testing.T) {
+		title := "create-foreign-milestone"
+		env := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+			"project_id":   f.ProjectID,
+			"type":         "task",
+			"title":        title,
+			"milestone_id": ft.MilestoneID, // foreign milestone — the reference under test
+		})
+		assertNotFound(t, env, "create (foreign milestone_id)")
+		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
+			t.Fatalf("create with foreign milestone_id stored %d item(s) in caller org, want 0", n)
+		}
+	})
+
+	// --- foreign label_id ⇒ NOT_FOUND, no item stored, no item_labels row
+	// (the labels[] gate, folded into this bead per Miguel 2026-06-12) ----
+	t.Run("foreign_label_id", func(t *testing.T) {
+		title := "create-foreign-label"
+		env := callTool(t, f.RawKey, sessionID, "create", map[string]any{
+			"project_id": f.ProjectID,
+			"type":       "task",
+			"title":      title,
+			"labels":     []string{ft.LabelID}, // foreign label — the reference under test
+		})
+		assertNotFound(t, env, "create (foreign label_id)")
+		if n := countCallerItemsTitled(t, ctx, f.OrgID, title); n != 0 {
+			t.Fatalf("create with foreign label_id stored %d item(s) in caller org, want 0", n)
+		}
+		// The atomic rollback also guarantees no item_labels row references the
+		// foreign label — assert the foreign label attached to nothing.
+		var n int
+		if err := encoredb.DB.QueryRow(ctx,
+			`SELECT COUNT(*) FROM workitems.item_labels WHERE label_id = $1`, ft.LabelID,
+		).Scan(&n); err != nil {
+			t.Fatalf("count item_labels for foreign label: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("create attached foreign label to %d item(s), want 0", n)
 		}
 	})
 }

--- a/apps/api/workitems/helpers.go
+++ b/apps/api/workitems/helpers.go
@@ -215,17 +215,40 @@ func loadLabels(ctx context.Context, itemID string) ([]string, error) {
 }
 
 // attachLabelsTx inserts (item_id, label_id) rows using the caller's
-// transaction handle. Errors map FK violations to NotFound and unique
-// violations to AlreadyExists.
-func attachLabelsTx(ctx context.Context, tx *sqldb.Tx, itemID string, labels []string) error {
+// transaction handle, gating each wire-supplied label_id against the caller's
+// org (round-16, bead unblock-tv8.78, SPEC §10.1.1). Errors map FK violations
+// and cross-tenant / missing labels to NotFound.
+//
+// Each INSERT is a guarded INSERT … SELECT whose WHERE admits the label only
+// when it is org-scoped to callerOrg OR project-scoped to a project in
+// callerOrg (the org-XOR-project label-ownership form, milestone precedent) —
+// so a foreign label_id (org- or project-scoped to another org) attaches
+// NOTHING and yields NOT_FOUND, the SAME envelope a genuinely-missing label
+// yields, never disclosing cross-tenant existence and never planting a
+// cross-org item_labels row.
+//
+// callerOrg keys the gate. The predicate takes the empty-callerOrg NO-OP form
+// (`callerOrg = ” OR …`): the create path always passes a real, non-empty
+// req.OrgID so the gate is active there; the Update label-replace caller
+// passes its CallerOrgID channel, which trusted internal no-auth callers leave
+// empty (the .77 §10.1.1 no-op convention) — MCP handlers always pin it, so the
+// no-op is unreachable from the agent surface. A non-existent label_id matches
+// no row → zero inserted → NOT_FOUND regardless of callerOrg.
+func attachLabelsTx(ctx context.Context, tx *sqldb.Tx, itemID, callerOrg string, labels []string) error {
 	for _, labelID := range labels {
 		if labelID == "" {
 			continue
 		}
-		_, err := tx.Exec(ctx,
-			`INSERT INTO workitems.item_labels (item_id, label_id) VALUES ($1, $2)
+		tag, err := tx.Exec(ctx,
+			`INSERT INTO workitems.item_labels (item_id, label_id)
+			 SELECT $1, $2
+			   FROM workitems.labels
+			  WHERE id = $2
+			    AND ($3 = ''
+			         OR org_id = $3
+			         OR project_id IN (SELECT id FROM org.projects WHERE org_id = $3))
 			 ON CONFLICT (item_id, label_id) DO NOTHING`,
-			itemID, labelID,
+			itemID, labelID, callerOrg,
 		)
 		if err != nil {
 			if isForeignKeyViolation(err) {
@@ -237,6 +260,30 @@ func attachLabelsTx(ctx context.Context, tx *sqldb.Tx, itemID string, labels []s
 			}
 			rlog.Error("workitems: label attach failed", "err", err, "item_id", itemID, "label_id", labelID)
 			return &errs.Error{Code: errs.Internal, Message: "label attach failed"}
+		}
+		// Zero inserted rows means EITHER the label does not exist OR it belongs
+		// to another org (the gate rejected it) — UNLESS the (item_id, label_id)
+		// pair already exists, in which case ON CONFLICT DO NOTHING legitimately
+		// affects zero rows. Distinguish: re-check whether the (item_id,
+		// label_id) row is now present. If present, the label was already
+		// attached (idempotent re-attach) — not an error. If absent, the gate or
+		// a missing label_id rejected it → NOT_FOUND, the same shape a missing
+		// label yields (never disclosing cross-tenant existence).
+		if tag.RowsAffected() == 0 {
+			var exists bool
+			if err := tx.QueryRow(ctx,
+				`SELECT EXISTS (SELECT 1 FROM workitems.item_labels WHERE item_id = $1 AND label_id = $2)`,
+				itemID, labelID,
+			).Scan(&exists); err != nil {
+				return &errs.Error{Code: errs.Internal, Message: "label attach verify failed"}
+			}
+			if !exists {
+				return &errs.Error{
+					Code:    errs.NotFound,
+					Message: fmt.Sprintf("label %q does not exist", labelID),
+					Meta:    errs.Metadata{"label_id": labelID},
+				}
+			}
 		}
 	}
 	return nil

--- a/apps/api/workitems/helpers.go
+++ b/apps/api/workitems/helpers.go
@@ -251,6 +251,12 @@ func attachLabelsTx(ctx context.Context, tx *sqldb.Tx, itemID, callerOrg string,
 			itemID, labelID, callerOrg,
 		)
 		if err != nil {
+			// Defensive / effectively unreachable for this guarded INSERT … SELECT:
+			// a missing label_id selects zero rows (no FK violation) and flows
+			// through the RowsAffected()==0 → EXISTS-recheck → NOT_FOUND path
+			// below; the item_id FK cannot fire (the item row was just created in
+			// this same tx). Kept so the NOT_FOUND outcome holds even if the query
+			// shape ever regresses to an INSERT … VALUES.
 			if isForeignKeyViolation(err) {
 				return &errs.Error{
 					Code:    errs.NotFound,

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -59,6 +59,34 @@
 //     target id therefore matches zero rows → NOT_FOUND (or zero rows
 //     inserted on an INSERT), never a cross-tenant mutation.
 //
+//   - The CREATE path (Create, Tool 4) self-gates its wire-supplied
+//     cross-references symmetrically (round-16 / bead unblock-tv8.78,
+//     SPEC §10.1.1 / §4.4 Create). The item INSERT is a guarded
+//     INSERT … SELECT whose WHERE validates project_id (IN caller-org
+//     projects), parent_id / discovered_from_id (IN caller-org items),
+//     and milestone_id (org-XOR-project) against the caller org; a
+//     foreign reference yields ZERO inserted rows → NOT_FOUND, the same
+//     envelope a missing id yields. Labels are gated identically by
+//     attachLabelsTx (org-XOR-project label-ownership form). The
+//     dependencies[] endpoints stay gated by deps.AddEdgeInTx's own
+//     CallerOrgID check.
+//
+//     DECISION (Miguel 2026-06-12, SPEC §10.1.1): the create-path gate
+//     keys on the EXISTING req.OrgID — the same value the INSERT stamps
+//     org_id from, already pinned from identity.OrgID by the MCP handler
+//     and validated non-empty — NOT a separate CallerOrgID channel, and
+//     with NO empty-OrgID no-op branch. Deliberate divergence from the
+//     .77 update/delete-by-id convention below: Create's internal callers
+//     (the §11.1.1 exit-criterion seed + integration tests) all pass a
+//     real, same-org OrgID referencing same-org rows, so the non-empty
+//     req.OrgID gate passes them with no no-op branch. Coverage is
+//     identical to the CallerOrgID-channel RPCs; only the key differs.
+//     (attachLabelsTx itself takes the empty-callerOrg no-op form because
+//     it is SHARED with the Update label-replace path, which keys on the
+//     .77 CallerOrgID channel that trusted internal callers leave empty;
+//     Create always passes a non-empty req.OrgID, so the gate is active
+//     on the create path regardless.)
+//
 // # Empty-CallerOrgID no-op (item/milestone) vs hard guard (labels)
 //
 // The item / milestone write RPCs take the empty-CallerOrgID NO-OP form:
@@ -970,14 +998,53 @@ func Create(ctx context.Context, req *CreateRequest) (*Item, error) {
 	// status stays 'Backlog' — is_ready=true makes the item immediately
 	// promote-able (Tool 15 / §6.6), but promotion is an explicit agent
 	// action, not an implicit side-effect of create.
-	_, err = tx.Exec(ctx,
+	// Create-path cross-reference tenant gate (round-16, bead unblock-tv8.78,
+	// SPEC §10.1.1 / §4.4 Create). The INSERT's FK constraints only check
+	// reference EXISTENCE in ANY org — a foreign-but-existing project_id /
+	// parent_id / discovered_from_id / milestone_id would otherwise be stored,
+	// producing an item whose org_id differs from the referenced row's org (the
+	// create-path analogue of the §10.1.1 write-by-id IDOR seam). We close that
+	// seam with a guarded INSERT … SELECT: each wire reference is validated
+	// against the caller org in the SELECT's WHERE before the row materialises.
+	//
+	// Gate-key DECISION (Miguel 2026-06-12, §10.1.1): the gate keys on the
+	// existing req.OrgID — the SAME value the INSERT stamps org_id from, already
+	// pinned from identity.OrgID by the MCP handler and validated non-empty at
+	// :874 — NOT a separate CallerOrgID channel, and with NO empty-OrgID no-op
+	// branch. This is a deliberate divergence from the .77 update/delete-by-id
+	// convention: Create's internal callers (the §11.1.1 exit-criterion seed +
+	// integration tests) all pass a real same-org OrgID referencing same-org
+	// rows, so the non-empty req.OrgID gate passes them without a no-op branch.
+	// Coverage is identical to the CallerOrgID-channel RPCs.
+	//
+	// Per-reference predicates (each guarded by `$n = '' OR …` so an UNSET
+	// optional reference skips the gate):
+	//   - project_id        → IN (SELECT id FROM org.projects WHERE org_id = $caller)
+	//   - parent_id         → IN (SELECT id FROM workitems.items WHERE org_id = $caller)
+	//   - discovered_from_id→ same as parent_id (a caller-org item)
+	//   - milestone_id      → org_id = $caller OR project_id IN caller-org projects
+	//                         (org-XOR-project; project-scoped milestones carry NULL org_id)
+	//
+	// A foreign reference yields ZERO inserted rows → NOT_FOUND below, the SAME
+	// envelope a genuinely-missing id yields (existence in another org is never
+	// disclosed). All inside the existing single tx (bead-unblock-tv8.17
+	// atomicity) so a reject rolls the whole create back. The dependencies[]
+	// endpoints are gated separately by deps.AddEdgeInTx below — unchanged.
+	tag, err := tx.Exec(ctx,
 		`INSERT INTO workitems.items
 		   (id, org_id, project_id, milestone_id, parent_id, discovered_from_id,
 		    type, title, body, priority,
 		    severity, kind_of_finding, is_ready)
-		 VALUES ($1, $2, NULLIF($3, ''), NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, ''),
-		         $7, $8, $9, $10,
-		         NULLIF($11, ''), NULLIF($12, ''), true)`,
+		 SELECT $1, $2, NULLIF($3, ''), NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, ''),
+		        $7, $8, $9, $10,
+		        NULLIF($11, ''), NULLIF($12, ''), true
+		  WHERE ($3 = '' OR $3 IN (SELECT id FROM org.projects WHERE org_id = $2))
+		    AND ($5 = '' OR $5 IN (SELECT id FROM workitems.items WHERE org_id = $2))
+		    AND ($6 = '' OR $6 IN (SELECT id FROM workitems.items WHERE org_id = $2))
+		    AND ($4 = ''
+		         OR $4 IN (SELECT id FROM workitems.milestones
+		                    WHERE org_id = $2
+		                       OR project_id IN (SELECT id FROM org.projects WHERE org_id = $2)))`,
 		id, req.OrgID, req.ProjectID, req.MilestoneID, req.ParentID, req.DiscoveredFromID,
 		itemType, title, req.Body, priority,
 		req.Severity, req.KindOfFinding,
@@ -992,10 +1059,24 @@ func Create(ctx context.Context, req *CreateRequest) (*Item, error) {
 		rlog.Error("workitems: create insert failed", "err", err, "org_id", req.OrgID)
 		return nil, &errs.Error{Code: errs.Internal, Message: "create insert failed"}
 	}
+	// Zero inserted rows means a cross-reference tenant gate rejected the
+	// INSERT: one of project_id / parent_id / discovered_from_id / milestone_id
+	// does not belong to the caller's org (or does not exist). Surface
+	// NOT_FOUND — the same shape a genuinely-missing reference yields — so a
+	// foreign-but-existing id is indistinguishable from a missing one and never
+	// leaks existence across the tenant boundary (§10.1.1, CreateLabel
+	// zero-rows precedent).
+	if tag.RowsAffected() == 0 {
+		return nil, &errs.Error{Code: errs.NotFound, Message: "referenced org/project/milestone/parent does not exist"}
+	}
 
-	// Attach labels in the same transaction.
+	// Attach labels in the same transaction. attachLabelsTx gates each
+	// wire-supplied label_id against the caller org (req.OrgID, the same
+	// create-path gate key as the cross-references above, §10.1.1): a foreign
+	// label_id attaches nothing and yields NOT_FOUND — never a cross-tenant
+	// attach (round-16, bead unblock-tv8.78).
 	if len(req.Labels) > 0 {
-		if err := attachLabelsTx(ctx, tx, id, req.Labels); err != nil {
+		if err := attachLabelsTx(ctx, tx, id, req.OrgID, req.Labels); err != nil {
 			return nil, err
 		}
 	}
@@ -1125,7 +1206,11 @@ func Update(ctx context.Context, req *UpdateRequest) (*Item, error) {
 			return nil, &errs.Error{Code: errs.Internal, Message: "label clear failed"}
 		}
 		if len(*req.Labels) > 0 {
-			if err := attachLabelsTx(ctx, tx, req.ItemID, *req.Labels); err != nil {
+			// Gate replacement labels on the .77 CallerOrgID channel (empty for
+			// trusted internal callers → no-op; MCP handlers always pin it). A
+			// foreign label_id attaches nothing → NOT_FOUND, matching the
+			// create-path label gate (round-16, bead unblock-tv8.78, §10.1.1).
+			if err := attachLabelsTx(ctx, tx, req.ItemID, req.CallerOrgID, *req.Labels); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
## unblock-tv8.78: workitems.Create cross-reference caller-org validation

`workitems.Create` stamped `org_id` from the caller identity but validated `project_id` / `parent_id` / `discovered_from_id` / `milestone_id` / `labels[]` for FK existence in ANY org only — letting a caller create an item whose `org_id` differs from a referenced row's org (the create-path analogue of the §10.1.1 write-by-id IDOR seam, proven live 2026-06-12).

### What was done
- INSERT…VALUES → guarded **INSERT…SELECT**: each wire reference validated against the caller org in the SELECT WHERE (project_id IN caller-org projects; parent_id / discovered_from_id IN caller-org items; milestone_id org-XOR-project). Zero inserted rows → NOT_FOUND.
- `attachLabelsTx` gains a `callerOrg` param + org-XOR-project label gate (empty-callerOrg no-op form, shared with the Update label-replace path). A foreign `label_id` attaches nothing → NOT_FOUND.
- All gates run inside the existing single create transaction (unblock-tv8.17 atomicity) — a reject rolls the whole create back.
- A foreign-but-existing reference yields the SAME NOT_FOUND envelope as a missing id; existence in another org is never disclosed.
- Auth-model doc-comment updated in lockstep.

### Files changed
- `apps/api/workitems/workitems.go`
- `apps/api/workitems/helpers.go`
- `apps/api/exitcriteriontest/write_surface_cross_tenant_test.go`

### Decisions
- Gate keys on the existing `req.OrgID` (no separate `CallerOrgID`, no no-op branch on the create path) — Miguel 2026-06-12, §10.1.1.
- `attachLabelsTx` shared-helper no-op form covers both Create and the Update label-replace path.

### Deviations
None — implemented per ratified spec `a0affbf` (§10.1.1 Create row, §6.2 Tool 4, §4.4 Create).

### Tests
`encore test ./...` passes. New `TestExitCriterion_CreateCrossReference_CrossTenantRejected` (5 subtests: foreign project / parent / discovered-from / milestone / label → NOT_FOUND + zero stored rows). Existing write-surface + workitems integration suites pass unchanged. `go fmt` / `go vet` / `encore check` clean; json-tag grep empty.