### PR TITLE
unblock-tv8.82: Uniform §7 VALIDATION at the MCP boundary

### DIFF
--- a/apps/api/exitcriteriontest/uniform_validation_test.go
+++ b/apps/api/exitcriteriontest/uniform_validation_test.go
@@ -1,0 +1,225 @@
+// uniform_validation_test.go is the end-to-end matrix for the
+// unblock-tv8.82 uniform §7 argument-validation contract (SPEC §7.3 /
+// §7.3.1 / §7.3.2 + §6.2.0a). It drives the real Streamable HTTP MCP
+// tools/call surface and asserts that EVERY argument-shape violation —
+// missing required, invalid enum, wrong JSON type, out-of-range numeric
+// bound, and unknown argument — surfaces the §7 VALIDATION envelope
+// (kind=VALIDATION, trace_id, data.field; data.bound on a range
+// violation), uniformly, with NO bare isError text frame. A happy-path
+// control proves valid in-range arguments still pass.
+//
+// expectError() (transport_test.go) already unwraps error.data into
+// envelopeData{Kind, Tool, TraceID, Details}; we assert on those fields.
+
+package exitcriteriontest_test
+
+import (
+	"testing"
+)
+
+// TestExitCriterion_UniformValidation_Matrix exercises the four
+// violation classes (+ unknown-key + happy control) across a
+// representative slice of the 23-tool surface.
+func TestExitCriterion_UniformValidation_Matrix(t *testing.T) {
+	f := fx(t)
+	sessionID := initializeSession(t, f.RawKey)
+
+	// validationCase is one row of the matrix: a tool + arguments that
+	// MUST reject with §7 VALIDATION naming wantField (and wantBound when
+	// the violation is a numeric range).
+	type validationCase struct {
+		name      string
+		tool      string
+		args      map[string]any
+		wantField string
+		wantBound string // "" → not a range violation; data.bound not asserted
+	}
+
+	cases := []validationCase{
+		// --- missing required ---
+		{
+			name:      "claim_missing_item_id",
+			tool:      "claim",
+			args:      map[string]any{},
+			wantField: "item_id",
+		},
+		{
+			name:      "search_missing_query",
+			tool:      "search",
+			args:      map[string]any{"project_id": f.ProjectID},
+			wantField: "query",
+		},
+		{
+			name:      "create_missing_title",
+			tool:      "create",
+			args:      map[string]any{"project_id": f.ProjectID, "type": "task"},
+			wantField: "title",
+		},
+
+		// --- invalid enum ---
+		{
+			name:      "create_invalid_type_enum",
+			tool:      "create",
+			args:      map[string]any{"project_id": f.ProjectID, "title": "x", "type": "bogus"},
+			wantField: "type",
+		},
+		{
+			name:      "create_invalid_priority_enum",
+			tool:      "create",
+			args:      map[string]any{"project_id": f.ProjectID, "title": "x", "priority": "P9"},
+			wantField: "priority",
+		},
+		{
+			name:      "set_state_invalid_impl_state_enum",
+			tool:      "set_state",
+			args:      map[string]any{"item_id": f.ItemID("itm_a"), "impl_state": "bogus"},
+			wantField: "impl_state",
+		},
+		{
+			name:      "ready_invalid_priority_min_enum",
+			tool:      "ready",
+			args:      map[string]any{"project_id": f.ProjectID, "priority_min": "P9"},
+			wantField: "priority_min",
+		},
+		{
+			name:      "comment_invalid_kind_enum",
+			tool:      "comment",
+			args:      map[string]any{"item_id": f.ItemID("itm_a"), "body": "b", "kind": "bogus"},
+			wantField: "kind",
+		},
+		{
+			name:      "add_dependency_invalid_kind_enum",
+			tool:      "add_dependency",
+			args:      map[string]any{"from_item_id": f.ItemID("itm_a"), "to_item_id": f.ItemID("itm_b"), "kind": "bogus"},
+			wantField: "kind",
+		},
+
+		// --- wrong type ---
+		{
+			name:      "ready_limit_wrong_type_string",
+			tool:      "ready",
+			args:      map[string]any{"project_id": f.ProjectID, "limit": "ten"},
+			wantField: "limit",
+		},
+		{
+			name:      "list_status_wrong_type_string",
+			tool:      "list",
+			args:      map[string]any{"project_id": f.ProjectID, "status": "Ready"},
+			wantField: "status",
+		},
+
+		// --- out-of-range numeric bound (data.bound asserted) ---
+		{
+			name:      "prime_ready_limit_zero",
+			tool:      "prime",
+			args:      map[string]any{"project_id": f.ProjectID, "ready_limit": 0},
+			wantField: "ready_limit",
+			wantBound: "1..50",
+		},
+		{
+			name:      "prime_ready_limit_above_max",
+			tool:      "prime",
+			args:      map[string]any{"project_id": f.ProjectID, "ready_limit": 51},
+			wantField: "ready_limit",
+			wantBound: "1..50",
+		},
+		{
+			name:      "ready_limit_zero",
+			tool:      "ready",
+			args:      map[string]any{"project_id": f.ProjectID, "limit": 0},
+			wantField: "limit",
+			wantBound: "1..200",
+		},
+		{
+			name:      "ready_limit_above_max",
+			tool:      "ready",
+			args:      map[string]any{"project_id": f.ProjectID, "limit": 201},
+			wantField: "limit",
+			wantBound: "1..200",
+		},
+		{
+			name:      "list_limit_above_max",
+			tool:      "list",
+			args:      map[string]any{"project_id": f.ProjectID, "limit": 201},
+			wantField: "limit",
+			wantBound: "1..200",
+		},
+		{
+			name:      "search_limit_zero",
+			tool:      "search",
+			args:      map[string]any{"project_id": f.ProjectID, "query": "x", "limit": 0},
+			wantField: "limit",
+			wantBound: "1..100",
+		},
+		{
+			name:      "search_limit_above_max",
+			tool:      "search",
+			args:      map[string]any{"project_id": f.ProjectID, "query": "x", "limit": 101},
+			wantField: "limit",
+			wantBound: "1..100",
+		},
+
+		// --- unknown argument (additionalProperties:false) ---
+		{
+			name:      "ready_unknown_argument",
+			tool:      "ready",
+			args:      map[string]any{"project_id": f.ProjectID, "bogus_field": "v"},
+			wantField: "bogus_field",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			env := callTool(t, f.RawKey, sessionID, tc.tool, tc.args)
+			data := expectError(t, env)
+			if data.Kind != "VALIDATION" {
+				t.Fatalf("%s: kind = %q, want VALIDATION", tc.tool, data.Kind)
+			}
+			if data.TraceID == "" {
+				t.Fatalf("%s: §7 envelope requires a non-empty trace_id", tc.tool)
+			}
+			if data.Tool != tc.tool {
+				t.Fatalf("%s: data.tool = %q, want %q", tc.tool, data.Tool, tc.tool)
+			}
+			if got, _ := data.Details["field"].(string); got != tc.wantField {
+				t.Fatalf("%s: data.field = %q, want %q (details=%v)", tc.tool, got, tc.wantField, data.Details)
+			}
+			if tc.wantBound != "" {
+				if got, _ := data.Details["bound"].(string); got != tc.wantBound {
+					t.Fatalf("%s: data.bound = %q, want %q", tc.tool, got, tc.wantBound)
+				}
+			}
+		})
+	}
+}
+
+// TestExitCriterion_UniformValidation_HappyControl proves the validation
+// layer does NOT reject valid in-range arguments: an OMITTED limit takes
+// the per-tool default (not a rejected zero), and an in-range supplied
+// limit passes. This is the control that distinguishes "rejects
+// out-of-range" from "rejects everything".
+func TestExitCriterion_UniformValidation_HappyControl(t *testing.T) {
+	f := fx(t)
+	sessionID := initializeSession(t, f.RawKey)
+
+	// Omitted limit → default applied, success.
+	omittedEnv := callTool(t, f.RawKey, sessionID, "ready", map[string]any{
+		"project_id": f.ProjectID,
+	})
+	_ = expectSuccess(t, omittedEnv)
+
+	// In-range supplied limit → success.
+	inRangeEnv := callTool(t, f.RawKey, sessionID, "ready", map[string]any{
+		"project_id": f.ProjectID,
+		"limit":      1,
+	})
+	_ = expectSuccess(t, inRangeEnv)
+
+	// In-range supplied prime.ready_limit at the boundary (50) → success.
+	primeEnv := callTool(t, f.RawKey, sessionID, "prime", map[string]any{
+		"project_id":  f.ProjectID,
+		"ready_limit": 50,
+	})
+	_ = expectSuccess(t, primeEnv)
+}

