### PR TITLE
unblock-tv8.81: narrow set_state I-4 to approved-only — one-call rework reachable

### DIFF
--- a/apps/api/exitcriteriontest/state_invariants_test.go
+++ b/apps/api/exitcriteriontest/state_invariants_test.go
@@ -200,32 +200,52 @@ func TestExitCriterion_StateInvariant_I5(t *testing.T) {
 		}
 	})
 
-	t.Run("rework_path_via_claim_I3", func(t *testing.T) {
-		// SPEC §11.1.2 I-5 last sub-bullet wording: "The same call
-		// when review_state='needs_rework' succeeds." A literal
-		// interpretation (a SetStateColumns request that flips
-		// impl_state=done → pending while also asserting/keeping
-		// review_state=needs_rework) is unreachable through
-		// SetStateColumns by design — I-4 still requires impl=done
-		// when review ∈ {approved, needs_rework} per workitems.go
-		// line 1268, so the combined request rejects on I-4 BEFORE
-		// the rework path can take effect.
+	t.Run("accept_with_rework_path", func(t *testing.T) {
+		// SPEC §11.1.2 I-5 last sub-bullet (lines 3914-3917): "The
+		// same call when review_state='needs_rework' succeeds." The
+		// one-call rework set_state(impl_state=pending,
+		// review_state=needs_rework) on a claimed impl=done item
+		// MUST SUCCEED end-to-end through the MCP surface. I-4 (SPEC
+		// §6.2 Tool 13 line 2241) is the FORWARD gate — only
+		// review→approved requires impl=done; needs_rework is EXEMPT
+		// (governed by I-5, which permits the concurrent impl
+		// done→pending). I-1 auto-resets qa_state→pending.
 		//
-		// The codebase convention (workitems/integration_test.go
-		// line 350-368, TestSetStateInvariantI5AllowedWhenQAAlreadyFailed,
-		// is t.Skip-ed with the same rationale) is that the
-		// canonical rework flow uses Claim's I-3 reset path, not a
-		// one-shot SetStateColumns. We follow the same convention:
-		// the I-3 reset is exercised by TestExitCriterion_StateInvariant_I3
-		// above, which is the spec's intended "rework path
-		// succeeds" assertion mediated by the production code path.
-		//
-		// DEVIATION-LOG (logged on bead unblock-tv8.26): the SPEC
-		// §11.1.2 I-5 second sub-bullet is unreachable through
-		// SetStateColumns alone; the production happy-rework flow
-		// is Claim's I-3. The internal I-3 path is exercised by
-		// the dedicated I-3 test above.
-		t.Skip("I-5 rework happy path is exercised by TestExitCriterion_StateInvariant_I3 (Claim I-3 reset); SetStateColumns one-shot combination is rejected by I-4 per workitems.go:1268. See DEVIATION on bead unblock-tv8.26.")
+		// Regression guard for unblock-tv8.81 (supersedes the prior
+		// t.Skip and its unblock-tv8.26 deviation): before the I-4
+		// predicate was narrowed to approved-only, this call rejected
+		// with review_change_requires_impl_done, making the §11.1.2
+		// exit criterion unsatisfiable through the agent surface.
+		itemID := seedFreshClaimedReady(t, ctx, f, "I-5-accept-target", "approved", "passed")
+
+		pending := "pending"
+		needsRework := "needs_rework"
+		env := callTool(t, f.RawKey, sessionID, "set_state", map[string]any{
+			"item_id":      itemID,
+			"impl_state":   pending,
+			"review_state": needsRework,
+		})
+		raw := expectSuccess(t, env)
+
+		var s struct {
+			Item struct {
+				ImplState   string `json:"impl_state"`
+				ReviewState string `json:"review_state"`
+				QAState     string `json:"qa_state"`
+			} `json:"item"`
+		}
+		if err := json.Unmarshal(raw, &s); err != nil {
+			t.Fatalf("unmarshal set_state result: %v; raw=%s", err, string(raw))
+		}
+		if s.Item.ImplState != "pending" {
+			t.Fatalf("I-5 accept: impl_state = %q, want pending", s.Item.ImplState)
+		}
+		if s.Item.ReviewState != "needs_rework" {
+			t.Fatalf("I-5 accept: review_state = %q, want needs_rework", s.Item.ReviewState)
+		}
+		if s.Item.QAState != "pending" {
+			t.Fatalf("I-5 accept: qa_state = %q, want pending (I-1 auto-reset)", s.Item.QAState)
+		}
 	})
 }
 

--- a/apps/api/workitems/integration_test.go
+++ b/apps/api/workitems/integration_test.go
@@ -341,15 +341,13 @@ func TestSetStateInvariantI4ReviewChangeRequiresImplDone(t *testing.T) {
 
 func TestSetStateInvariantI5ImplDoneToPendingOnlyViaRework(t *testing.T) {
 	// I-5: A bare impl=pending request on an item currently at impl=done
-	// (no review/qa change) MUST reject — the rework path is the only
-	// transition that resets impl. The actual rework workflow per
-	// PRD §6.2 is: (1) SetStateColumns(review_state=needs_rework) flips
-	// review and auto-resets qa (I-1); (2) the next supervisor Claim
-	// resets impl/review/qa to pending (I-3, enforced in Claim).
-	// SetStateColumns itself does NOT support the (impl=pending,
-	// review=needs_rework) one-shot transition — I-4 would still fire
-	// because review_state ∈ {approved,needs_rework} requires
-	// impl_state=done by the spec literal at §6.2 Tool 13 line 1506.
+	// (no review/qa change, no active rework predicate) MUST reject with
+	// impl_done_to_pending_requires_rework_path — the rework path is the
+	// only transition that resets impl. The one-call rework
+	// (impl=pending, review=needs_rework) IS supported and succeeds —
+	// see TestSetStateOneCallReworkSucceeds. SPEC §6.2 Tool 13 I-4 (line
+	// 2241): I-4 is the FORWARD gate (only review→approved requires
+	// impl=done); needs_rework is exempt and governed by I-5.
 	ctx := context.Background()
 	fx := seedFixture(t, ctx)
 	itemID := createReadyItem(t, ctx, fx)
@@ -369,24 +367,55 @@ func TestSetStateInvariantI5ImplDoneToPendingOnlyViaRework(t *testing.T) {
 	}
 }
 
-func TestSetStateInvariantI5AllowedWhenQAAlreadyFailed(t *testing.T) {
-	// I-5 rework-path: when the item is at impl=done and qa=failed
-	// already, a SetStateColumns(impl=pending) with no qa change is
-	// allowed (the failed qa is the rework signal — currentQAFailedAndUnchanged).
-	// But I-2 would block (qa=failed requires review=approved) on the
-	// resulting state if review is changed; here review stays
-	// approved so I-2 passes. I-4 also passes because newImpl=pending
-	// AND newReview is approved → I-4 fires "review approved requires
-	// impl done". So this transition would still trip I-4 by the
-	// literal spec.
+func TestSetStateOneCallReworkSucceeds(t *testing.T) {
+	// SPEC §6.2 Tool 13 I-4 (line 2241) + §11.1.2 exit criterion
+	// (lines 3914-3917): the one-call rework
+	// set_state(impl_state=pending, review_state=needs_rework) on a
+	// CLAIMED item at impl=done MUST SUCCEED. I-5 (workitems.go) permits
+	// the concurrent impl done→pending because the review=needs_rework
+	// rework predicate is satisfied; I-4 is the FORWARD gate and is
+	// EXEMPT for needs_rework (only approved requires impl=done); I-1
+	// auto-resets qa_state→pending. Result: impl=pending,
+	// review=needs_rework, qa=pending.
 	//
-	// In practice the rework flow goes via Claim's I-3 reset, not via
-	// SetStateColumns. This test is intentionally NOT testing a
-	// "happy" rework via SetStateColumns; it documents that I-5's
-	// rework-path detection works (the rejection skips when the
-	// rework predicate is satisfied). The downstream I-4 enforcement
-	// is the next gate.
-	t.Skip("I-5 rework-path interactions with I-4 are documented in workitems.go; the only end-to-end rework is via Claim (TestClaimResetsReworkOnQAFailed).")
+	// This is the regression guard for unblock-tv8.81: before the fix,
+	// I-4 keyed on the coalesced new_review IN (approved, needs_rework)
+	// and over-fired "review_change_requires_impl_done" on this call,
+	// making the §11.1.2 exit criterion unsatisfiable through the MCP
+	// surface.
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+	itemID := createReadyItem(t, ctx, fx)
+	// Claimed item at impl=done, review=approved, qa=passed.
+	setItemState(t, ctx, itemID, "done", "approved", "passed", fx.UserID)
+
+	newImpl := "pending"
+	newReview := "needs_rework"
+	got, err := workitems.SetStateColumns(ctx, &workitems.SetStateRequest{
+		ItemID:      itemID,
+		ImplState:   &newImpl,
+		ReviewState: &newReview,
+	})
+	if err != nil {
+		t.Fatalf("one-call rework SetStateColumns: unexpected error: %v", err)
+	}
+	if got.ImplState != "pending" {
+		t.Fatalf("impl_state = %q, want pending", got.ImplState)
+	}
+	if got.ReviewState != "needs_rework" {
+		t.Fatalf("review_state = %q, want needs_rework", got.ReviewState)
+	}
+	// I-1 auto-reset: review_state=needs_rework forces qa_state→pending.
+	if got.QAState != "pending" {
+		t.Fatalf("qa_state = %q, want pending (I-1 auto-reset)", got.QAState)
+	}
+
+	// Verify the persisted row matches the returned Item.
+	impl, review, qa, _ := readItemStateColumns(t, ctx, itemID)
+	if impl != "pending" || review != "needs_rework" || qa != "pending" {
+		t.Fatalf("persisted (impl,review,qa) = (%q,%q,%q), want (pending,needs_rework,pending)",
+			impl, review, qa)
+	}
 }
 
 func TestSetStateImplDoneRequiresClaim(t *testing.T) {
@@ -560,7 +589,7 @@ func TestClaimResetsReworkOnQAFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
-	// SPEC §6.2 I-3 line 1505: Claim resets review_state + qa_state to
+	// SPEC §6.2 Tool 13 I-3 (line 2240): Claim resets review_state + qa_state to
 	// pending. impl_state is deliberately preserved (the worker drives
 	// any impl_state mutation through SetStateColumns, which enforces
 	// I-4/I-5 against the rework path).
@@ -1086,7 +1115,7 @@ func TestMilestoneTreeAssemblesNestedStructure(t *testing.T) {
 //	(phase 3, sequential) Claim — observes qa='failed' and applies
 //	  I-3 atomically, resetting review_state + qa_state to 'pending'.
 //	  impl_state MUST remain 'done' (I-3 scope is review+qa only,
-//	  matching SPEC §6.2 line 1505 verbatim).
+//	  matching SPEC §6.2 Tool 13 I-3 line 2240 verbatim).
 //
 // Iterating phases 1+2+3 N times stresses both the SELECT FOR UPDATE
 // serialisation (phase 1) and the I-3 atomic reset (phase 3) under
@@ -1196,7 +1225,7 @@ func TestClaimVsSetStateColumnsRaceAR18(t *testing.T) {
 		}
 		// I-3: review_state + qa_state both reset to 'pending';
 		// impl_state preserved (scope is review+qa only per SPEC §6.2
-		// line 1505).
+		// Tool 13 I-3 line 2240).
 		if got.ReviewState != "pending" || got.QAState != "pending" {
 			i3Violations++
 			t.Fatalf("iter %d phase 3 I-3 reset: review=%q qa=%q (want pending/pending)",

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -1672,8 +1672,15 @@ func SetStateColumns(ctx context.Context, req *SetStateRequest) (*Item, error) {
 		}
 	}
 
-	// I-4: review_state ∈ (approved, needs_rework) requires impl_state=done.
-	if (newReview == reviewApproved || newReview == reviewNeedsRework) && newImpl != implDone {
+	// I-4 (FORWARD review gate, SPEC §6.2 Tool 13 line 2241 + SQL
+	// pseudocode line 2269): review_state → approved requires
+	// impl_state=done. The review_state → needs_rework transition is the
+	// REWORK trigger, governed by I-5 above (which legitimately permits
+	// the concurrent impl done → pending), so it is EXEMPT from I-4.
+	// Keying on needs_rework here would make the one-call
+	// set_state(impl_state=pending, review_state=needs_rework) rework
+	// unreachable and violate the §11.1.2 exit criterion.
+	if newReview == reviewApproved && newImpl != implDone {
 		return nil, preconditionError("review_change_requires_impl_done", "review_state change requires impl_state=done")
 	}
 


### PR DESCRIPTION
## unblock-tv8.81: set_state rework transition unreachable — I-4 over-fires

The I-4 `set_state` precondition keyed on the COALESCED `new_review IN (approved, needs_rework)`, so the one-call rework `set_state(impl_state=pending, review_state=needs_rework)` on a claimed `impl=done` item over-fired and rejected with `review_change_requires_impl_done` — making the SPEC §11.1.2 I-5 exit criterion ("the same call when `review_state='needs_rework'` succeeds") unsatisfiable through the MCP surface.

### What was done
Narrowed the I-4 predicate to the FORWARD gate only: reject iff `new_review == approved && new_impl != done`. `needs_rework` is exempt — it is the rework trigger governed by I-5 (which permits the concurrent `impl done→pending`). I-5 and I-1 (qa auto-reset) were already correct; no change. Matches the reconciled SPEC §6.2 Tool 13 I-4 (prose line 2241 + SQL pseudocode line 2269), committed to main as c505195.

### Files changed
- `apps/api/workitems/workitems.go` — I-4 predicate at the SetStateColumns invariant block
- `apps/api/workitems/integration_test.go` — replaced skipped `TestSetStateInvariantI5AllowedWhenQAAlreadyFailed` with `TestSetStateOneCallReworkSucceeds`; refreshed stale §6.2 line-number comments
- `apps/api/exitcriteriontest/state_invariants_test.go` — un-skipped the I-5 `accept_with_rework_path` sub-test (end-to-end via the set_state MCP tool)

### Decisions
None — implemented per the ratified spec reconciliation.

### Deviations
None — implemented as spec. Additionally un-skipped the parallel end-to-end MCP exit-criterion sub-test (the §11.1.2 "succeeds" clause through the agent surface), superseding its stale unblock-tv8.26 t.Skip. No spec file change (§6.2 + §11.1.2 already reconciled on main).

### Tests
`encore test ./...` fully green (16 packages). I-1..I-5 invariant tests pass; no-regression guards confirmed (review→approved on impl=pending still rejects; bare impl=pending still rejects). go fmt / go vet / encore check clean.