### PR TITLE
unblock-tv8.80: same-item parent_id gate on AppendComment — close cross-tenant IDOR

### DIFF
--- a/apps/api/exitcriteriontest/write_surface_cross_tenant_test.go
+++ b/apps/api/exitcriteriontest/write_surface_cross_tenant_test.go
@@ -39,6 +39,7 @@ package exitcriteriontest_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	encoredb "encore.app/db"
@@ -57,6 +58,7 @@ type foreignTenant struct {
 	ProjMilesID string // a foreign project-scoped milestone (org_id NULL, project_id set) — locks the project_id branch of the milestone org-XOR-project gate
 	EdgeID      string // a foreign edge ItemID → ClaimedID
 	LabelID     string // a foreign org-scoped label (create-path label gate, bead unblock-tv8.78)
+	CommentID   string // a foreign comment ON the foreign ItemID (AppendComment parent_id same-item gate, bead unblock-tv8.80)
 }
 
 // seedForeignTenant inserts a complete foreign org B (org, user, project,
@@ -75,6 +77,7 @@ func seedForeignTenant(t *testing.T, ctx context.Context) foreignTenant {
 		ProjMilesID: mustULID(t, "foreign project milestone"),
 		EdgeID:      mustULID(t, "foreign edge"),
 		LabelID:     mustULID(t, "foreign label"),
+		CommentID:   mustULID(t, "foreign comment"),
 	}
 	foreignSlug := "foreign-" + ft.OrgID[len(ft.OrgID)-8:]
 
@@ -157,6 +160,17 @@ func seedForeignTenant(t *testing.T, ctx context.Context) foreignTenant {
 	); err != nil {
 		t.Fatalf("insert foreign label: %v", err)
 	}
+	// A foreign comment ON the foreign item — the AppendComment parent_id
+	// same-item gate target (bead unblock-tv8.80). A home caller threading a
+	// reply whose parent_id is this id must get NOT_FOUND (foreign-org parent),
+	// indistinguishable from a missing parent.
+	if _, err := encoredb.DB.Exec(ctx,
+		`INSERT INTO workitems.comments (id, item_id, author_id, kind, body)
+		 VALUES ($1, $2, $3, 'general', 'Foreign comment')`,
+		ft.CommentID, ft.ItemID, ft.UserID,
+	); err != nil {
+		t.Fatalf("insert foreign comment: %v", err)
+	}
 	return ft
 }
 
@@ -209,21 +223,110 @@ func TestExitCriterion_WriteSurface_CrossTenantRejected(t *testing.T) {
 		}
 	})
 