--- a/apps/api/mcp/catalogue_test.go
+++ b/apps/api/mcp/catalogue_test.go
@@ -292,6 +292,20 @@ func TestGeneratedCatalogueRoundTrips(t *testing.T) {
 // same code path the wire-protocol does.
 func liveSDKToolNames(t *testing.T) []string {
 	t.Helper()
+	tools := liveSDKTools(t)
+	names := make([]string, 0, len(tools))
+	for name := range tools {
+		names = append(names, name)
+	}
+	return names
+}
+
+// liveSDKTools drives the SDK's tools/list over an in-memory transport
+// pair (the wire-protocol path agents use) and returns the advertised
+// *Tool per name. Used to assert BOTH the tool-name inventory and the
+// advertised InputSchema parity against the catalogue.
+func liveSDKTools(t *testing.T) map[string]*sdkmcp.Tool {
+	t.Helper()
 	ctx := context.Background()
 
 	clientTransport, serverTransport := sdkmcp.NewInMemoryTransports()
@@ -317,9 +331,69 @@ func liveSDKToolNames(t *testing.T) []string {
 		t.Fatalf("clientSession.ListTools: %v", err)
 	}
 
-	names := make([]string, 0, len(res.Tools))
+	tools := make(map[string]*sdkmcp.Tool, len(res.Tools))
 	for _, tool := range res.Tools {
-		names = append(names, tool.Name)
+		tools[tool.Name] = tool
 	}
-	return names
+	return tools
+}
+
+// TestRegisteredInputSchemaMatchesCatalogue is the unblock-tv8.82
+// schema-parity drift guard (§6.2.0a + §7.3.2). The pre-existing
+// TestCatalogueNamesMatchToolRegistrars asserts only NAME equality
+// between catalogue.json and the live tools/list; it does NOT diff the
+// schemas, so a schema-enriching rework could silently advertise a schema
+// that diverges from the catalogue. This test closes that gap: the rich
+// InputSchema the SDK advertises in tools/list for every tool MUST be
+// byte-identical (under canonicalisation) to the catalogue's input_schema.
+// They share a single source of truth — registerValidatedTool reads the
+// advertised schema straight from ToolByName(name).InputSchema — so this
+// is a structural guarantee, asserted here to keep it that way.
+func TestRegisteredInputSchemaMatchesCatalogue(t *testing.T) {
+	doc := loadCatalogueFromDisk(t)
+	catalogueByName := make(map[string]json.RawMessage, len(doc.Tools))
+	for _, tool := range doc.Tools {
+		catalogueByName[tool.Name] = tool.InputSchema
+	}
+
+	live := liveSDKTools(t)
+	for name, want := range catalogueByName {
+		tool, ok := live[name]
+		if !ok {
+			t.Errorf("tool %q present in catalogue.json but not in live tools/list", name)
+			continue
+		}
+		gotCanon := canonicaliseJSON(t, mustMarshalSchema(t, tool.InputSchema))
+		wantCanon := canonicaliseJSON(t, want)
+		if gotCanon != wantCanon {
+			t.Errorf("tool %q advertised input schema differs from catalogue:\n  live      = %s\n  catalogue = %s",
+				name, gotCanon, wantCanon)
+		}
+	}
+}
+
+// mustMarshalSchema marshals the advertised InputSchema (a
+// *jsonschema.Schema or remarshalable value) back to JSON bytes.
+func mustMarshalSchema(t *testing.T, schema any) []byte {
+	t.Helper()
+	b, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal advertised InputSchema: %v", err)
+	}
+	return b
+}
+
+// canonicaliseJSON round-trips JSON bytes through a map so key order and
+// whitespace are normalised before comparison.
+func canonicaliseJSON(t *testing.T, raw []byte) string {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("canonicalise: unmarshal %s: %v", string(raw), err)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("canonicalise: marshal: %v", err)
+	}
+	return string(out)
 }

--- a/apps/api/mcp/errmap.go
+++ b/apps/api/mcp/errmap.go
@@ -183,6 +183,16 @@ func classifyEnvelopeError(err error) envelopeError {
 		} else {
 			details["reason"] = msg
 		}
+		// SPEC §7.3.1 (bead unblock-tv8.82): an out-of-range numeric
+		// argument (paginated limit / ready_limit below the minimum or
+		// above the maximum) carries the advertised inclusive range under
+		// Meta["bound"] (e.g. "1..200"). Surface it as data.bound so the
+		// agent can self-correct. Present only on range violations; other
+		// VALIDATION causes (missing required, invalid enum, wrong type)
+		// omit it.
+		if v, ok := e.Meta["bound"].(string); ok && v != "" {
+			details["bound"] = v
+		}
 		return envelopeError{kind: envelopeKindValidation, message: msg, details: details}
 
 	case errs.AlreadyExists:

