### PR TITLE
unblock-tv8.79: corrective forward migration 0140 — re-assert cascade_events_kind_chk (4 kinds)

### DIFF
--- a/apps/api/db/migrations/0140_deps_cascade_events_kind_chk_fix.up.sql
+++ b/apps/api/db/migrations/0140_deps_cascade_events_kind_chk_fix.up.sql
@@ -1,0 +1,44 @@
+-- Corrective forward migration: re-assert deps.cascade_events_kind_chk with
+-- the full 4-kind set (bead unblock-tv8.79).
+-- Canonical DDL: docs/specs/01-spec-backend-mvp.md § 3.2 (0140 row) and the
+-- §9.4.4-mirroring cascade_events.kind enum block (both at 4 kinds).
+--
+-- ROOT CAUSE: round-6 cascade-symmetry (commit 3e0d00d) widened the CHECK on
+-- deps.cascade_events from 2 kinds ('close','edge_removed') to 4
+-- ('close','edge_added','edge_removed','state_change') by EDITING
+-- 0050_deps.up.sql IN PLACE. golang-migrate (Encore's migration engine) keys
+-- migrations by VERSION NUMBER, not content checksum, so any database that had
+-- already applied 0050 before that edit never re-ran it and silently retains
+-- the OLD 2-kind constraint. On such an environment the cascade subscriber's
+-- audit INSERT (kind = msg.Reason) violates the stale CHECK with SQLSTATE
+-- 23514 for the 'state_change' and 'edge_added' reasons, the handler errors,
+-- and Encore Pub/Sub retries — producing a retry storm. The functional cascade
+-- recompute (is_ready propagation) commits in its own tx before the audit
+-- insert and is UNAFFECTED; only the audit row and the retry noise break.
+--
+-- FIX (roll-forward discipline, spec § 3.3): a NEW up-only forward migration —
+-- 0050 is NOT re-edited. DROP CONSTRAINT IF EXISTS then ADD CONSTRAINT
+-- re-asserts the constraint with the full 4-kind set under the SAME name
+-- (cascade_events_kind_chk — named identifiers are contract, spec § 3.3).
+-- The constraint name MUST stay identical: re-adding under a different name
+-- would orphan the stale constraint on already-migrated environments.
+--
+-- Idempotent on both paths:
+--   * Fresh DB (already 4-kind from the post-edit 0050): DROP+ADD yields an
+--     identical constraint — a no-op-equivalent. The re-ADD re-validates
+--     existing rows, but every cascade_events row carries one of the 4 kinds
+--     BY CONSTRUCTION (the only writers are the cascade subscriber with
+--     kind = msg.Reason gated to the 4 values, and the inline edge-removal
+--     writer using 'edge_removed'), so validation cannot fail.
+--   * Stale DB (2-kind): DROP+ADD corrects the drift so state_change /
+--     edge_added audit inserts succeed.
+--
+-- golang-migrate wraps each up file in a single transaction, so the DROP+ADD
+-- is atomic. Pre-production: no backfill or data migration is required.
+
+ALTER TABLE deps.cascade_events
+    DROP CONSTRAINT IF EXISTS cascade_events_kind_chk;
+
+ALTER TABLE deps.cascade_events
+    ADD CONSTRAINT cascade_events_kind_chk
+        CHECK (kind IN ('close', 'edge_added', 'edge_removed', 'state_change'));


### PR DESCRIPTION
## unblock-tv8.79: corrective forward migration for cascade_events_kind_chk drift

Round-6 (commit 3e0d00d) widened `deps.cascade_events_kind_chk` from 2 kinds to 4 by editing `0050_deps.up.sql` in place. golang-migrate keys by version number, so any DB that had already applied 0050 silently retained the stale 2-kind constraint — `state_change`/`edge_added` cascade audit inserts then fail with SQLSTATE 23514, triggering a Pub/Sub retry storm.

### What was done
New up-only forward migration `0140_deps_cascade_events_kind_chk_fix.up.sql` that DROPs (IF EXISTS) and re-ADDs `cascade_events_kind_chk` with the full 4-kind set (`close`, `edge_added`, `edge_removed`, `state_change`) under the same constraint name. Idempotent: no-op-equivalent on fresh DBs, corrective on stale ones. `0050` is NOT re-edited (roll-forward discipline, spec §3.3). No down file per §3.3 doctrine.

### Files changed
- `apps/api/db/migrations/0140_deps_cascade_events_kind_chk_fix.up.sql` (new)

### Decisions
None — implemented per investigation approach + spec §3.2/§3.3.

### Deviations
None — implemented as spec.

### Tests
- `encore check` passes (0140 applies clean on fresh cluster).
- `encore test ./exitcriteriontest/... ./deps/...` both pass.
- `cascade_kinds_test` verbose run: `TestExitCriterion_CascadeKind_EdgeAdded/EdgeRemoved/StateChange` all PASS — regression proof that 4-kind audit inserts land end-to-end.