-	// --- comment: foreign item ⇒ NOT_FOUND, zero comments inserted ------
+	// --- comment: foreign item ⇒ NOT_FOUND, no comment inserted ------
+	// The fixture seeds one comment on the foreign item (ft.CommentID, the
+	// parent_id gate target below); the cross-tenant call must add nothing, so
+	// the count stays at its seeded baseline.
 	t.Run("comment", func(t *testing.T) {
+		before := countItemComments(t, ctx, ft.ItemID)
 		env := callTool(t, f.RawKey, sessionID, "comment", map[string]any{
 			"item_id": ft.ItemID,
 			"body":    "intruder comment",
 		})
 		assertNotFound(t, env, "comment")
-		var n int
-		if err := encoredb.DB.QueryRow(ctx,
-			`SELECT COUNT(*) FROM workitems.comments WHERE item_id = $1`, ft.ItemID,
-		).Scan(&n); err != nil {
-			t.Fatalf("count foreign comments: %v", err)
+		if after := countItemComments(t, ctx, ft.ItemID); after != before {
+			t.Fatalf("cross-tenant comment changed foreign item comment count %d → %d, want unchanged", before, after)
 		}
-		if n != 0 {
-			t.Fatalf("cross-tenant comment inserted %d row(s) on foreign item, want 0", n)
+	})
+
+	// --- comment: foreign-org parent_id ⇒ NOT_FOUND, no reply inserted ---
+	// Home caller, home item, but parent_id = a comment that lives in the
+	// FOREIGN org (on the foreign item). The same-item parent_id gate (bead
+	// unblock-tv8.80, §10.1.1 / §6.2 Tool 10) must reject this with NOT_FOUND
+	// — indistinguishable from a missing parent — and insert zero rows.
+	t.Run("comment_foreign_parent_id", func(t *testing.T) {
+		homeItem := f.ItemID("itm_a")
+		before := countItemComments(t, ctx, homeItem)
+		env := callTool(t, f.RawKey, sessionID, "comment", map[string]any{
+			"item_id":   homeItem,
+			"parent_id": ft.CommentID, // foreign-org comment — the reference under test
+			"body":      "reply under a foreign comment",
+		})
+		assertNotFound(t, env, "comment (foreign parent_id)")
+		if after := countItemComments(t, ctx, homeItem); after != before {
+			t.Fatalf("comment with foreign parent_id changed home item comment count %d → %d, want unchanged", before, after)
+		}
+	})
+
+	// --- comment: cross-item (same-org) parent_id ⇒ NOT_FOUND ------------
+	// Home caller, home item itm_b, parent_id = a comment that exists in the
+	// SAME org but on a DIFFERENT home item (itm_a). The gate is same-item, not
+	// merely same-org, so this must also be NOT_FOUND with zero rows inserted
+	// (bead unblock-tv8.80 — cross-item threading is rejected even within a tenant).
+	t.Run("comment_cross_item_parent_id", func(t *testing.T) {
+		itemA := f.ItemID("itm_a")
+		itemB := f.ItemID("itm_b")
+		// Seed a home comment ON itm_a (same org as the caller).
+		parentOnA := mustULID(t, "home parent on itm_a")
+		if _, err := encoredb.DB.Exec(ctx,
+			`INSERT INTO workitems.comments (id, item_id, author_id, kind, body)
+			 VALUES ($1, $2, $3, 'general', 'home comment on itm_a')`,
+			parentOnA, itemA, f.UserID,
+		); err != nil {
+			t.Fatalf("seed home comment on itm_a: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = encoredb.DB.Exec(context.Background(), `DELETE FROM workitems.comments WHERE id = $1`, parentOnA)
+		})
+		before := countItemComments(t, ctx, itemB)
+		env := callTool(t, f.RawKey, sessionID, "comment", map[string]any{
+			"item_id":   itemB,     // a DIFFERENT home item
+			"parent_id": parentOnA, // same-org comment, but on itm_a — the reference under test
+			"body":      "reply on itm_b pointing at an itm_a comment",
+		})
+		assertNotFound(t, env, "comment (cross-item parent_id)")
+		if after := countItemComments(t, ctx, itemB); after != before {
+			t.Fatalf("comment with cross-item parent_id changed itm_b comment count %d → %d, want unchanged", before, after)
+		}
+	})
+
+	// --- comment: same-item parent_id ⇒ SUCCESS, reply threaded ----------
+	// The positive control: a home caller threading a reply on the SAME home
+	// item as the parent comment must SUCCEED and echo parent_id (proves the
+	// same-item gate does not over-reject legitimate threading).
+	t.Run("comment_same_item_parent_id", func(t *testing.T) {
+		itemA := f.ItemID("itm_a")
+		parentOnA := mustULID(t, "home parent for same-item thread")
+		if _, err := encoredb.DB.Exec(ctx,
+			`INSERT INTO workitems.comments (id, item_id, author_id, kind, body)
+			 VALUES ($1, $2, $3, 'general', 'home parent for same-item thread')`,
+			parentOnA, itemA, f.UserID,
+		); err != nil {
+			t.Fatalf("seed same-item parent comment: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = encoredb.DB.Exec(context.Background(), `DELETE FROM workitems.comments WHERE parent_id = $1 OR id = $1`, parentOnA)
+		})
+		env := callTool(t, f.RawKey, sessionID, "comment", map[string]any{
+			"item_id":   itemA,
+			"parent_id": parentOnA, // a comment on the SAME item — must thread
+			"body":      "valid same-item reply",
+		})
+		var out struct {
+			Comment struct {
+				ID       string `json:"id"`
+				ItemID   string `json:"item_id"`
+				ParentID string `json:"parent_id"`
+			} `json:"comment"`
+		}
+		if err := json.Unmarshal(expectSuccess(t, env), &out); err != nil {
+			t.Fatalf("unmarshal comment success: %v", err)
+		}
+		if out.Comment.ParentID != parentOnA {
+			t.Fatalf("same-item reply parent_id = %q, want %q", out.Comment.ParentID, parentOnA)
+		}
+		if out.Comment.ItemID != itemA {
+			t.Fatalf("same-item reply item_id = %q, want %q", out.Comment.ItemID, itemA)
 		}
 	})
 
@@ -432,6 +535,20 @@ func countCallerItemsTitled(t *testing.T, ctx context.Context, orgID, title stri
 		`SELECT COUNT(*) FROM workitems.items WHERE org_id = $1 AND title = $2`, orgID, title,
 	).Scan(&n); err != nil {
 		t.Fatalf("count caller items titled %q: %v", title, err)
+	}
+	return n
+}
+
+// countItemComments returns the number of comments on the given item — used to
+// prove the AppendComment parent_id same-item gate (bead unblock-tv8.80) inserts
+// ZERO rows when a non-empty parent_id is foreign-org or cross-item.
+func countItemComments(t *testing.T, ctx context.Context, itemID string) int {
+	t.Helper()
+	var n int
+	if err := encoredb.DB.QueryRow(ctx,
+		`SELECT COUNT(*) FROM workitems.comments WHERE item_id = $1`, itemID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count comments on item %s: %v", itemID, err)
 	}
 	return n
 }

--- a/apps/api/workitems/integration_test.go
+++ b/apps/api/workitems/integration_test.go
@@ -268,6 +268,52 @@ func TestAppendComment(t *testing.T) {
 	if c.ID == "" || c.Body != "hello" {
 		t.Fatalf("AppendComment returned bad comment: %+v", c)
 	}
+
+	// Same-item parent_id threads successfully (bead unblock-tv8.80,
+	// §10.1.1 / §6.2 Tool 10): a reply whose parent_id is a comment on the
+	// SAME item must succeed and echo parent_id. This is the positive control
+	// for the same-item gate (proves it does not over-reject legitimate
+	// threading). The internal caller passes an empty CallerOrgID (the no-op
+	// branch), so the same-item predicate is the sole gate exercised here.
+	reply, err := workitems.AppendComment(ctx, &workitems.AppendCommentRequest{
+		ItemID:   item.ID,
+		ParentID: c.ID, // a comment on the SAME item
+		AuthorID: fx.UserID,
+		Kind:     "general",
+		Status:   "info",
+		Body:     "threaded reply",
+	})
+	if err != nil {
+		t.Fatalf("AppendComment same-item thread: %v", err)
+	}
+	if reply.ParentID != c.ID {
+		t.Fatalf("same-item reply parent_id = %q, want %q", reply.ParentID, c.ID)
+	}
+
+	// Cross-item parent_id is rejected with NOT_FOUND (bead unblock-tv8.80):
+	// the gate is same-item, not merely same-org. A reply on item2 whose
+	// parent_id points at a comment on item1 (same org) must insert zero rows
+	// and surface NOT_FOUND, indistinguishable from a missing parent.
+	item2, err := workitems.Create(ctx, &workitems.CreateRequest{
+		OrgID: fx.OrgID, ProjectID: fx.ProjectID, Type: "task", Title: "T2",
+	})
+	if err != nil {
+		t.Fatalf("Create item2: %v", err)
+	}
+	_, err = workitems.AppendComment(ctx, &workitems.AppendCommentRequest{
+		ItemID:   item2.ID,
+		ParentID: c.ID, // a comment on item1 — a DIFFERENT item
+		AuthorID: fx.UserID,
+		Kind:     "general",
+		Status:   "info",
+		Body:     "cross-item reply",
+	})
+	if err == nil {
+		t.Fatalf("AppendComment cross-item parent_id: expected NOT_FOUND, got success")
+	}
+	if code := errs.Code(err); code != errs.NotFound {
+		t.Fatalf("AppendComment cross-item parent_id: code = %v, want NotFound", code)
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1473,6 +1473,17 @@ func GetTrail(ctx context.Context, req *GetTrailRequest) (*Trail, error) {
 // the INSERT so callers get a clearer error than a Postgres CHECK
 // violation.
 //
+// Tenant + threading gate (§10.1.1, §6.2 Tool 10): the INSERT … SELECT
+// gates the target item on org_id = CallerOrgID (empty CallerOrgID is the
+// trusted-internal no-op), and — when ParentID is non-empty — additionally
+// requires the parent comment to live on the SAME target item (parent_id IN
+// (SELECT id FROM workitems.comments WHERE item_id = $target_item), bead
+// unblock-tv8.80). Same-item transitively implies same-org, so no separate
+// parent-org branch is needed; a foreign-org OR cross-item parent_id inserts
+// zero rows → NOT_FOUND, indistinguishable from a missing parent. The
+// empty-ParentID top-level-comment path and the self-parent prohibition
+// (comments_no_self_parent_chk) are preserved.
+//
 //encore:api private method=POST path=/workitems.AppendComment
 func AppendComment(ctx context.Context, req *AppendCommentRequest) (*Comment, error) {
 	if req == nil || req.ItemID == "" {
@@ -1517,16 +1528,34 @@ func AppendComment(ctx context.Context, req *AppendCommentRequest) (*Comment, er
 	// inserted rows → NOT_FOUND below, never a cross-tenant comment. The
 	// empty-CallerOrgID no-op keeps trusted internal callers operating
 	// unscoped; the MCP handler always pins CallerOrgID from identity.OrgID,
-	// so the no-op is unreachable from the agent surface. The parent_id FK
-	// (parent comment must reference the same item) is still enforced by the
-	// comments_parent_fk constraint, surfacing as the FK-violation arm below.
+	// so the no-op is unreachable from the agent surface.
+	//
+	// parent_id same-item threading scope (bead unblock-tv8.80, §10.1.1,
+	// §6.2 Tool 10, contract LOCKED by Miguel 2026-06-12): when ParentID is
+	// non-empty it MUST resolve to an existing comment ON THE SAME target
+	// item ($2) — the AND ($3 = '' OR $3 IN (SELECT id FROM
+	// workitems.comments WHERE item_id = $2)) arm below. The target item is
+	// already CallerOrgID-gated by the i.org_id predicate, so same-item
+	// transitively guarantees same-org; no separate parent-org branch is
+	// needed. A foreign-org OR cross-item parent_id matches zero comments →
+	// zero source rows → zero inserted rows → NOT_FOUND, indistinguishable
+	// from a missing parent (closes the live-proven parent_id IDOR). The
+	// empty-ParentID arm preserves the top-level-comment path. The
+	// self-parent prohibition is still enforced by comments_no_self_parent_chk
+	// (a comment cannot be its own parent even on the same item). The
+	// existence-only inline FK to workitems.comments(id) (migration 0040,
+	// ON DELETE SET NULL, unnamed — there is NO constraint named
+	// comments_parent_fk) is retained as defense-in-depth; the INSERT … SELECT
+	// predicate is the primary, tenant- and item-scoped gate.
 	tag, err := db.Exec(ctx,
 		`INSERT INTO workitems.comments
 		   (id, item_id, parent_id, author_id, author_agent, kind, status, body)
 		 SELECT $1, i.id, NULLIF($3, ''), NULLIF($4, ''), NULLIF($5, ''), $6, $7, $8
 		   FROM workitems.items i
 		  WHERE i.id = $2
-		    AND ($9 = '' OR i.org_id = $9)`,
+		    AND ($9 = '' OR i.org_id = $9)
+		    AND ($3 = ''
+		         OR $3 IN (SELECT id FROM workitems.comments WHERE item_id = $2))`,
 		id, req.ItemID, req.ParentID, req.AuthorID, req.AuthorAgent,
 		kind, status, req.Body, req.CallerOrgID,
 	)
@@ -1537,9 +1566,11 @@ func AppendComment(ctx context.Context, req *AppendCommentRequest) (*Comment, er
 		rlog.Error("workitems: append comment failed", "err", err, "item_id", req.ItemID)
 		return nil, &errs.Error{Code: errs.Internal, Message: "append comment failed"}
 	}
-	// Zero inserted rows means the parent item does not exist OR belongs to
-	// another tenant (org_id != CallerOrgID). Surface NOT_FOUND for both so
-	// a cross-tenant ItemID is indistinguishable from a missing one.
+	// Zero inserted rows means the target item does not exist OR belongs to
+	// another tenant (org_id != CallerOrgID) OR a non-empty parent_id does
+	// not resolve to a comment on the SAME target item (foreign-org or
+	// cross-item parent). Surface NOT_FOUND for all so a cross-tenant ItemID
+	// or a foreign/cross-item ParentID is indistinguishable from a missing one.
 	if tag.RowsAffected() == 0 {
 		return nil, &errs.Error{Code: errs.NotFound, Message: "item not found"}
 	}


### PR DESCRIPTION
## unblock-tv8.80: comment.parent_id same-item tenant gate

Closes a P1 cross-tenant IDOR: `AppendComment` inserted the wire-supplied `parent_id` verbatim, gating only the target item by org. A caller could thread under a foreign-org OR cross-item comment, disclosing existence.

### What was done
- Extended the `AppendComment` `INSERT … SELECT` with a same-item `parent_id` predicate: `($3 = '' OR $3 IN (SELECT id FROM workitems.comments WHERE item_id = $2))`. A non-empty `parent_id` must resolve to a comment on the SAME target item; foreign-org OR cross-item → zero rows → `NOT_FOUND`, indistinguishable from a missing parent. Same-item transitively implies same-org (target item already `CallerOrgID`-gated), so no separate parent-org branch.
- Corrected the false code comment at the INSERT site (there is NO `comments_parent_fk` constraint — the FK is an unnamed inline `REFERENCES`; the gate is now the `INSERT … SELECT` predicate) and added same-item scoping prose to the RPC doc-comment.
- Preserved the empty-`parent_id` top-level path, `comments_no_self_parent_chk`, and the existence-only FK as defense-in-depth. No DDL/migration change.

### Files changed
- `apps/api/workitems/workitems.go`
- `apps/api/workitems/integration_test.go`
- `apps/api/exitcriteriontest/write_surface_cross_tenant_test.go`

### Tests
- `write_surface_cross_tenant_test.go`: foreign comment seed + `comment_foreign_parent_id` & `comment_cross_item_parent_id` NOT_FOUND negatives + `comment_same_item_parent_id` positive control.
- `integration_test.go` `TestAppendComment`: same-item-parent thread succeeds & echoes `parent_id`; cross-item-parent → NotFound.
- Full `encore test ./...` PASS; gofmt/go vet/`encore check`/JSON-tag gate clean.

### Decisions
None — implemented per the ratified contract.

### Deviations
None — §6.2 Tool 10 + §10.1.1 SAME-ITEM contract (ratified 0f9d2f4).