--- a/apps/api/mcp/handler_add_dependency.go
+++ b/apps/api/mcp/handler_add_dependency.go
@@ -78,14 +78,13 @@ type addDependencyOut struct {
 // registerHandleAddDependency is invoked by transport.go's init — see
 // the toolRegistrars rationale there.
 func registerHandleAddDependency(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "add_dependency",
-		Description: "Add a dependency edge between two work items in the " +
-			"same project. Cycle-detected inline (per-project advisory " +
-			"lock + depth-counter CTE per §6.5). Cross-project edges are " +
-			"rejected with VALIDATION. kind defaults to \"blocks\". " +
+	registerValidatedTool(s, "add_dependency",
+		"Add a dependency edge between two work items in the "+
+			"same project. Cycle-detected inline (per-project advisory "+
+			"lock + depth-counter CTE per §6.5). Cross-project edges are "+
+			"rejected with VALIDATION. kind defaults to \"blocks\". "+
 			"SPEC § 6.2 Tool 11.",
-	}, handleAddDependency)
+		nil, handleAddDependency)
 }
 
 func handleAddDependency(ctx context.Context, req *sdkmcp.CallToolRequest, in addDependencyIn) (*sdkmcp.CallToolResult, addDependencyOut, error) {

--- a/apps/api/mcp/handler_assign_item.go
+++ b/apps/api/mcp/handler_assign_item.go
@@ -56,14 +56,13 @@ type assignItemOut struct {
 // registerHandleAssignItem is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleAssignItem(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "assign_item",
-		Description: "Assign a work item to a milestone, or unassign it by " +
-			"passing milestone_id as the empty string. The actor is the " +
-			"calling identity (not a wire argument). A milestone not reachable " +
-			"in the item's project rejects with PRECONDITION_NOT_MET " +
+	registerValidatedTool(s, "assign_item",
+		"Assign a work item to a milestone, or unassign it by "+
+			"passing milestone_id as the empty string. The actor is the "+
+			"calling identity (not a wire argument). A milestone not reachable "+
+			"in the item's project rejects with PRECONDITION_NOT_MET "+
 			"(data.invariant=M-INV-7). SPEC § 6.2 Tool 18.",
-	}, handleAssignItem)
+		nil, handleAssignItem)
 }
 
 func handleAssignItem(ctx context.Context, req *sdkmcp.CallToolRequest, in assignItemIn) (*sdkmcp.CallToolResult, assignItemOut, error) {

--- a/apps/api/mcp/handler_claim.go
+++ b/apps/api/mcp/handler_claim.go
@@ -31,12 +31,11 @@ type claimOut struct {
 // registerHandleClaim is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleClaim(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "claim",
-		Description: "Atomically claim a Ready item. Loser path returns " +
-			"ALREADY_CLAIMED with winner_user_id, winner_agent, " +
+	registerValidatedTool(s, "claim",
+		"Atomically claim a Ready item. Loser path returns "+
+			"ALREADY_CLAIMED with winner_user_id, winner_agent, "+
 			"claimed_at. SPEC § 6.2 Tool 3 + § 6.4.",
-	}, handleClaim)
+		nil, handleClaim)
 }
 
 func handleClaim(ctx context.Context, req *sdkmcp.CallToolRequest, in claimIn) (*sdkmcp.CallToolResult, claimOut, error) {

--- a/apps/api/mcp/handler_close.go
+++ b/apps/api/mcp/handler_close.go
@@ -46,13 +46,12 @@ type closeOut struct {
 // registerHandleClose is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleClose(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "close",
-		Description: "Flip an item to Done. Rejects with PRECONDITION_NOT_MET " +
-			"(data.missing=claimed_by_id) when the item is not currently " +
-			"claimed. Emits CascadeRequested{Reason:\"close\"} post-commit. " +
+	registerValidatedTool(s, "close",
+		"Flip an item to Done. Rejects with PRECONDITION_NOT_MET "+
+			"(data.missing=claimed_by_id) when the item is not currently "+
+			"claimed. Emits CascadeRequested{Reason:\"close\"} post-commit. "+
 			"SPEC § 6.2 Tool 6.",
-	}, handleClose)
+		nil, handleClose)
 }
 
 func handleClose(ctx context.Context, req *sdkmcp.CallToolRequest, in closeIn) (*sdkmcp.CallToolResult, closeOut, error) {

--- a/apps/api/mcp/handler_comment.go
+++ b/apps/api/mcp/handler_comment.go
@@ -75,13 +75,12 @@ type commentOut struct {
 // registerHandleComment is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleComment(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "comment",
-		Description: "Append a comment to a work item. Append-only — no " +
-			"update or delete tool ships in P01. Validates kind/status " +
-			"against §6.5 enums; body length 1..16384 chars. SPEC § 6.2 " +
+	registerValidatedTool(s, "comment",
+		"Append a comment to a work item. Append-only — no "+
+			"update or delete tool ships in P01. Validates kind/status "+
+			"against §6.5 enums; body length 1..16384 chars. SPEC § 6.2 "+
 			"Tool 10.",
-	}, handleComment)
+		nil, handleComment)
 }
 
 func handleComment(ctx context.Context, req *sdkmcp.CallToolRequest, in commentIn) (*sdkmcp.CallToolResult, commentOut, error) {

--- a/apps/api/mcp/handler_create.go
+++ b/apps/api/mcp/handler_create.go
@@ -54,13 +54,12 @@ type createOut struct {
 // registerHandleCreate is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleCreate(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "create",
-		Description: "Create a new work item (epic | task | finding). " +
-			"Optional dependencies[] entries are cycle-checked inline " +
-			"inside the same transaction as the item insert; on any " +
+	registerValidatedTool(s, "create",
+		"Create a new work item (epic | task | finding). "+
+			"Optional dependencies[] entries are cycle-checked inline "+
+			"inside the same transaction as the item insert; on any "+
 			"failure the entire create is rejected. SPEC § 6.2 Tool 4.",
-	}, handleCreate)
+		nil, handleCreate)
 }
 
 func handleCreate(ctx context.Context, req *sdkmcp.CallToolRequest, in createIn) (*sdkmcp.CallToolResult, createOut, error) {

--- a/apps/api/mcp/handler_create_label.go
+++ b/apps/api/mcp/handler_create_label.go
@@ -51,14 +51,13 @@ type createLabelOut struct {
 // registerHandleCreateLabel is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleCreateLabel(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "create_label",
-		Description: "Create a label in the registry, scoped to the caller's " +
-			"org or to a project (pass project_id to project-scope; omit it to " +
-			"org-scope). name is 1..64 chars and unique within scope " +
-			"(case-insensitive); color is #RRGGBB. A duplicate name rejects " +
+	registerValidatedTool(s, "create_label",
+		"Create a label in the registry, scoped to the caller's "+
+			"org or to a project (pass project_id to project-scope; omit it to "+
+			"org-scope). name is 1..64 chars and unique within scope "+
+			"(case-insensitive); color is #RRGGBB. A duplicate name rejects "+
 			"with CONFLICT carrying data.constraint. SPEC § 6.2 Tool 20.",
-	}, handleCreateLabel)
+		nil, handleCreateLabel)
 }
 
 func handleCreateLabel(ctx context.Context, req *sdkmcp.CallToolRequest, in createLabelIn) (*sdkmcp.CallToolResult, createLabelOut, error) {

--- a/apps/api/mcp/handler_create_milestone.go
+++ b/apps/api/mcp/handler_create_milestone.go
@@ -54,15 +54,14 @@ type createMilestoneOut struct {
 // registerHandleCreateMilestone is invoked by transport.go's init — see
 // the toolRegistrars rationale there.
 func registerHandleCreateMilestone(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "create_milestone",
-		Description: "Create a milestone scoped to the caller's org or to a " +
-			"project (pass project_id to project-scope; omit it to org-scope). " +
-			"Optional parent_milestone_id nests the milestone (depth ≤ 4); the " +
-			"child date range must be within the parent's. Invariant violations " +
-			"(M-INV-2/3/5/6) reject with PRECONDITION_NOT_MET carrying " +
+	registerValidatedTool(s, "create_milestone",
+		"Create a milestone scoped to the caller's org or to a "+
+			"project (pass project_id to project-scope; omit it to org-scope). "+
+			"Optional parent_milestone_id nests the milestone (depth ≤ 4); the "+
+			"child date range must be within the parent's. Invariant violations "+
+			"(M-INV-2/3/5/6) reject with PRECONDITION_NOT_MET carrying "+
 			"data.invariant. SPEC § 6.2 Tool 16.",
-	}, handleCreateMilestone)
+		nil, handleCreateMilestone)
 }
 
 func handleCreateMilestone(ctx context.Context, req *sdkmcp.CallToolRequest, in createMilestoneIn) (*sdkmcp.CallToolResult, createMilestoneOut, error) {

--- a/apps/api/mcp/handler_delete_label.go
+++ b/apps/api/mcp/handler_delete_label.go
@@ -42,13 +42,12 @@ type deleteLabelOut struct {
 // registerHandleDeleteLabel is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleDeleteLabel(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "delete_label",
-		Description: "Delete a label from the registry. Detaches it from every " +
-			"item it was applied to (the items are not deleted); " +
-			"detached_item_count reports how many attachments were removed. " +
+	registerValidatedTool(s, "delete_label",
+		"Delete a label from the registry. Detaches it from every "+
+			"item it was applied to (the items are not deleted); "+
+			"detached_item_count reports how many attachments were removed. "+
 			"A missing label rejects with NOT_FOUND. SPEC § 6.2 Tool 23.",
-	}, handleDeleteLabel)
+		nil, handleDeleteLabel)
 }
 
 func handleDeleteLabel(ctx context.Context, req *sdkmcp.CallToolRequest, in deleteLabelIn) (*sdkmcp.CallToolResult, deleteLabelOut, error) {

--- a/apps/api/mcp/handler_get_state.go
+++ b/apps/api/mcp/handler_get_state.go
@@ -74,13 +74,12 @@ type getStateOut struct {
 // registerHandleGetState is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleGetState(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "get_state",
-		Description: "Read the four state dimensions + materialised " +
-			"pipeline_stage + is_ready + claim columns + the per-kind " +
-			"recent_kinds aggregate from workitems.comments (one row per " +
+	registerValidatedTool(s, "get_state",
+		"Read the four state dimensions + materialised "+
+			"pipeline_stage + is_ready + claim columns + the per-kind "+
+			"recent_kinds aggregate from workitems.comments (one row per "+
 			"distinct kind, most recent first). SPEC § 6.2 Tool 14.",
-	}, handleGetState)
+		nil, handleGetState)
 }
 
 func handleGetState(ctx context.Context, req *sdkmcp.CallToolRequest, in getStateIn) (*sdkmcp.CallToolResult, getStateOut, error) {

--- a/apps/api/mcp/handler_list.go
+++ b/apps/api/mcp/handler_list.go
@@ -41,15 +41,12 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// listLimitDefault / listLimitMax mirror SPEC §6.2 Tool 8 line 1389
-// (1..200; default 50). Aligns with workitems.listDefaultLimit /
-// listMaxLimit so the wire ceiling matches the downstream RPC.
-// Two local consts keep this handler's behaviour readable without
-// chasing constants across package boundaries.
-const (
-	listLimitDefault = 50
-	listLimitMax     = 200
-)
+// listLimitDefault is the per-tool default applied when `limit` is
+// OMITTED (SPEC §6.2 Tool 8 line 1389: default 50). The advertised
+// inclusive range (1..200) lives in catalogue.gen.go and is ENFORCED by
+// the shared validateArgs boundary pass (§7.3.1) — a supplied
+// out-of-range value rejects with VALIDATION, never clamps.
+const listLimitDefault = 50
 
 type listIn struct {
 	ProjectID     string   `json:"project_id,omitempty"`
@@ -73,12 +70,11 @@ type listOut struct {
 // registerHandleList is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleList(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "list",
-		Description: "Paginate workitems with scalar + array filters " +
-			"(project_id, milestone_id, status, pipeline_stage, " +
+	registerValidatedTool(s, "list",
+		"Paginate workitems with scalar + array filters "+
+			"(project_id, milestone_id, status, pipeline_stage, "+
 			"claimed_by, labels). Ordered by id ASC. SPEC § 6.2 Tool 8.",
-	}, handleList)
+		nil, handleList)
 }
 
 func handleList(ctx context.Context, req *sdkmcp.CallToolRequest, in listIn) (*sdkmcp.CallToolResult, listOut, error) {
@@ -98,19 +94,12 @@ func handleList(ctx context.Context, req *sdkmcp.CallToolRequest, in listIn) (*s
 		state.Call.ProjectID = in.ProjectID
 	}
 
-	// Limit bounds — same shape as handler_ready.go (rework S4): explicit
-	// default coercion + explicit range rejection. limit=0/negative
-	// coerces to listLimitDefault (50); limit > listLimitMax is a
-	// contract violation surfaced as VALIDATION.
-	if in.Limit <= 0 {
+	// §7.3.1: a SUPPLIED limit outside 1..200 was already rejected with
+	// VALIDATION by the shared validateArgs boundary pass (§7.3.2). A
+	// zero here can only mean the argument was OMITTED, so we apply the
+	// per-tool default on omission only — no clamp, no coerce.
+	if in.Limit == 0 {
 		in.Limit = listLimitDefault
-	}
-	if in.Limit > listLimitMax {
-		return nil, listOut{}, mapError(state, tool, &errs.Error{
-			Code:    errs.InvalidArgument,
-			Message: "limit out of range (1..200)",
-			Meta:    errs.Metadata{"field": "limit"},
-		})
 	}
 
 	// §6.2.0 cursor decode — the opaque token is verified and the {id}

--- a/apps/api/mcp/handler_list_label.go
+++ b/apps/api/mcp/handler_list_label.go
@@ -37,13 +37,12 @@ type listLabelsOut struct {
 // registerHandleListLabel is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleListLabel(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "list_labels",
-		Description: "List labels visible to the caller within a scope. Without " +
-			"project_id, returns the caller's org labels. With project_id, " +
-			"returns the project's labels plus the inherited org labels " +
+	registerValidatedTool(s, "list_labels",
+		"List labels visible to the caller within a scope. Without "+
+			"project_id, returns the caller's org labels. With project_id, "+
+			"returns the project's labels plus the inherited org labels "+
 			"(project wins on identical name). SPEC § 6.2 Tool 21.",
-	}, handleListLabel)
+		nil, handleListLabel)
 }
 
 func handleListLabel(ctx context.Context, req *sdkmcp.CallToolRequest, in listLabelsIn) (*sdkmcp.CallToolResult, listLabelsOut, error) {

--- a/apps/api/mcp/handler_milestone_tree.go
+++ b/apps/api/mcp/handler_milestone_tree.go
@@ -95,15 +95,13 @@ var milestoneTreeOutputSchema = &jsonschema.Schema{
 // registerHandleMilestoneTree is invoked by transport.go's init — see
 // the toolRegistrars rationale there.
 func registerHandleMilestoneTree(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "milestone_tree",
-		Description: "Return the milestone tree for the caller's org (or a " +
-			"project, via project_id), or the subtree rooted at " +
-			"root_milestone_id. Depth is bounded at 4. Pass " +
-			"include_cancelled=true to include cancelled milestones. " +
+	registerValidatedTool(s, "milestone_tree",
+		"Return the milestone tree for the caller's org (or a "+
+			"project, via project_id), or the subtree rooted at "+
+			"root_milestone_id. Depth is bounded at 4. Pass "+
+			"include_cancelled=true to include cancelled milestones. "+
 			"SPEC § 6.2 Tool 19.",
-		OutputSchema: milestoneTreeOutputSchema,
-	}, handleMilestoneTree)
+		milestoneTreeOutputSchema, handleMilestoneTree)
 }
 
 func handleMilestoneTree(ctx context.Context, req *sdkmcp.CallToolRequest, in milestoneTreeIn) (*sdkmcp.CallToolResult, milestoneTreeOut, error) {

--- a/apps/api/mcp/handler_prime.go
+++ b/apps/api/mcp/handler_prime.go
@@ -31,11 +31,6 @@ import (
 // (default 10, range 1..50). Same shape as the Tool 2 `ready` limit.
 const primeReadyLimitDefault = 10
 
-// primeReadyLimitMax mirrors readyMaxLimit — kept as a separate
-// const so a future spec amendment that diverges Tool 1 from Tool 2
-// is a single-line edit here.
-const primeReadyLimitMax = 50
-
 // primeClaimedPageSize is the cursor page size used by the
 // claimed_by_me fan-out loop. Matches workitems.listMaxLimit (the
 // hard ceiling enforced inside workitems.List) so each round-trip
@@ -130,12 +125,11 @@ type primeMemoryHint struct {
 // order hazard where handler_*.go inits would otherwise crash on a
 // nil sdkServer).
 func registerHandlePrime(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "prime",
-		Description: "Dashboard read for a fresh agent session: ready " +
-			"summary, items the caller already claims, recent cascade " +
+	registerValidatedTool(s, "prime",
+		"Dashboard read for a fresh agent session: ready "+
+			"summary, items the caller already claims, recent cascade "+
 			"events, and (P02+) memory hints. SPEC § 6.2 Tool 1.",
-	}, handlePrime)
+		nil, handlePrime)
 }
 
 // handlePrime executes the §6.2 Tool 1 read fan-out. Identity is
@@ -161,12 +155,14 @@ func handlePrime(ctx context.Context, req *sdkmcp.CallToolRequest, in primeIn) (
 		state.Call.ProjectID = in.ProjectID
 	}
 
+	// §7.3.1: a SUPPLIED ready_limit outside 1..50 was already rejected
+	// with VALIDATION by the shared validateArgs boundary pass (§7.3.2).
+	// By the time control reaches here, in.ReadyLimit == 0 can only mean
+	// the argument was OMITTED (an explicit 0 would have rejected), so we
+	// apply the per-tool default on omission only — no clamp, no coerce.
 	readyLimit := in.ReadyLimit
-	if readyLimit <= 0 {
+	if readyLimit == 0 {
 		readyLimit = primeReadyLimitDefault
-	}
-	if readyLimit > primeReadyLimitMax {
-		readyLimit = primeReadyLimitMax
 	}
 
 	// 1) ready_summary — wraps workitems.Ready under the same scope.

--- a/apps/api/mcp/handler_promote.go
+++ b/apps/api/mcp/handler_promote.go
@@ -40,14 +40,13 @@ type promoteOut struct {
 // registerHandlePromote is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandlePromote(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "promote",
-		Description: "Promote a Backlog item to Ready so it enters the ready " +
-			"queue and becomes claimable. Precondition: status='Backlog' AND " +
-			"is_ready=true (no open blockers). A still-blocked or wrong-status " +
-			"item is rejected with PRECONDITION_NOT_MET carrying {status, " +
+	registerValidatedTool(s, "promote",
+		"Promote a Backlog item to Ready so it enters the ready "+
+			"queue and becomes claimable. Precondition: status='Backlog' AND "+
+			"is_ready=true (no open blockers). A still-blocked or wrong-status "+
+			"item is rejected with PRECONDITION_NOT_MET carrying {status, "+
 			"required}. SPEC § 6.2 Tool 15 + § 6.6.",
-	}, handlePromote)
+		nil, handlePromote)
 }
 
 func handlePromote(ctx context.Context, req *sdkmcp.CallToolRequest, in promoteIn) (*sdkmcp.CallToolResult, promoteOut, error) {

--- a/apps/api/mcp/handler_ready.go
+++ b/apps/api/mcp/handler_ready.go
@@ -22,14 +22,12 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// readyLimitDefault / readyLimitMax mirror SPEC §6.2 Tool 2 line 1183
-// (1..200; default 10). After round-7 the rework removed the
-// downstream 50-cap (Linus REVIEW S2) so the wire range is honoured
-// end-to-end without silent truncation.
-const (
-	readyLimitDefault = 10
-	readyLimitMax     = 200
-)
+// readyLimitDefault is the per-tool default applied when `limit` is
+// OMITTED (SPEC §6.2 Tool 2 line 1183: default 10). The advertised
+// inclusive range (1..200) lives in catalogue.gen.go and is ENFORCED by
+// the shared validateArgs boundary pass (§7.3.1) — a supplied
+// out-of-range value rejects with VALIDATION, never clamps.
+const readyLimitDefault = 10
 
 type readyIn struct {
 	ProjectID   string `json:"project_id,omitempty"`
@@ -60,12 +58,11 @@ type readyOut struct {
 // registerHandleReady is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleReady(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "ready",
-		Description: "Items currently Ready for any agent to claim, " +
-			"ordered by (priority asc, created_at asc, id asc). " +
+	registerValidatedTool(s, "ready",
+		"Items currently Ready for any agent to claim, "+
+			"ordered by (priority asc, created_at asc, id asc). "+
 			"Paginates via opaque cursor (§6.2.0). SPEC § 6.2 Tool 2.",
-	}, handleReady)
+		nil, handleReady)
 }
 
 func handleReady(ctx context.Context, req *sdkmcp.CallToolRequest, in readyIn) (*sdkmcp.CallToolResult, readyOut, error) {
@@ -85,20 +82,12 @@ func handleReady(ctx context.Context, req *sdkmcp.CallToolRequest, in readyIn) (
 		state.Call.ProjectID = in.ProjectID
 	}
 
-	// Limit bounds per SPEC §6.2 Tool 2 line 1183 (1..200; default 10).
-	// Two explicit lines that read straight off the spec (rework S4 —
-	// no magic, no chained defaults). limit > 200 is a contract
-	// violation and surfaces as VALIDATION; limit <= 0 coerces to the
-	// spec default.
-	if in.Limit <= 0 {
+	// §7.3.1: a SUPPLIED limit outside 1..200 was already rejected with
+	// VALIDATION by the shared validateArgs boundary pass (§7.3.2). A
+	// zero here can only mean the argument was OMITTED, so we apply the
+	// per-tool default on omission only — no clamp, no coerce.
+	if in.Limit == 0 {
 		in.Limit = readyLimitDefault
-	}
-	if in.Limit > readyLimitMax {
-		return nil, readyOut{}, mapError(state, tool, &errs.Error{
-			Code:    errs.InvalidArgument,
-			Message: "limit out of range (1..200)",
-			Meta:    errs.Metadata{"field": "limit"},
-		})
 	}
 
 	// §6.2.0 cursor decode. The opaque token is verified and the

--- a/apps/api/mcp/handler_remove_dependency.go
+++ b/apps/api/mcp/handler_remove_dependency.go
@@ -66,15 +66,14 @@ type removeDependencyOut struct {
 // registerHandleRemoveDependency is invoked by transport.go's init —
 // see the toolRegistrars rationale there.
 func registerHandleRemoveDependency(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "remove_dependency",
-		Description: "Delete a dependency edge. Accepts edge_id OR the " +
-			"composite (from_item_id, to_item_id, kind) — exactly one " +
-			"shape. Recomputes is_ready inline for the direct to_item " +
-			"(single-hop) and publishes CascadeRequested{Reason:" +
-			"\"edge_removed\"} post-commit for the multi-hop " +
+	registerValidatedTool(s, "remove_dependency",
+		"Delete a dependency edge. Accepts edge_id OR the "+
+			"composite (from_item_id, to_item_id, kind) — exactly one "+
+			"shape. Recomputes is_ready inline for the direct to_item "+
+			"(single-hop) and publishes CascadeRequested{Reason:"+
+			"\"edge_removed\"} post-commit for the multi-hop "+
 			"pipeline_stage recompute. SPEC § 6.2 Tool 12.",
-	}, handleRemoveDependency)
+		nil, handleRemoveDependency)
 }
 
 func handleRemoveDependency(ctx context.Context, req *sdkmcp.CallToolRequest, in removeDependencyIn) (*sdkmcp.CallToolResult, removeDependencyOut, error) {

--- a/apps/api/mcp/handler_search.go
+++ b/apps/api/mcp/handler_search.go
@@ -26,13 +26,12 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// searchLimitDefault / searchLimitMax mirror SPEC §6.2 Tool 9 line 1428
-// (1..100; default 25). Aligns with workitems.searchDefaultLimit /
-// searchMaxLimit so the wire ceiling matches the downstream RPC.
-const (
-	searchLimitDefault = 25
-	searchLimitMax     = 100
-)
+// searchLimitDefault is the per-tool default applied when `limit` is
+// OMITTED (SPEC §6.2 Tool 9 line 1428: default 25). The advertised
+// inclusive range (1..100) lives in catalogue.gen.go and is ENFORCED by
+// the shared validateArgs boundary pass (§7.3.1) — a supplied
+// out-of-range value rejects with VALIDATION, never clamps.
+const searchLimitDefault = 25
 
 type searchIn struct {
 	ProjectID string `json:"project_id,omitempty"`
@@ -66,13 +65,12 @@ type searchOut struct {
 // registerHandleSearch is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleSearch(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "search",
-		Description: "Full-text search over items + comments. UNION ALL " +
-			"over items_fts_idx and comments_fts_idx; ranked by " +
-			"ts_rank_cd DESC; snippet via ts_headline (≤ 200 chars). " +
+	registerValidatedTool(s, "search",
+		"Full-text search over items + comments. UNION ALL "+
+			"over items_fts_idx and comments_fts_idx; ranked by "+
+			"ts_rank_cd DESC; snippet via ts_headline (≤ 200 chars). "+
 			"Paginates via opaque cursor (§6.2.0). SPEC § 6.2 Tool 9.",
-	}, handleSearch)
+		nil, handleSearch)
 }
 
 func handleSearch(ctx context.Context, req *sdkmcp.CallToolRequest, in searchIn) (*sdkmcp.CallToolResult, searchOut, error) {
@@ -105,18 +103,12 @@ func handleSearch(ctx context.Context, req *sdkmcp.CallToolRequest, in searchIn)
 		})
 	}
 
-	// Limit bounds — same shape as handler_ready.go / handler_list.go.
-	// limit <= 0 coerces to spec default (25); limit > 100 is a
-	// contract violation and surfaces as VALIDATION data.field=limit.
-	if in.Limit <= 0 {
+	// §7.3.1: a SUPPLIED limit outside 1..100 was already rejected with
+	// VALIDATION by the shared validateArgs boundary pass (§7.3.2). A
+	// zero here can only mean the argument was OMITTED, so we apply the
+	// per-tool default on omission only — no clamp, no coerce.
+	if in.Limit == 0 {
 		in.Limit = searchLimitDefault
-	}
-	if in.Limit > searchLimitMax {
-		return nil, searchOut{}, mapError(state, tool, &errs.Error{
-			Code:    errs.InvalidArgument,
-			Message: "limit out of range (1..100)",
-			Meta:    errs.Metadata{"field": "limit"},
-		})
 	}
 
 	// §6.2.0 cursor decode — verifies HMAC + version discriminator,

--- a/apps/api/mcp/handler_set_state.go
+++ b/apps/api/mcp/handler_set_state.go
@@ -210,14 +210,13 @@ var intentCommentAllowedStatuses = map[string]struct{}{
 // registerHandleSetState is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleSetState(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "set_state",
-		Description: "Set one or more of (impl_state, review_state, " +
-			"qa_state, pipeline_state) atomically. Enforces the five " +
-			"PRD §6.2 state-machine invariants I-1..I-5 (data.invariant " +
-			"populated on PRECONDITION_NOT_MET). Optionally writes an " +
+	registerValidatedTool(s, "set_state",
+		"Set one or more of (impl_state, review_state, "+
+			"qa_state, pipeline_state) atomically. Enforces the five "+
+			"PRD §6.2 state-machine invariants I-1..I-5 (data.invariant "+
+			"populated on PRECONDITION_NOT_MET). Optionally writes an "+
 			"intent_comment alongside the state change. SPEC § 6.2 Tool 13.",
-	}, handleSetState)
+		nil, handleSetState)
 }
 
 func handleSetState(ctx context.Context, req *sdkmcp.CallToolRequest, in setStateIn) (*sdkmcp.CallToolResult, setStateOut, error) {

--- a/apps/api/mcp/handler_show.go
+++ b/apps/api/mcp/handler_show.go
@@ -105,13 +105,12 @@ type showOut struct {
 // registerHandleShow is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleShow(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "show",
-		Description: "Read an item with its comments, incoming + outgoing " +
-			"dependencies, and finding children. include_comments / " +
-			"include_dependencies / include_findings default to true. " +
+	registerValidatedTool(s, "show",
+		"Read an item with its comments, incoming + outgoing "+
+			"dependencies, and finding children. include_comments / "+
+			"include_dependencies / include_findings default to true. "+
 			"SPEC § 6.2 Tool 7.",
-	}, handleShow)
+		nil, handleShow)
 }
 
 func handleShow(ctx context.Context, req *sdkmcp.CallToolRequest, in showIn) (*sdkmcp.CallToolResult, showOut, error) {

--- a/apps/api/mcp/handler_update.go
+++ b/apps/api/mcp/handler_update.go
@@ -49,7 +49,6 @@ import (
 
 	"encore.app/workitems"
 	"encore.dev/beta/errs"
-	"github.com/google/jsonschema-go/jsonschema"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -91,50 +90,24 @@ type updateOut struct {
 // registerHandleUpdate is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 //
-// Tool.InputSchema is set explicitly to an object schema with
-// AdditionalProperties = true so the SDK's auto-inferred
-// `additionalProperties: false` does not fire on impl_state/etc. The
-// handler enforces the rejection itself with a §7-shaped error.
+// update routes through the SHARED §7.3 validation layer
+// (registerValidatedTool) like every other tool. The catalogue `update`
+// schema declares `additionalProperties:true` (the ONLY tool that does),
+// so validateArgs does NOT reject unknown keys — the four forbidden
+// state-dimension keys (impl_state / review_state / qa_state /
+// pipeline_state) survive into req.Params.Arguments where handleUpdate's
+// raw-JSON sniff rejects them with the §7 VALIDATION envelope. The shared
+// layer still enforces the rich contract's required[item_id] and the
+// priority enum; milestone_id's three-way null/string/absent intent is
+// resolved from the raw JSON inside handleUpdate (the typed updateIn
+// deliberately omits MilestoneID — see its doc comment).
 func registerHandleUpdate(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "update",
-		Description: "Update editable item columns (title, body, priority, " +
-			"milestone_id, labels). State dimensions (impl_state, " +
-			"review_state, qa_state, pipeline_state) are rejected with " +
+	registerValidatedTool(s, "update",
+		"Update editable item columns (title, body, priority, "+
+			"milestone_id, labels). State dimensions (impl_state, "+
+			"review_state, qa_state, pipeline_state) are rejected with "+
 			"VALIDATION — use set_state instead. SPEC § 6.2 Tool 5.",
-		// AdditionalProperties: true here keeps the SDK's
-		// applySchema from rejecting unknown keys before the handler
-		// runs (which would surface as an SDK IsError content frame,
-		// not the §7 envelope the spec mandates). The handler then
-		// sniffs req.Params.Arguments for the forbidden state-
-		// dimension keys and produces the canonical envelope.
-		InputSchema: &jsonschema.Schema{
-			Type: "object",
-			Properties: map[string]*jsonschema.Schema{
-				"item_id":      {Type: "string"},
-				"title":        {Type: "string"},
-				"body":         {Type: "string"},
-				"priority":     {Type: "string"},
-				"milestone_id": {Types: []string{"string", "null"}},
-				"labels": {
-					Type:  "array",
-					Items: &jsonschema.Schema{Type: "string"},
-				},
-			},
-			Required:             []string{"item_id"},
-			AdditionalProperties: trueSchemaForUpdate(),
-		},
-	}, handleUpdate)
-}
-
-// trueSchemaForUpdate returns the JSON-Schema sentinel for "any
-// additional properties are allowed". The jsonschema-go library
-// distinguishes "no constraint" (nil) from "explicit allow" via a
-// pointer to an empty schema; we use the latter to make the intent
-// reviewable and to prevent a future re-inference pass from collapsing
-// nil into the default falseSchema().
-func trueSchemaForUpdate() *jsonschema.Schema {
-	return &jsonschema.Schema{}
+		nil, handleUpdate)
 }
 
 func handleUpdate(ctx context.Context, req *sdkmcp.CallToolRequest, in updateIn) (*sdkmcp.CallToolResult, updateOut, error) {

--- a/apps/api/mcp/handler_update_label.go
+++ b/apps/api/mcp/handler_update_label.go
@@ -46,13 +46,12 @@ type updateLabelOut struct {
 // registerHandleUpdateLabel is invoked by transport.go's init — see the
 // toolRegistrars rationale there.
 func registerHandleUpdateLabel(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "update_label",
-		Description: "Rename and/or recolor an existing label. Only the " +
-			"supplied fields change; the label's scope is immutable. A rename " +
-			"that collides with an existing label in the same scope rejects " +
+	registerValidatedTool(s, "update_label",
+		"Rename and/or recolor an existing label. Only the "+
+			"supplied fields change; the label's scope is immutable. A rename "+
+			"that collides with an existing label in the same scope rejects "+
 			"with CONFLICT. SPEC § 6.2 Tool 22.",
-	}, handleUpdateLabel)
+		nil, handleUpdateLabel)
 }
 
 func handleUpdateLabel(ctx context.Context, req *sdkmcp.CallToolRequest, in updateLabelIn) (*sdkmcp.CallToolResult, updateLabelOut, error) {

--- a/apps/api/mcp/handler_update_milestone.go
+++ b/apps/api/mcp/handler_update_milestone.go
@@ -57,14 +57,13 @@ type updateMilestoneOut struct {
 // registerHandleUpdateMilestone is invoked by transport.go's init — see
 // the toolRegistrars rationale there.
 func registerHandleUpdateMilestone(s *sdkmcp.Server) {
-	sdkmcp.AddTool(s, &sdkmcp.Tool{
-		Name: "update_milestone",
-		Description: "Update a milestone's name, description, start/end " +
-			"dates, or cancellation. Only the supplied fields change. " +
-			"Reparenting is not supported in P01 (rejected with VALIDATION). " +
-			"Date changes that violate a parent's or child's range reject " +
+	registerValidatedTool(s, "update_milestone",
+		"Update a milestone's name, description, start/end "+
+			"dates, or cancellation. Only the supplied fields change. "+
+			"Reparenting is not supported in P01 (rejected with VALIDATION). "+
+			"Date changes that violate a parent's or child's range reject "+
 			"with PRECONDITION_NOT_MET. SPEC § 6.2 Tool 17.",
-	}, handleUpdateMilestone)
+		nil, handleUpdateMilestone)
 }
 
 func handleUpdateMilestone(ctx context.Context, req *sdkmcp.CallToolRequest, in updateMilestoneIn) (*sdkmcp.CallToolResult, updateMilestoneOut, error) {

--- a/apps/api/mcp/transport.go
+++ b/apps/api/mcp/transport.go
@@ -71,10 +71,12 @@ const sdkServerName = "unblock-mcp"
 const sdkServerVersion = "0.1.0"
 
 // sdkServer is the package-level MCP server instance. Tool handlers
-// (D-2..D-6, beads unblock-tv8.17..unblock-tv8.21) call
-// sdkmcp.AddTool(sdkServer, …) at package init to register tools;
-// in D-1 no tools are registered and the SDK exposes only the
-// built-in initialize / list_tools / list_resources methods.
+// register against it at package init via registerValidatedTool
+// (validate.go), which advertises the rich catalogue input schema in
+// tools/list and routes every dispatch through the shared §7.3
+// argument-validation boundary pass (bead unblock-tv8.82). In D-1 no
+// tools are registered and the SDK exposes only the built-in
+// initialize / list_tools / list_resources methods.
 //
 // Initialized at package init via initSDKServer (see init() below)
 // — package-init order is unimportant because no //encore:api
@@ -92,8 +94,9 @@ var sdkStreamableHandler *sdkmcp.StreamableHTTPHandler
 // toolRegistrar is one entry in the per-tool registration table.
 // Each tool handler file (handler_prime.go, handler_ready.go,
 // handler_claim.go, handler_create.go, …) exposes a registerXxx
-// function that calls sdkmcp.AddTool against the constructed
-// sdkServer. We collect them here so the package init order is:
+// function that calls registerValidatedTool (validate.go) against the
+// constructed sdkServer. We collect them here so the package init order
+// is:
 //
 //  1. transport.go init runs first (alphabetically first file with
 //     an init() in this package is errenvelope.go which has none;

--- a/apps/api/mcp/validate.go
+++ b/apps/api/mcp/validate.go
@@ -1,0 +1,560 @@
+// validate.go is the SHARED argument-validation boundary layer for the
+// MCP tool surface (SPEC §7.3 / §7.3.1 / §7.3.2 + §6.2.0a, bead
+// unblock-tv8.82).
+//
+// # Why this layer exists
+//
+// The live `tools/list` schema is the schema the go-sdk (v1.6.0) would
+// otherwise REFLECT from each handler's Go input struct via
+// jsonschema.ForType — which carries only `type`, `required` (absence
+// of `,omitempty`), and `additionalProperties:false`. It NEVER carries
+// `enum` or `minimum`/`maximum`, so the per-tool bounds/enums quoted in
+// the §6.2 argument comments and in catalogue.json were never on the
+// wire (§7.3.2). Worse, the SDK validates that reflected schema
+// PRE-handler (server.go applySchema → resolved.Validate); a PRE-handler
+// failure returns a bare `isError` text frame with NO §7 envelope (no
+// kind=VALIDATION, no trace_id, no data.field). That is the B3 surface.
+//
+// # The mechanism (§7.3.2, option (i) — fully uniform)
+//
+// We OWN every argument-shape dimension (required / enum / type / range /
+// additionalProperties) in this shared layer instead of letting the SDK
+// own any of them:
+//
+//   - Tools are registered via the NON-generic sdkServer.AddTool (see
+//     registerValidatedTool), which stores the Tool verbatim and runs
+//     ZERO applySchema pre-validation. The advertised InputSchema is the
+//     FULL rich schema from catalogue.gen.go (enum + minimum/maximum +
+//     required + additionalProperties) — so `tools/list` advertises the
+//     complete contract for agent discovery (§6.2.0a, NET-NEW).
+//   - validateArgs runs at the TOP of every wrapped handler against that
+//     same rich schema. On any violation it mints the §7 VALIDATION
+//     envelope via the existing errmap.go mapError path (errs.InvalidArgument
+//     + Meta{field, reason[, bound]}). No argument violation can surface
+//     as a bare isError frame.
+//
+// The rich schema is read straight from ToolByName(tool).InputSchema
+// (the catalogue.gen.go embedded JSON), so the validated contract and the
+// advertised contract are the SAME bytes by construction — they cannot
+// drift (asserted by TestRegisteredInputSchemaMatchesCatalogue).
+//
+// # Bounds are ENFORCED — out-of-range REJECTS (§7.3.1, behavior change)
+//
+// A supplied paginated `limit`/`ready_limit` below the advertised minimum
+// (including 0 / negative) OR above the maximum is REJECTED with
+// VALIDATION (data.field = the argument, data.bound = the range). The
+// server does NOT clamp-to-max or coerce-to-default an out-of-range value.
+// An OMITTED limit still takes the per-tool default — the bound check
+// applies only to a value the caller actually supplies (absence is not a
+// zero). The handlers apply the omitted-default AFTER this layer passes.
+//
+// SPEC: docs/specs/01-spec-backend-mvp.md §7.3 + §7.3.1 + §7.3.2 +
+// §6.2.0a + §7 (VALIDATION envelope) + §10.3 (catalogue).
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+
+	"encore.dev/beta/errs"
+	"github.com/google/jsonschema-go/jsonschema"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// richSchemaCache memoises the parsed rich input schema per tool name so
+// each tools/call does not re-parse the catalogue JSON. Populated lazily
+// by toolInputSchema under richSchemaOnce-per-key guard.
+var (
+	richSchemaCache   = map[string]*jsonschema.Schema{}
+	richSchemaCacheMu sync.RWMutex
+)
+
+// toolInputSchema returns the parsed rich JSON Schema for a tool from the
+// catalogue.gen.go embedded bytes (the single source of truth that
+// tools/list also advertises). It panics if the tool is unknown or the
+// embedded schema fails to parse — both are build-time invariants
+// (catalogue.gen.go is generated + drift-guarded), so a failure here is a
+// programmer error surfaced at boot, never a request-time condition.
+func toolInputSchema(tool string) *jsonschema.Schema {
+	richSchemaCacheMu.RLock()
+	if s, ok := richSchemaCache[tool]; ok {
+		richSchemaCacheMu.RUnlock()
+		return s
+	}
+	richSchemaCacheMu.RUnlock()
+
+	ct, ok := ToolByName(tool)
+	if !ok {
+		panic(fmt.Sprintf("mcp: validate: unknown tool %q (not in catalogue.gen.go)", tool))
+	}
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(ct.InputSchema, &schema); err != nil {
+		panic(fmt.Sprintf("mcp: validate: tool %q input_schema does not parse: %v", tool, err))
+	}
+
+	richSchemaCacheMu.Lock()
+	richSchemaCache[tool] = &schema
+	richSchemaCacheMu.Unlock()
+	return &schema
+}
+
+// validateArgs is the shared §7.3 argument-validation pass. It validates
+// the raw JSON tool arguments against the tool's rich input schema and,
+// on the FIRST violation it finds, returns a §7 VALIDATION envelope error
+// (built via mapError) suitable for returning directly from the handler.
+// It returns nil when every argument is in-contract.
+//
+// Dimensions enforced, in order, against the top-level object schema:
+//
+//  1. arguments parse as a JSON object (a non-object body → field
+//     "arguments").
+//  2. additionalProperties:false → any key not in properties → that key
+//     is the offending field.
+//  3. required[] → a missing required key → that key is the field.
+//  4. per-property type → wrong JSON type → that key is the field.
+//  5. per-property enum → value outside the closed set → that key is the
+//     field, reason lists the allowed values.
+//  6. per-property minimum/maximum → an out-of-range number → that key is
+//     the field, data.bound = "min..max" (§7.3.1).
+//
+// state may be nil (unit-test paths); mapError tolerates a nil state.
+//
+// Determinism: keys are visited in sorted order so the FIRST surfaced
+// violation is stable across runs (Go map iteration is randomised). The
+// spec is silent on multi-violation ordering; a stable order keeps tests
+// and agent retries predictable.
+func validateArgs(state *requestState, tool string, rawArgs json.RawMessage) error {
+	schema := toolInputSchema(tool)
+
+	// Decode into a generic map so we can inspect presence + JSON type of
+	// every supplied argument without a typed struct (which would silently
+	// drop unknown keys and coerce types). An empty/absent body is the
+	// "no arguments supplied" case — valid iff there are no required keys.
+	args := map[string]json.RawMessage{}
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return mapError(state, tool, validationErr("arguments", "arguments must be a JSON object", ""))
+		}
+	}
+
+	// (2) additionalProperties:false — reject unknown keys. The catalogue
+	// schema sets additionalProperties:false on every tool except `update`
+	// (which intentionally allows extras and owns its own state-dimension
+	// sniff in handler_update.go); for `update` schema.AdditionalProperties
+	// is a non-nil empty schema (allow-all) so this branch is skipped.
+	if additionalPropertiesForbidden(schema) {
+		for _, key := range sortedKeys(args) {
+			if _, declared := schema.Properties[key]; !declared {
+				return mapError(state, tool, validationErr(
+					key,
+					fmt.Sprintf("unknown argument %q", key),
+					"",
+				))
+			}
+		}
+	}
+
+	// (3) required[] — a declared-required key that is absent (or present
+	// as JSON null) is a missing-required violation.
+	for _, req := range schema.Required {
+		tok, present := args[req]
+		if !present || string(tok) == "null" {
+			return mapError(state, tool, validationErr(
+				req,
+				fmt.Sprintf("missing required argument %q", req),
+				"",
+			))
+		}
+	}
+
+	// (4)(5)(6) per-property type / enum / range. Visit supplied keys in
+	// sorted order for deterministic first-violation surfacing.
+	for _, key := range sortedKeys(args) {
+		prop, declared := schema.Properties[key]
+		if !declared {
+			// Unknown key on an additionalProperties:true tool (update):
+			// no per-property constraints to check.
+			continue
+		}
+		tok := args[key]
+		if string(tok) == "null" {
+			// Explicit JSON null: treated as "not supplied" for an
+			// optional field; required-null was already rejected above.
+			continue
+		}
+		if err := validateProperty(state, tool, key, prop, tok); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateProperty checks a single supplied argument value against its
+// property schema (type, then enum, then numeric range). Returns a §7
+// VALIDATION envelope error on the first violation, nil otherwise.
+func validateProperty(state *requestState, tool, field string, prop *jsonschema.Schema, tok json.RawMessage) error {
+	// (4) type. We only enforce the scalar/array/object JSON types the
+	// P01 schemas use (string, integer, number, boolean, array, object).
+	// A property declaring multiple Types (e.g. ["string","null"]) passes
+	// if the value matches ANY of them.
+	wantTypes := propertyTypes(prop)
+	if len(wantTypes) > 0 {
+		got := jsonTypeOf(tok)
+		if !typeMatches(got, wantTypes) {
+			return mapError(state, tool, validationErr(
+				field,
+				fmt.Sprintf("expected %s, got %s", joinTypes(wantTypes), got),
+				"",
+			))
+		}
+	}
+
+	// (5) enum — closed value set. The catalogue enums are all string
+	// enums in P01; compare the decoded string against the allowed set.
+	if len(prop.Enum) > 0 {
+		var got string
+		if err := json.Unmarshal(tok, &got); err == nil {
+			if !enumContains(prop.Enum, got) {
+				return mapError(state, tool, validationErr(
+					field,
+					fmt.Sprintf("must be one of %s", enumValues(prop.Enum)),
+					"",
+				))
+			}
+		}
+		// If the value is not a string at all, the type check above
+		// already rejected it (enum properties declare type:string).
+	}
+
+	// (6) numeric range — minimum/maximum (inclusive). Applies only when
+	// the value is a JSON number; non-number values were rejected by the
+	// type check. data.bound carries the advertised "min..max" range so
+	// the agent can self-correct (§7.3.1).
+	if prop.Minimum != nil || prop.Maximum != nil {
+		var n float64
+		if err := json.Unmarshal(tok, &n); err == nil {
+			if prop.Minimum != nil && n < *prop.Minimum {
+				return mapError(state, tool, validationErr(
+					field, "out of range", boundString(prop),
+				))
+			}
+			if prop.Maximum != nil && n > *prop.Maximum {
+				return mapError(state, tool, validationErr(
+					field, "out of range", boundString(prop),
+				))
+			}
+		}
+	}
+
+	return nil
+}
+
+// validationErr builds the canonical errs.InvalidArgument carrying the
+// §7 VALIDATION Meta. field always set; reason set when non-empty; bound
+// set when non-empty (range violations only — surfaces as data.bound via
+// errmap.go). mapError maps InvalidArgument → VALIDATION with data.field
+// (and data.reason / data.bound).
+func validationErr(field, reason, bound string) error {
+	meta := errs.Metadata{"field": field}
+	if reason != "" {
+		meta["reason"] = reason
+	}
+	if bound != "" {
+		meta["bound"] = bound
+	}
+	msg := reason
+	if msg == "" {
+		msg = "invalid argument"
+	}
+	return &errs.Error{
+		Code:    errs.InvalidArgument,
+		Message: msg,
+		Meta:    meta,
+	}
+}
+
+// additionalPropertiesForbidden reports whether the schema forbids
+// additional properties (additionalProperties:false). The jsonschema-go
+// representation of `false` is a non-nil schema whose `Not` is the empty
+// schema (the "never" schema); the representation of allow-all (the
+// `update` case) is a non-nil EMPTY schema. We distinguish the two by
+// remarshalling the additionalProperties value: `false` marshals to the
+// literal `false`, allow-all marshals to `{}`.
+func additionalPropertiesForbidden(schema *jsonschema.Schema) bool {
+	ap := schema.AdditionalProperties
+	if ap == nil {
+		// Absent → JSON Schema default is "allow additional properties".
+		return false
+	}
+	b, err := json.Marshal(ap)
+	if err != nil {
+		return false
+	}
+	return string(b) == "false"
+}
+
+// propertyTypes returns the JSON type(s) a property accepts. The
+// jsonschema.Schema custom (un)marshaller maps the `type` keyword into
+// Type (single) or Types (multiple).
+func propertyTypes(prop *jsonschema.Schema) []string {
+	if prop.Type != "" {
+		return []string{prop.Type}
+	}
+	return prop.Types
+}
+
+// jsonTypeOf reports the JSON type of a raw token using the JSON Schema
+// type vocabulary. "integer" is reported for numbers with no fractional
+// part so an integer-typed property accepts 5 but rejects 5.5; callers
+// treat "integer" as a subtype of "number" via typeMatches.
+func jsonTypeOf(tok json.RawMessage) string {
+	var v any
+	if err := json.Unmarshal(tok, &v); err != nil {
+		return "unknown"
+	}
+	switch t := v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64:
+		if t == math.Trunc(t) && !math.IsInf(t, 0) {
+			return "integer"
+		}
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+// typeMatches reports whether the observed JSON type satisfies any of the
+// schema's accepted types. "integer" satisfies a "number" requirement (an
+// integer is a number); "integer" also satisfies "integer". The reverse
+// is enforced by jsonTypeOf, which only reports "integer" for whole
+// numbers, so a fractional value never satisfies an "integer" requirement.
+func typeMatches(got string, want []string) bool {
+	for _, w := range want {
+		if got == w {
+			return true
+		}
+		if w == "number" && got == "integer" {
+			return true
+		}
+	}
+	return false
+}
+
+// enumContains reports whether v is a member of the (string) enum set.
+func enumContains(enum []any, v string) bool {
+	for _, e := range enum {
+		if s, ok := e.(string); ok && s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// enumValues renders the allowed enum members as a quoted comma list for
+// the VALIDATION reason text (e.g. `"P0", "P1", "P2"`).
+func enumValues(enum []any) string {
+	parts := make([]string, 0, len(enum))
+	for _, e := range enum {
+		if s, ok := e.(string); ok {
+			parts = append(parts, fmt.Sprintf("%q", s))
+		}
+	}
+	return joinComma(parts)
+}
+
+// boundString renders the advertised inclusive range as "min..max" for
+// data.bound. Both bounds are present on every paginated limit property
+// in P01; a half-open bound degrades gracefully to "min.." / "..max".
+func boundString(prop *jsonschema.Schema) string {
+	lo, hi := "", ""
+	if prop.Minimum != nil {
+		lo = trimFloat(*prop.Minimum)
+	}
+	if prop.Maximum != nil {
+		hi = trimFloat(*prop.Maximum)
+	}
+	return lo + ".." + hi
+}
+
+// trimFloat renders a float that holds an integer value without a
+// trailing ".0" (so 50.0 → "50", matching the §6.2.0a "1..50" prose).
+func trimFloat(f float64) string {
+	if f == math.Trunc(f) && !math.IsInf(f, 0) {
+		return fmt.Sprintf("%d", int64(f))
+	}
+	return fmt.Sprintf("%g", f)
+}
+
+func joinTypes(types []string) string { return joinComma(types) }
+
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// sortedKeys returns the map keys in lexical order for deterministic
+// first-violation surfacing.
+func sortedKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// registerValidatedTool registers a typed tool handler against sdkServer
+// such that:
+//
+//   - the advertised `tools/list` InputSchema is the FULL rich schema
+//     from catalogue.gen.go (enum/min/max/required/additionalProperties),
+//     for agent discovery (§6.2.0a), and
+//   - the go-sdk runs NO pre-handler applySchema validation (the
+//     non-generic Server.AddTool path stores the Tool verbatim and never
+//     resolves an input schema), so no argument violation can surface as
+//     a bare isError frame, and
+//   - validateArgs (§7.3) runs at the boundary, before the typed handler,
+//     minting §7 VALIDATION on any argument-shape violation.
+//
+// This is the generalisation of the handler_update.go precedent into a
+// single shared boundary layer (§7.3.2). The helper replicates the
+// go-sdk generic-handler output path faithfully (StructuredContent +
+// TextContent mirror + output-schema validation) so existing
+// structured-echoes-text assertions stay green.
+//
+// in is a fresh zero In on every call (the closure constructs its own),
+// so the helper is safe for concurrent dispatch.
+func registerValidatedTool[In, Out any](
+	s *sdkmcp.Server,
+	name, description string,
+	outputSchema *jsonschema.Schema,
+	typed func(context.Context, *sdkmcp.CallToolRequest, In) (*sdkmcp.CallToolResult, Out, error),
+) {
+	richInput := toolInputSchema(name)
+
+	// Derive (or accept) the output schema the same way the generic SDK
+	// path would, so the advertised outputSchema and the output validation
+	// are unchanged from the reflected default. A caller may pass an
+	// explicit schema (handler_milestone_tree.go does) to override the
+	// reflected shape.
+	outSchema := outputSchema
+	if outSchema == nil {
+		derived, err := jsonschema.For[Out](nil)
+		if err != nil {
+			panic(fmt.Sprintf("mcp: validate: output schema inference for %q: %v", name, err))
+		}
+		outSchema = derived
+	}
+	outResolved, err := outSchema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
+	if err != nil {
+		panic(fmt.Sprintf("mcp: validate: output schema resolve for %q: %v", name, err))
+	}
+
+	handler := func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		// §7.3 uniform argument validation BEFORE the typed handler runs.
+		// bindTool registers the tool name on the audit row exactly as
+		// the typed handlers do; on a validation reject mapError (called
+		// inside validateArgs) flips the audit row to result_kind=error.
+		state := bindTool(req, name)
+		if err := validateArgs(state, name, req.Params.Arguments); err != nil {
+			return nil, err
+		}
+
+		// Unmarshal the validated arguments into the typed input. We use
+		// stdlib json.Unmarshal (unknown keys already rejected by
+		// validateArgs for additionalProperties:false tools; tolerated
+		// for `update`, which owns its own raw sniff). A malformed body
+		// was already rejected by validateArgs.
+		var in In
+		if len(req.Params.Arguments) > 0 {
+			if err := json.Unmarshal(req.Params.Arguments, &in); err != nil {
+				return nil, mapError(state, name, validationErr("arguments", "arguments must be a JSON object", ""))
+			}
+		}
+
+		res, out, herr := typed(ctx, req, in)
+		if herr != nil {
+			// A handler that already returns a *jsonrpc.Error (the §7
+			// path via mapError) is forwarded verbatim; any other error
+			// is wrapped by the SDK as an isError tool result. The typed
+			// handlers always return mapError output, so this is the §7
+			// path in practice.
+			return nil, herr
+		}
+
+		return marshalToolOutput(res, out, outResolved)
+	}
+
+	// Non-generic registration: stores richInput verbatim as the
+	// advertised InputSchema and runs our handler directly. No applySchema.
+	s.AddTool(&sdkmcp.Tool{
+		Name:         name,
+		Description:  description,
+		InputSchema:  richInput,
+		OutputSchema: outSchema,
+	}, handler)
+}
+
+// marshalToolOutput replicates the go-sdk generic-handler output path
+// (server.go toolForErr): marshal Out → StructuredContent, validate
+// against the resolved output schema, and mirror into a TextContent
+// block when the handler did not set Content itself. Keeps the wire
+// shape byte-identical to the previous generic AddTool registration so
+// assertStructuredEchoesText and friends stay green.
+func marshalToolOutput[Out any](res *sdkmcp.CallToolResult, out Out, outResolved *jsonschema.Resolved) (*sdkmcp.CallToolResult, error) {
+	if res == nil {
+		res = &sdkmcp.CallToolResult{}
+	}
+
+	outBytes, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling output: %w", err)
+	}
+	outJSON := json.RawMessage(outBytes)
+	if outResolved != nil {
+		v := map[string]any{}
+		if len(outJSON) > 0 {
+			if err := json.Unmarshal(outJSON, &v); err != nil {
+				return nil, fmt.Errorf("unmarshaling output for validation: %w", err)
+			}
+		}
+		if err := outResolved.ApplyDefaults(&v); err != nil {
+			return nil, fmt.Errorf("applying output defaults: %w", err)
+		}
+		if err := outResolved.Validate(&v); err != nil {
+			return nil, fmt.Errorf("validating tool output: %w", err)
+		}
+		if outBytes, err = json.Marshal(v); err != nil {
+			return nil, fmt.Errorf("re-marshaling output: %w", err)
+		}
+		outJSON = json.RawMessage(outBytes)
+	}
+
+	res.StructuredContent = outJSON
+	if res.Content == nil {
+		res.Content = []sdkmcp.Content{&sdkmcp.TextContent{Text: string(outJSON)}}
+	}
+	return res, nil
+}

--- a/apps/api/shared/mcpaudittest/d2_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d2_tools_test.go
@@ -853,33 +853,39 @@ func TestD2_ReadyLimitOutOfRange(t *testing.T) {
 	}
 }
 
-// TestD2_ReadyLimitZeroDefaultsTo10 asserts the round-7 S4 contract:
-// limit <= 0 coerces to the spec default (10) — NOT to the prior
-// "negative-then-zero" indirection. Seed 12 items, request limit=0,
-// expect exactly 10 items returned + total_ready=12 + a non-empty
-// next_cursor (more pages exist).
-func TestD2_ReadyLimitZeroDefaultsTo10(t *testing.T) {
+// TestD2_ReadyLimitZeroRejects asserts the unblock-tv8.82 §7.3.1
+// re-lock: a SUPPLIED limit=0 is below the advertised minimum (1) and is
+// now REJECTED with §7 VALIDATION (data.field=limit, data.bound="1..200")
+// — NOT coerced to the per-tool default. This supersedes the round-7
+// "limit<=0 coerces to default" semantics. (An OMITTED limit still takes
+// the default — covered by the happy-path control elsewhere; absence is
+// not a supplied zero.)
+func TestD2_ReadyLimitZeroRejects(t *testing.T) {
 	resetToolCalls(t)
 	fx := seedD2Fixture(t)
 	for i := 0; i < 12; i++ {
 		seedReadyItem(t, fx.OrgID, fx.ProjectID, "P1", time.Duration(i)*time.Second)
 	}
 
-	// limit=0 → coerced to readyLimitDefault (10).
 	env := callTool(t, fx.RawKey, "ready", map[string]any{
 		"project_id": fx.ProjectID,
 		"limit":      0,
 	})
-	res := assertStructuredEchoesText(t, env)
-	page := decodeReadyPage(t, res.StructuredContent)
-	if len(page.Items) != 10 {
-		t.Fatalf("items len = %d, want 10 (spec default)", len(page.Items))
+	if env.Error == nil {
+		t.Fatalf("expected VALIDATION envelope on supplied limit=0; got success result=%s", string(env.Result))
 	}
-	if page.TotalReady != 12 {
-		t.Fatalf("total_ready = %d, want 12", page.TotalReady)
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
 	}
-	if page.NextCursor == nil {
-		t.Fatalf("next_cursor nil — 2 more rows exist")
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	}
+	if v, _ := data.Details["field"].(string); v != "limit" {
+		t.Fatalf("error.data.details.field = %q, want \"limit\"", v)
+	}
+	if v, _ := data.Details["bound"].(string); v != "1..200" {
+		t.Fatalf("error.data.details.bound = %q, want \"1..200\"", v)
 	}
 }
 

--- a/apps/api/shared/mcpaudittest/d4_tools_test.go
+++ b/apps/api/shared/mcpaudittest/d4_tools_test.go
@@ -550,41 +550,48 @@ func TestD4_CommentBodyExceedsCap(t *testing.T) {
 	}
 }
 
-// TestD4_CommentMissingItemID: missing item_id is rejected by the
-// MCP SDK's JSON-schema pre-validation (item_id is declared without
-// `omitempty` so the SDK marks it required at the schema layer). The
-// rejection surfaces as a successful JSON-RPC `result` envelope with
-// `isError:true` and a `content[0].text` carrying the SDK validator's
-// message — distinct from the §7 VALIDATION envelope which only fires
-// AFTER schema validation passes. We assert the SDK error path here
-// because the wire-level guarantee is "missing item_id never executes
-// AppendComment", which the SDK enforces upstream of our handler.
+// TestD4_CommentMissingItemID: a missing required item_id now surfaces
+// the §7 VALIDATION envelope (kind=VALIDATION, trace_id, data.field=
+// item_id) — NOT a bare isError text frame. This is the canonical proof
+// of the unblock-tv8.82 uniform argument-validation contract (SPEC §7.3):
+// every argument-shape violation at the MCP boundary is §7-shaped,
+// because the shared validateArgs boundary pass runs the required/enum/
+// type/range checks itself and mints the envelope via mapError BEFORE the
+// handler's domain logic (the go-sdk no longer pre-validates — tools are
+// registered with the rich schema via the non-generic path, §7.3.2).
+// Pre-tv8.82 this case returned a successful result with isError:true and
+// a content-text "validating arguments: …" frame; that behavior is now
+// retired.
 func TestD4_CommentMissingItemID(t *testing.T) {
 	resetToolCalls(t)
 	fx := seedD2Fixture(t)
 
+	// Absent required item_id → §7 VALIDATION, data.field=item_id.
 	env := callTool(t, fx.RawKey, "comment", map[string]any{
 		"kind":   "general",
 		"status": "info",
 		"body":   "body",
 	})
-	if env.Error != nil {
-		t.Fatalf("expected SDK-level isError, got JSON-RPC error envelope data=%s", string(env.Error.Data))
+	if env.Error == nil {
+		t.Fatalf("expected §7 VALIDATION on missing item_id; got success result=%s", string(env.Result))
 	}
-	var res toolCallResult
-	if err := json.Unmarshal(env.Result, &res); err != nil {
-		t.Fatalf("unmarshal result: %v", err)
+	var data envelopeData
+	if err := json.Unmarshal(env.Error.Data, &data); err != nil {
+		t.Fatalf("unmarshal error.data: %v", err)
 	}
-	if !res.IsError {
-		t.Fatalf("missing item_id must produce isError=true result; got %+v", res)
+	if data.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION (data=%s)", data.Kind, string(env.Error.Data))
 	}
-	if len(res.Content) == 0 || !strings.Contains(res.Content[0].Text, "item_id") {
-		t.Fatalf("expected error text to mention item_id; got content=%+v", res.Content)
+	if data.TraceID == "" {
+		t.Fatalf("error.data.trace_id is empty; §7 envelope requires it")
+	}
+	if got, _ := data.Details["field"].(string); got != "item_id" {
+		t.Fatalf("error.data.details.field = %q, want \"item_id\"", got)
 	}
 
-	// Defense-in-depth: an EMPTY item_id (present but zero) bypasses
-	// the SDK's required-field check (the field IS present) and reaches
-	// the handler's own guard, which surfaces §7 VALIDATION with
+	// Defense-in-depth: an EMPTY item_id (present but zero) passes the
+	// required-key presence check (the field IS present) and reaches the
+	// handler's own guard, which surfaces the same §7 VALIDATION with
 	// data.field="item_id".
 	env2 := callTool(t, fx.RawKey, "comment", map[string]any{
 		"item_id": "",
@@ -595,14 +602,14 @@ func TestD4_CommentMissingItemID(t *testing.T) {
 	if env2.Error == nil {
 		t.Fatalf("expected §7 VALIDATION on empty item_id; got success result=%s", string(env2.Result))
 	}
-	var data envelopeData
-	if err := json.Unmarshal(env2.Error.Data, &data); err != nil {
+	var data2 envelopeData
+	if err := json.Unmarshal(env2.Error.Data, &data2); err != nil {
 		t.Fatalf("unmarshal error.data: %v", err)
 	}
-	if data.Kind != "VALIDATION" {
-		t.Fatalf("error.data.kind = %q, want VALIDATION", data.Kind)
+	if data2.Kind != "VALIDATION" {
+		t.Fatalf("error.data.kind = %q, want VALIDATION", data2.Kind)
 	}
-	if got, _ := data.Details["field"].(string); got != "item_id" {
+	if got, _ := data2.Details["field"].(string); got != "item_id" {
 		t.Fatalf("error.data.details.field = %q, want \"item_id\"", got)
 	}
 }


### PR DESCRIPTION
## unblock-tv8.82: Uniform §7 VALIDATION at the MCP boundary

Closes the B2+B3 argument-validation gaps surfaced by the live MCP catalogue sweep: advertised numeric bounds were never on the wire and schema-gate rejections bypassed the §7 envelope. Implements the ratified §7.3 / §7.3.1 / §7.3.2 + §6.2.0a contract (committed to main as 3f502c7).

### What was done
Generalized the shipped `handler_update.go` relaxed-schema precedent into a **shared boundary-validation layer** (`apps/api/mcp/validate.go`). Every tool registers via the non-generic `sdkServer.AddTool` with the **full rich catalogue schema** as the advertised `tools/list` InputSchema (enum + min/max + required + additionalProperties — NET-NEW per §6.2.0a) while the go-sdk runs **zero** `applySchema` pre-validation; the shared `validateArgs` pass then enforces required/enum/type/range/additionalProperties at the handler boundary and mints the §7 `VALIDATION` envelope via the existing `errmap.go` `mapError` path.

- **B3** — missing-required / invalid-enum / wrong-type / unknown-key now surface §7 `VALIDATION` (`kind`, `trace_id`, `data.field`), never a bare `isError` frame — uniform across all 23 tools.
- **B2 / §7.3.1** — a supplied paginated `limit`/`ready_limit` outside its advertised inclusive range (incl. `limit<=0` and `prime.ready_limit>50`) **rejects** with `VALIDATION` (`data.field` + `data.bound`), no clamp/coerce. An omitted limit still takes the per-tool default.

### Files changed
- NEW `apps/api/mcp/validate.go` — `validateArgs` + `registerValidatedTool`
- `apps/api/mcp/errmap.go` — surface `Meta["bound"]` as `data.bound`
- All 23 `handler_*.go` registrations routed through `registerValidatedTool`; the 4 paginated handlers dropped the old clamp/coerce/range checks + max consts; `handler_update.go` dropped its bespoke relaxed InputSchema
- `apps/api/mcp/transport.go` — doc update
- NEW `apps/api/exitcriteriontest/uniform_validation_test.go` — e2e matrix + happy control
- `apps/api/mcp/catalogue_test.go` — `TestRegisteredInputSchemaMatchesCatalogue` schema-parity guard
- `apps/api/shared/mcpaudittest/d4_tools_test.go` (missing item_id → §7 VALIDATION) + `d2_tools_test.go` (ready limit=0 → VALIDATION re-lock)

### Decisions
- `validateArgs` reads the rich contract directly from `catalogue.gen.go` (single source of truth; advertised == validated bytes, drift-guarded)
- `data.bound` flows via `errs.Meta["bound"]` → `errmap.go` for range violations only

### Deviations
- §7.3.2 phrases the mechanism as "registered schema relaxed while tools/list enriched"; in go-sdk v1.6.0 the generic `AddTool` couples advertised + validated schema to one object with no post-hoc accessor, so the equivalent invariant is implemented via the **non-generic `Server.AddTool`** (stores rich schema verbatim, runs no `applySchema`, 100% validation owned by `validateArgs`). Same observable contract; the helper replicates the SDK generic output path so structured-echoes-text tests stay green.

### Tests
`encore test ./...` — all packages pass. `go fmt` / `go vet` clean; `encore check` passes (app boots, 37 endpoints register); JSON-tag PascalCase gate clean.