### PR TITLE
unblock-tv8.86: caller-org gate org.AddMember/CreateProject — close cross-tenant write IDOR + priv-esc

### DIFF
--- a/apps/api/org/caller_gate_test.go
+++ b/apps/api/org/caller_gate_test.go
@@ -1,0 +1,335 @@
+// Cross-tenant caller-gate tests for org.AddMember and org.CreateProject
+// (bead unblock-tv8.86 — org-provisioning write-surface tenant gates,
+// SPEC §4.2 / §10.1.1).
+//
+// Both RPCs gained an off-wire CallerUserID channel pinned from the
+// resolved caller identity (the future key-management / web-admin BFF's
+// session→user→org resolution, §4.3.2), NEVER from the wire. When
+// CallerUserID is non-empty:
+//
+//   - AddMember requires the caller to hold an admin/owner org.members
+//     row in OrgID AND caps the granted Role at the caller's effective
+//     role (a CRITICAL cross-tenant privilege-escalation gate).
+//   - CreateProject requires the caller to be a write-capable member of
+//     OrgID (a WARNING-class cross-tenant write IDOR gate, replacing the
+//     FK→NotFound that only caught a non-existent org).
+//
+// A foreign / non-member / non-admin caller → NotFound (existence not
+// leaked); an AddMember over-grant → PermissionDenied. Nothing is
+// inserted in either rejection path.
+//
+// Empty CallerUserID is the DORMANT no-op (the trusted §11.1.1 seed +
+// org / rbactest / exitcriteriontest / perftest callers pass no caller
+// identity) — exercised by every pre-existing org RPC test, which still
+// passes. These tests assert the ACTIVE (non-empty-CallerUserID) path.
+//
+// Shares the seedUser / seedOrg / asUser helpers and the package shape
+// of rpc_integration_test.go. MUST run under `encore test
+// ./apps/api/org/...` (Docker-backed cluster) — plain `go test` leaves
+// org.db == nil and the RPC bodies panic. None call t.Parallel() (BindDB
+// is not goroutine-safe; same single-threaded convention as the sibling
+// integration tests).
+
+package org_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	encoredb "encore.app/db"
+	"encore.app/org"
+	"encore.app/shared/ulid"
+	"encore.dev/beta/errs"
+)
+
+// enrol adds userID to orgID with the given role via the DORMANT-gate
+// path (no CallerUserID), the same way the §11.1.1 seed enrols members.
+// Used to establish the caller's own membership before the active-gate
+// assertions.
+func enrol(t *testing.T, ctx context.Context, orgID, userID, role string) {
+	t.Helper()
+	if err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:  orgID,
+		UserID: userID,
+		Role:   role,
+		// CallerUserID empty → dormant no-op (seed-style enrolment).
+	}); err != nil {
+		t.Fatalf("enrol %s as %s in %s: %v", userID, role, orgID, err)
+	}
+}
+
+// memberCount returns the number of org.members rows for (orgID, userID).
+// Used to assert that a rejected write inserted nothing.
+func memberCount(t *testing.T, ctx context.Context, orgID, userID string) int {
+	t.Helper()
+	var n int
+	if err := encoredb.DB.QueryRow(ctx,
+		`SELECT count(*) FROM org.members WHERE org_id = $1 AND user_id = $2`,
+		orgID, userID,
+	).Scan(&n); err != nil {
+		t.Fatalf("memberCount(%s,%s): %v", orgID, userID, err)
+	}
+	return n
+}
+
+// projectCountInOrg returns the number of org.projects rows under orgID.
+// Used to assert that a rejected CreateProject inserted nothing.
+func projectCountInOrg(t *testing.T, ctx context.Context, orgID string) int {
+	t.Helper()
+	var n int
+	if err := encoredb.DB.QueryRow(ctx,
+		`SELECT count(*) FROM org.projects WHERE org_id = $1`,
+		orgID,
+	).Scan(&n); err != nil {
+		t.Fatalf("projectCountInOrg(%s): %v", orgID, err)
+	}
+	return n
+}
+
+func newSlug(t *testing.T, prefix string) string {
+	t.Helper()
+	suffix, err := ulid.New()
+	if err != nil {
+		t.Fatalf("ulid (%s slug): %v", prefix, err)
+	}
+	return strings.ToLower(prefix + "-" + suffix[len(suffix)-12:])
+}
+
+// TestAddMemberForeignOrgRejected (AC5a) — a caller who is an admin of
+// org A cannot add a member to a FOREIGN org B in which they hold no
+// row. The pinned CallerUserID gate rejects with NotFound (existence not
+// leaked) and inserts nothing.
+func TestAddMemberForeignOrgRejected(t *testing.T) {
+	ctx := context.Background()
+
+	orgA := seedOrg(t, ctx, "am-foreign-a")
+	orgB := seedOrg(t, ctx, "am-foreign-b")
+
+	caller := seedUser(t, ctx) // admin of A only
+	enrol(t, ctx, orgA.ID, caller, "admin")
+
+	victim := seedUser(t, ctx) // the user the attacker tries to plant in B
+
+	err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:        orgB.ID, // FOREIGN org — caller holds no row here
+		UserID:       victim,
+		Role:         "member",
+		CallerUserID: caller, // pinned → ACTIVE gate
+	})
+	if err == nil {
+		t.Fatalf("AddMember into foreign org succeeded, want NotFound")
+	}
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("foreign-org AddMember code = %v, want NotFound (err=%v)", errs.Code(err), err)
+	}
+	if n := memberCount(t, ctx, orgB.ID, victim); n != 0 {
+		t.Fatalf("foreign-org AddMember inserted %d rows, want 0", n)
+	}
+}
+
+// TestAddMemberOverGrantRejected (AC5b) — an admin of an org cannot grant
+// a role ABOVE their own (here: admin attempting to mint an owner). The
+// role cap rejects with PermissionDenied and inserts nothing.
+func TestAddMemberOverGrantRejected(t *testing.T) {
+	ctx := context.Background()
+
+	o := seedOrg(t, ctx, "am-overgrant")
+	caller := seedUser(t, ctx) // admin (strength 3)
+	enrol(t, ctx, o.ID, caller, "admin")
+
+	victim := seedUser(t, ctx)
+
+	err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:        o.ID,
+		UserID:       victim,
+		Role:         "owner", // strength 4 > caller's 3 → over-grant
+		CallerUserID: caller,
+	})
+	if err == nil {
+		t.Fatalf("AddMember over-grant succeeded, want PermissionDenied")
+	}
+	if errs.Code(err) != errs.PermissionDenied {
+		t.Fatalf("over-grant AddMember code = %v, want PermissionDenied (err=%v)", errs.Code(err), err)
+	}
+	if n := memberCount(t, ctx, o.ID, victim); n != 0 {
+		t.Fatalf("over-grant AddMember inserted %d rows, want 0", n)
+	}
+}
+
+// TestAddMemberNonAdminCallerRejected — a same-org MEMBER (not admin) is
+// not authorised to add members. The gate rejects with NotFound
+// (existence not leaked) and inserts nothing.
+func TestAddMemberNonAdminCallerRejected(t *testing.T) {
+	ctx := context.Background()
+
+	o := seedOrg(t, ctx, "am-nonadmin")
+	caller := seedUser(t, ctx) // plain member (no admin authority)
+	enrol(t, ctx, o.ID, caller, "member")
+
+	victim := seedUser(t, ctx)
+
+	err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:        o.ID,
+		UserID:       victim,
+		Role:         "member",
+		CallerUserID: caller,
+	})
+	if err == nil {
+		t.Fatalf("AddMember by non-admin member succeeded, want NotFound")
+	}
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("non-admin AddMember code = %v, want NotFound (err=%v)", errs.Code(err), err)
+	}
+	if n := memberCount(t, ctx, o.ID, victim); n != 0 {
+		t.Fatalf("non-admin AddMember inserted %d rows, want 0", n)
+	}
+}
+
+// TestAddMemberSameOrgAdminPositive — same-org positive control: an admin
+// adding a member at-or-below their own role succeeds via the ACTIVE
+// gate, and the row is written.
+func TestAddMemberSameOrgAdminPositive(t *testing.T) {
+	ctx := context.Background()
+
+	o := seedOrg(t, ctx, "am-positive")
+	caller := seedUser(t, ctx) // admin
+	enrol(t, ctx, o.ID, caller, "admin")
+
+	newMember := seedUser(t, ctx)
+
+	if err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:        o.ID,
+		UserID:       newMember,
+		Role:         "member", // at-or-below admin → within cap
+		CallerUserID: caller,
+	}); err != nil {
+		t.Fatalf("same-org admin AddMember (within cap) failed: %v", err)
+	}
+	if n := memberCount(t, ctx, o.ID, newMember); n != 1 {
+		t.Fatalf("same-org admin AddMember wrote %d rows, want 1", n)
+	}
+
+	// invited_by must record the pinned CallerUserID (the audit trail
+	// follows the off-wire caller identity when present).
+	var invitedBy *string
+	if err := encoredb.DB.QueryRow(ctx,
+		`SELECT invited_by FROM org.members WHERE org_id = $1 AND user_id = $2`,
+		o.ID, newMember,
+	).Scan(&invitedBy); err != nil {
+		t.Fatalf("read invited_by: %v", err)
+	}
+	if invitedBy == nil || *invitedBy != caller {
+		t.Fatalf("invited_by = %v, want %q (the pinned CallerUserID)", invitedBy, caller)
+	}
+}
+
+// TestAddMemberOwnerCanGrantOwnerPositive — role-cap boundary: an owner
+// (the top role) MAY grant owner. Confirms the cap is "above", not
+// "at-or-above".
+func TestAddMemberOwnerCanGrantOwnerPositive(t *testing.T) {
+	ctx := context.Background()
+
+	o := seedOrg(t, ctx, "am-owner-grant")
+	caller := seedUser(t, ctx) // owner
+	enrol(t, ctx, o.ID, caller, "owner")
+
+	coOwner := seedUser(t, ctx)
+
+	if err := org.AddMember(ctx, &org.AddMemberRequest{
+		OrgID:        o.ID,
+		UserID:       coOwner,
+		Role:         "owner", // equal to caller's role → within cap
+		CallerUserID: caller,
+	}); err != nil {
+		t.Fatalf("owner granting owner failed, want permit: %v", err)
+	}
+	if n := memberCount(t, ctx, o.ID, coOwner); n != 1 {
+		t.Fatalf("owner-grant AddMember wrote %d rows, want 1", n)
+	}
+}
+
+// TestCreateProjectForeignOrgRejected (AC5c) — a caller who is a member
+// of org A cannot create a project under a FOREIGN org B. The pinned
+// CallerUserID gate rejects with NotFound (replacing the FK→NotFound that
+// only caught a non-existent org) and inserts nothing under B.
+func TestCreateProjectForeignOrgRejected(t *testing.T) {
+	ctx := context.Background()
+
+	orgA := seedOrg(t, ctx, "cp-foreign-a")
+	orgB := seedOrg(t, ctx, "cp-foreign-b")
+
+	caller := seedUser(t, ctx) // member of A only
+	enrol(t, ctx, orgA.ID, caller, "member")
+
+	before := projectCountInOrg(t, ctx, orgB.ID)
+
+	_, err := org.CreateProject(ctx, &org.CreateProjectRequest{
+		OrgID:        orgB.ID, // FOREIGN org — caller holds no row here
+		Name:         "intruder project",
+		Slug:         newSlug(t, "intruder"),
+		CallerUserID: caller, // pinned → ACTIVE gate
+	})
+	if err == nil {
+		t.Fatalf("CreateProject under foreign org succeeded, want NotFound")
+	}
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("foreign-org CreateProject code = %v, want NotFound (err=%v)", errs.Code(err), err)
+	}
+	if after := projectCountInOrg(t, ctx, orgB.ID); after != before {
+		t.Fatalf("foreign-org CreateProject changed project count under B: %d → %d, want unchanged", before, after)
+	}
+}
+
+// TestCreateProjectViewerCallerRejected — a same-org VIEWER (read-only)
+// is not write-capable and cannot create a project. The gate rejects
+// with NotFound and inserts nothing.
+func TestCreateProjectViewerCallerRejected(t *testing.T) {
+	ctx := context.Background()
+
+	o := seedOrg(t, ctx, "cp-viewer")
+	caller := seedUser(t, ctx) // viewer (read-only)
+	enrol(t, ctx, o.ID, caller, "viewer")
+
+	before := projectCountInOrg(t, ctx, o.ID)
+
+	_, err := org.CreateProject(ctx, &org.CreateProjectRequest{
+		OrgID:        o.ID,
+		Name:         "viewer project",
+		Slug:         newSlug(t, "viewer"),
+		CallerUserID: caller,
+	})
+	if err == nil {
+		t.Fatalf("CreateProject by viewer succeeded, want NotFound")
+	}
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("viewer CreateProject code = %v, want NotFound (err=%v)", errs.Code(err), err)
+	}
+	if after := projectCountInOrg(t, ctx, o.ID); after != before {
+		t.Fatalf("viewer CreateProject changed project count: %d → %d, want unchanged", before, after)
+	}
+}
+
+// TestCreateProjectSameOrgMemberPositive — same-org positive control: a
+// write-capable member creates a project under their own org via the
+// ACTIVE gate, and the row is written.
+func TestCreateProjectSameOrgMemberPositive(t *testing.T) {
+	ctx := context.Background()
+
+	o := seedOrg(t, ctx, "cp-positive")
+	caller := seedUser(t, ctx) // member (write-capable)
+	enrol(t, ctx, o.ID, caller, "member")
+
+	p, err := org.CreateProject(ctx, &org.CreateProjectRequest{
+		OrgID:        o.ID,
+		Name:         "member project",
+		Slug:         newSlug(t, "member"),
+		CallerUserID: caller,
+	})
+	if err != nil {
+		t.Fatalf("same-org member CreateProject failed: %v", err)
+	}
+	if p.ID == "" || p.OrgID != o.ID {
+		t.Fatalf("CreateProject returned %+v, want non-empty id and org_id=%s", p, o.ID)
+	}
+}

--- a/apps/api/org/caller_gate_test.go
+++ b/apps/api/org/caller_gate_test.go
@@ -45,8 +45,10 @@ import (
 
 // enrol adds userID to orgID with the given role via the DORMANT-gate
 // path (no CallerUserID), the same way the §11.1.1 seed enrols members.
-// Used to establish the caller's own membership before the active-gate
-// assertions.
+// It deliberately bypasses the active caller-gate via the empty-caller
+// no-op to establish the membership fixture — the gate under test would
+// otherwise reject the very rows these assertions need in place. Used to
+// establish the caller's own membership before the active-gate assertions.
 func enrol(t *testing.T, ctx context.Context, orgID, userID, role string) {
 	t.Helper()
 	if err := org.AddMember(ctx, &org.AddMemberRequest{

--- a/apps/api/org/org.go
+++ b/apps/api/org/org.go
@@ -69,6 +69,16 @@ type CreateProjectRequest struct {
 	OrgID string `json:"org_id"`
 	Name  string `json:"name"`
 	Slug  string `json:"slug"`
+	// CallerUserID is the caller-membership gate key (bead
+	// unblock-tv8.86). It is pinned from the resolved caller identity
+	// (the future key-management BFF / web-admin surface's
+	// session→user→org resolution, §4.3.2) and is NEVER accepted from
+	// the wire — exactly the §10.1.1 internal-channel convention. When
+	// non-empty the RPC requires the caller to be a write-capable member
+	// of OrgID before the INSERT. Empty → dormant no-op (the trusted
+	// §11.1.1 seed + org / rbactest / exitcriteriontest / perftest
+	// callers pass no caller identity).
+	CallerUserID string `json:"caller_user_id"` // ULID
 }
 
 // AddMemberRequest is the input to AddMember. SPEC §4.2.
@@ -76,6 +86,17 @@ type AddMemberRequest struct {
 	OrgID  string `json:"org_id"`
 	UserID string `json:"user_id"`
 	Role   string `json:"role"` // "owner" | "admin" | "member" | "viewer"
+	// CallerUserID is the caller-admin gate key + role-cap basis (bead
+	// unblock-tv8.86). It is pinned from the resolved caller identity
+	// (the future key-management BFF / web-admin surface's
+	// session→user→org resolution, §4.3.2) and is NEVER accepted from
+	// the wire — exactly the §10.1.1 internal-channel convention. When
+	// non-empty the RPC requires the caller to hold an admin/owner
+	// org.members row in OrgID AND caps the granted Role at the caller's
+	// effective role (no granting above one's own). Empty → dormant
+	// no-op (the trusted §11.1.1 seed + org / rbactest /
+	// exitcriteriontest / perftest callers pass no caller identity).
+	CallerUserID string `json:"caller_user_id"` // ULID
 }
 
 // AuthorizeRequest is the input to Authorize. SPEC §4.2.
@@ -276,6 +297,29 @@ func CreateOrganization(ctx context.Context, req *CreateOrganizationRequest) (*O
 // CreateProject inserts a new org.projects row. UNIQUE (org_id, slug)
 // is enforced by projects_org_slug_uniq.
 //
+// Tenant gate (bead unblock-tv8.86, SPEC §4.2 / §10.1.1). Pre-this-round
+// the only guard on the wire-supplied OrgID was the org_id FK →
+// NotFound, which catches a NON-EXISTENT org but NOT a FOREIGN EXISTING
+// one — so a caller could create a project under any other tenant's org
+// (a WARNING-class cross-tenant write IDOR). It is NOT reachable from the
+// MCP agent wire today (no MCP tool maps to it; only test/seed callers
+// exist) — LATENTLY exploitable once a future key-management / web-admin
+// BFF is wired. When CallerUserID is non-empty the RPC requires the
+// caller to be a write-capable member of OrgID (an org.members row whose
+// role permits the "write" action, the org.Authorize predicate, SELECT
+// role FROM org.members WHERE org_id=$1 AND user_id=$2, §4.2 /
+// apps/api/org/org.go:520) BEFORE the INSERT; a foreign / non-member
+// OrgID → NotFound (replacing the FK→NotFound, which only caught a
+// non-existent org), nothing inserted, existence not leaked. CallerUserID
+// is pinned from the resolved caller identity (the future BFF's
+// session→user→org resolution, §4.3.2) and is NEVER from the wire. Empty
+// CallerUserID is a NO-OP (dormant gate): the gate is skipped so the
+// trusted §11.1.1 seed + org / rbactest / exitcriteriontest / perftest
+// callers (no caller identity) operate unscoped — DORMANT until the
+// future BFF pins CallerUserID, and that future bead MUST pin it (else
+// the no-op leaves the IDOR open). No org schema change — the gate is an
+// org.members membership read.
+//
 //encore:api private method=POST path=/org.CreateProject
 func CreateProject(ctx context.Context, req *CreateProjectRequest) (*Project, error) {
 	if req == nil {
@@ -291,6 +335,32 @@ func CreateProject(ctx context.Context, req *CreateProjectRequest) (*Project, er
 	slug, err := normaliseSlug(req.Slug)
 	if err != nil {
 		return nil, err
+	}
+
+	// Tenant gate (bead unblock-tv8.86): when CallerUserID is pinned,
+	// require the caller to be a write-capable member of OrgID before
+	// the INSERT. Empty CallerUserID is a dormant no-op (trusted §11.1.1
+	// seed / org / rbactest / exitcriteriontest / perftest callers). A
+	// foreign / non-member OrgID surfaces as NotFound (existence not
+	// leaked), never a cross-tenant write.
+	if req.CallerUserID != "" {
+		role, err := orgMemberRole(ctx, req.OrgID, req.CallerUserID)
+		if err != nil {
+			rlog.Error("org: create project caller-membership lookup failed", "err", err, "org_id", req.OrgID)
+			return nil, &errs.Error{Code: errs.Internal, Message: "create project failed"}
+		}
+		// Caller must be a member AND hold a role that permits the
+		// "write" action (owner/admin/member; viewer is read-only). A
+		// non-member OR a write-incapable member both surface as
+		// NotFound so a cross-tenant probe cannot distinguish "org does
+		// not exist" from "org belongs to another tenant" (existence
+		// not leaked).
+		if role == "" || !rolePermits(role, actionWrite) {
+			return nil, &errs.Error{
+				Code:    errs.NotFound,
+				Message: fmt.Sprintf("organization %q not found", req.OrgID),
+			}
+		}
 	}
 
 	id, err := ulid.New()
@@ -425,6 +495,32 @@ type projectRow struct {
 // AddMember inserts an org.members row. Role is validated client-side
 // so the DB CHECK (members_role_chk) is never the surface error.
 //
+// Tenant gate (bead unblock-tv8.86, SPEC §4.2 / §10.1.1) — CRITICAL
+// privilege escalation. Pre-this-round the INSERT stamped OrgID, UserID,
+// and Role straight from the wire with ZERO caller-ownership check
+// (callerIdentity fed only the invited_by audit column, NEVER
+// authorization) and Role had no cap — so a caller could mint themselves
+// (or anyone) as owner of ANY existing org. It is NOT reachable from the
+// MCP agent wire today (no MCP tool maps to it; only test/seed callers
+// exist) — LATENTLY exploitable once a future key-management / web-admin
+// BFF is wired. When CallerUserID is non-empty the RPC enforces BOTH:
+// (a) the caller holds an admin/owner org.members row in OrgID (the
+// org.Authorize predicate, SELECT role FROM org.members WHERE org_id=$1
+// AND user_id=$2, §4.2 / apps/api/org/org.go:520) BEFORE the INSERT; and
+// (b) the granted Role is CAPPED at the caller's effective role — a
+// caller cannot grant a role above their own. A foreign / non-member
+// OrgID or an unauthorised (non-admin) caller → NotFound (existence not
+// leaked); an over-grant → PermissionDenied; nothing inserted in either
+// case. CallerUserID is pinned from the resolved caller identity (the
+// future BFF's session→user→org resolution, §4.3.2) and is NEVER from
+// the wire. Empty CallerUserID is a NO-OP (dormant gate): the gate is
+// skipped so the trusted §11.1.1 seed + org / rbactest /
+// exitcriteriontest / perftest callers (no caller identity) operate
+// unscoped — DORMANT until the future BFF pins CallerUserID, and that
+// future bead MUST pin it (else the no-op leaves the priv-esc open). No
+// org schema change — the gate is an org.members membership read + a
+// role cap.
+//
 //encore:api private method=POST path=/org.AddMember
 func AddMember(ctx context.Context, req *AddMemberRequest) error {
 	if req == nil {
@@ -454,17 +550,56 @@ func AddMember(ctx context.Context, req *AddMemberRequest) error {
 		}
 	}
 
+	// Tenant gate + role cap (bead unblock-tv8.86): when CallerUserID is
+	// pinned, the caller must be an admin/owner of OrgID, and the
+	// granted Role must not exceed the caller's effective role. Empty
+	// CallerUserID is a dormant no-op (trusted §11.1.1 seed / org /
+	// rbactest / exitcriteriontest / perftest callers).
+	if req.CallerUserID != "" {
+		callerRole, err := orgMemberRole(ctx, req.OrgID, req.CallerUserID)
+		if err != nil {
+			rlog.Error("org: add member caller-membership lookup failed", "err", err, "org_id", req.OrgID)
+			return &errs.Error{Code: errs.Internal, Message: "add member failed"}
+		}
+		// (a) Caller must hold an admin or owner row in OrgID. A
+		// non-member, or a member without admin authority, surfaces as
+		// NotFound so a cross-tenant probe cannot distinguish "org does
+		// not exist" from "org belongs to another tenant" or "caller
+		// lacks admin" (existence not leaked).
+		if callerRole != roleAdmin && callerRole != roleOwner {
+			return &errs.Error{
+				Code:    errs.NotFound,
+				Message: fmt.Sprintf("organization %q not found", req.OrgID),
+			}
+		}
+		// (b) Role cap: the granted role may not exceed the caller's
+		// effective role (an admin cannot mint an owner). An over-grant
+		// is an authorization failure, not an existence probe, so it
+		// surfaces as PermissionDenied.
+		if roleStrength[req.Role] > roleStrength[callerRole] {
+			return &errs.Error{
+				Code:    errs.PermissionDenied,
+				Message: fmt.Sprintf("cannot grant role %q above caller's role %q", req.Role, callerRole),
+				Meta:    errs.Metadata{"field": "role"},
+			}
+		}
+	}
+
 	id, err := ulid.New()
 	if err != nil {
 		return &errs.Error{Code: errs.Internal, Message: "member id generation failed"}
 	}
 
-	// invited_by is sourced from the caller's auth.Identity (Encore
-	// auth-context wired via auth.UserID). Nullable in the schema —
-	// when the caller is an agent or the context is missing, we
-	// insert NULL rather than fabricating a user id.
+	// invited_by is the audit trail for who added this member. When the
+	// caller identity is pinned off-wire (CallerUserID, the future BFF
+	// surface) it is authoritative; otherwise we fall back to the Encore
+	// auth-context identity (callerIdentity). Nullable in the schema —
+	// when neither is present, or the caller is an agent, we insert NULL
+	// rather than fabricating a user id.
 	var invitedBy any
-	if identity, ok := callerIdentity(ctx); ok && identity.UserID != "" && identity.Role != roleAgent {
+	if req.CallerUserID != "" {
+		invitedBy = req.CallerUserID
+	} else if identity, ok := callerIdentity(ctx); ok && identity.UserID != "" && identity.Role != roleAgent {
 		invitedBy = identity.UserID
 	}
 
@@ -638,6 +773,33 @@ func effectiveRole(ctx context.Context, orgID, projectID, userID string) (string
 	}
 
 	return strongerRole(orgRole, projectRole), nil
+}
+
+// orgMemberRole returns the org-level role of userID in orgID, or "" when
+// the user has no org.members row. It is the load-bearing gate read for
+// the CreateProject caller-membership and AddMember caller-admin checks
+// (bead unblock-tv8.86) — the same canonical predicate org.Authorize keys
+// on (SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2, §4.2 /
+// apps/api/org/org.go:520-624). A genuine "no membership" returns
+// ("", nil); only a real query failure returns a non-nil error. Empty
+// orgID/userID can never match a membership row, so they short-circuit to
+// ("", nil) — a malformed caller cannot probe with empty ids.
+func orgMemberRole(ctx context.Context, orgID, userID string) (string, error) {
+	if orgID == "" || userID == "" {
+		return "", nil
+	}
+	var role string
+	err := db.QueryRow(ctx,
+		`SELECT role FROM org.members WHERE org_id = $1 AND user_id = $2`,
+		orgID, userID,
+	).Scan(&role)
+	if err != nil {
+		if errors.Is(err, sqldb.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("org members lookup: %w", err)
+	}
+	return role, nil
 }
 
 // strongerRole returns the rank-max of two role strings. Empty strings

--- a/apps/api/workitems/workitems.go
+++ b/apps/api/workitems/workitems.go
@@ -106,15 +106,23 @@
 // they have no trusted-internal-caller path (they are MCP-only), so an
 // empty CallerOrgID there is always a programming error.
 //
-// The org service's own private writes (org.CreateProject etc.) follow
-// the same Bearer-resolved-identity pattern. This matches SPEC §10.1 /
-// §10.1.1's gate model: read and write tenant gates both live in the
-// SQL, with the write gate keyed on the CallerOrgID internal channel.
-// Layering an explicit org.Authorize call inside every private write RPC
-// (belt-and-suspenders) was considered and rejected during round-2
-// review of bead unblock-tv8.10 — the duplicate gate would obscure the
-// model without adding a meaningful security property over the row-level
-// predicate above.
+// The org service's own tenant-scoped private writes (org.CreateProject,
+// org.AddMember) self-gate via a CallerUserID org.members membership
+// predicate of their own (bead unblock-tv8.86, SPEC §4.2 / §10.1.1) —
+// NOT via this CallerOrgID channel and NOT via org.Authorize (which is
+// the cross-SERVICE primitive other services call, never the gate for
+// org's own provisioning writes). That org-write gate is DORMANT today
+// (an empty-CallerUserID no-op for the trusted §11.1.1 seed + org /
+// rbactest / exitcriteriontest / perftest callers) and goes live once a
+// future key-management / web-admin BFF pins CallerUserID from the
+// resolved session identity. (Bootstrapping writes — org.CreateOrganization,
+// where the caller BECOMES the owner — carry no membership gate by
+// design and are correctly out of scope.) This matches SPEC §10.1 /
+// §10.1.1's gate model: each service's write tenant gate lives in its own
+// RPC, keyed on a caller-identity channel pinned off-wire from the
+// resolved session — the workitems write gate keys on the CallerOrgID
+// channel above; the org provisioning writes key on their own
+// CallerUserID membership predicate.
 package workitems
 
 import (

--- a/docs/specs/01-spec-backend-mvp.md
+++ b/docs/specs/01-spec-backend-mvp.md
@@ -1,7 +1,8 @@
 # SPEC: P01 — Backend MVP Implementation Contract
 
-**Status:** APPROVED (auth/BFF admin write-surface tenant gates applied 2026-06-15 — §10.1.1 gate-model extended to the two `auth` RPCs that write `mcp.api_keys` (`IssueAPIKey` `org.Authorize`-on-`CallerUserID` ownership + `issued_to_user ∈ org.members`; `RevokeAPIKey` `CallerOrgID` row predicate on the UPDATE), closing TWO LATENT cross-tenant write IDORs on the admin/BFF surface the MCP-wire sweep set aside — DORMANT (empty-caller no-op) until a future key-management BFF pins the caller identity (bead `unblock-tv8.85`); `Update.milestone_id` write-scope tenant gate applied 2026-06-15 — §10.1.1 gate-model extended to `workitems.Update`'s wire-supplied `milestone_id` selector (org-XOR-project milestone predicate, `AssignItem`/`Create` precedent), closing the CRITICAL cross-tenant write IDOR that `.83`'s AC4 wrongly assumed gated (bead `unblock-tv8.84`); `create_milestone.project_id` INSERT-scope tenant gate applied 2026-06-15 — §10.1.1 gate-model extended to `workitems.CreateMilestone`'s project-scoped `project_id` selector (guarded INSERT…SELECT, `CreateLabel` precedent), closing the last ungated cross-reference write-IDOR in the family (bead `unblock-tv8.83`); create-path cross-reference tenant validation applied 2026-06-12 — §10.1.1 gate-model extended to `workitems.Create`'s wire references, keyed on the existing `req.OrgID` per Miguel's 2026-06-12 DECISION, + §4.4 `CreateRequest`/`DependencyEdge` drift reconciliation; round-16 write-surface tenant-hardening lockstep applied 2026-06-11 — §10.1.1 row-level write gate + per-RPC `CallerOrgID` channel + deps fold-in + `CreateLabel` empty-`CallerOrgID` guard; round-16 label-tools drift-closure applied 2026-06-11 — labels `updated_at` migration `0130` + Tools 20–23 auth wording + Tools 16/19 wire-sample/prose alignment; round-16 P01 tool-surface scope amendment applied 2026-06-04; §3.5 fifth-secret addition applied 2026-06-02; round-15 NFR-1 harness test-isolation + mcpaudittest hardening applied 2026-05-29; round-14 NFR-1 latency-harness scope applied 2026-05-29; round-6 cascade-symmetry applied 2026-05-12; round-5 tracing applied 2026-05-12; round-4 auth applied 2026-05-11; DRIFT-1/-2 applied 2026-05-08; round-2 applied 2026-05-08; round-3 research applied 2026-05-08; original APPROVED 2026-05-07)
+**Status:** APPROVED (org-provisioning write-surface tenant gates applied 2026-06-15 — §10.1.1 gate-model + §4.2 extended to the two `org` RPCs that write tenant-scoped rows from the wire (`org.AddMember` caller-admin `org.members` predicate + role cap — closing a CRITICAL cross-tenant privilege escalation; `org.CreateProject` caller-membership predicate replacing the FK→`NotFound` that only caught a non-existent org — closing a WARNING write IDOR), the sibling org-provisioning RPCs the `.85` admin/BFF sweep set aside — DORMANT (empty-caller no-op) until a future key-management BFF pins the caller identity (bead `unblock-tv8.86`); auth/BFF admin write-surface tenant gates applied 2026-06-15 — §10.1.1 gate-model extended to the two `auth` RPCs that write `mcp.api_keys` (`IssueAPIKey` `org.Authorize`-on-`CallerUserID` ownership + `issued_to_user ∈ org.members`; `RevokeAPIKey` `CallerOrgID` row predicate on the UPDATE), closing TWO LATENT cross-tenant write IDORs on the admin/BFF surface the MCP-wire sweep set aside — DORMANT (empty-caller no-op) until a future key-management BFF pins the caller identity (bead `unblock-tv8.85`); `Update.milestone_id` write-scope tenant gate applied 2026-06-15 — §10.1.1 gate-model extended to `workitems.Update`'s wire-supplied `milestone_id` selector (org-XOR-project milestone predicate, `AssignItem`/`Create` precedent), closing the CRITICAL cross-tenant write IDOR that `.83`'s AC4 wrongly assumed gated (bead `unblock-tv8.84`); `create_milestone.project_id` INSERT-scope tenant gate applied 2026-06-15 — §10.1.1 gate-model extended to `workitems.CreateMilestone`'s project-scoped `project_id` selector (guarded INSERT…SELECT, `CreateLabel` precedent), closing the last ungated cross-reference write-IDOR in the family (bead `unblock-tv8.83`); create-path cross-reference tenant validation applied 2026-06-12 — §10.1.1 gate-model extended to `workitems.Create`'s wire references, keyed on the existing `req.OrgID` per Miguel's 2026-06-12 DECISION, + §4.4 `CreateRequest`/`DependencyEdge` drift reconciliation; round-16 write-surface tenant-hardening lockstep applied 2026-06-11 — §10.1.1 row-level write gate + per-RPC `CallerOrgID` channel + deps fold-in + `CreateLabel` empty-`CallerOrgID` guard; round-16 label-tools drift-closure applied 2026-06-11 — labels `updated_at` migration `0130` + Tools 20–23 auth wording + Tools 16/19 wire-sample/prose alignment; round-16 P01 tool-surface scope amendment applied 2026-06-04; §3.5 fifth-secret addition applied 2026-06-02; round-15 NFR-1 harness test-isolation + mcpaudittest hardening applied 2026-05-29; round-14 NFR-1 latency-harness scope applied 2026-05-29; round-6 cascade-symmetry applied 2026-05-12; round-5 tracing applied 2026-05-12; round-4 auth applied 2026-05-11; DRIFT-1/-2 applied 2026-05-08; round-2 applied 2026-05-08; round-3 research applied 2026-05-08; original APPROVED 2026-05-07)
 **Changelog:**
+- 2026-06-15 — org-provisioning write-surface tenant gates (bead `unblock-tv8.86`, discovered-from the 2026-06-15 admin/BFF surface IDOR sweep — the SIBLING org-provisioning RPCs the `.85` round, on the same admin/BFF surface, deliberately set aside; status remains APPROVED — this is an additive §10.1.1 gate-model + §4.2 extension closing a CRITICAL cross-tenant privilege escalation + a write IDOR, NOT a re-architecting). Two `private` Encore RPCs in `apps/api/org/org.go` write tenant-scoped rows from the wire with NO caller-ownership check: **(1) `org.AddMember` (org.go:429-475) — CRITICAL cross-tenant privilege escalation** — takes `OrgID`/`UserID`/`Role` straight from the wire and INSERTs an `org.members` row with ZERO caller-ownership check (`callerIdentity` feeds only the `invited_by` audit column, NEVER authorization), and `Role` has no cap → a caller can mint itself (or anyone) as `owner` of ANY existing org; **(2) `org.CreateProject` (org.go:280-311) — WARNING** — takes `OrgID` from the wire and INSERTs an `org.projects` row under it; the only guard is the FK→`NotFound`, which catches a NON-EXISTENT org but NOT a FOREIGN existing one. NEITHER is reachable from the MCP agent wire today (no MCP tool maps to them; no non-test in-repo caller; `apps/web` is a README placeholder) — both are LATENTLY exploitable cross-tenant once a future key-management / web-admin BFF is wired. **Locked contract (decided by Miguel — fix now via spec-first, mirroring `.85`):** these RPCs carry NO caller identity today; the fix ADDS an off-wire `CallerUserID` channel pinned from the resolved session identity (the future BFF's session→user→org resolution, §4.3.2), NEVER from the wire — exactly the §10.1.1 / `.85` internal-channel convention, NOT a wire argument. **AddMember:** new `CallerUserID` field; when non-empty, require the caller to hold an **admin/owner** `org.members` row in `OrgID` (`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2`, §4.2 / `org.go:520`) BEFORE the INSERT, AND **cap the grantable `Role` at the caller's effective role** (a caller cannot grant above their own). A foreign / non-member `OrgID`, an unauthorised caller, or an over-grant → `NOT_FOUND` / appropriate error, nothing inserted, existence not leaked. **CreateProject:** new `CallerUserID` field; when non-empty, require the caller to be a **write-capable member** of `OrgID` before the INSERT; a foreign / non-member `OrgID` → `NOT_FOUND`, **replacing the FK→`NotFound`** that only caught a non-existent org. **Empty-caller NO-OP (dormant gate):** when `CallerUserID` is empty (the trusted §11.1.1 seed + `org` / `rbactest` / `exitcriteriontest` / `perftest` callers, which pass no caller identity) the gate is skipped — DORMANT until the future BFF pins the caller; that future bead MUST pin it (else the no-op leaves the priv-esc / IDOR open). Same empty-caller no-op precedent as `.85` / the §10.1.1 item/milestone write-RPC pattern. Bootstrapping is correctly OUT of scope: `org.CreateOrganization` (caller becomes owner), `auth.ExchangeOAuthCode` / `auth.Validate` (identity establishment). Infra CONFIRMED present: `org.members` (migration `0030`), `org.Authorize` (`org.go:520`), the org service owns the `org` schema (direct read OK). Proactively noted: `org.project_members` has no write RPC yet (seed-only) — a future `AddProjectMember`-style RPC will need the IDENTICAL gate. Patched in lockstep: §4.2 (new `CreateProject` / `AddMember` tenant-gate doc-comments + `CreateProjectRequest` / `AddMemberRequest` struct stubs carrying the new `CallerUserID` channel; the `Authorize` doc-comment reconciled — see below; the future-`AddProjectMember` note); §10.1.1 "Auth / BFF admin write surface" subsection (two new rows — `org.AddMember`, `org.CreateProject` — + the org-provisioning intro paragraph + widened closing no-op prose). **Spec self-overclaim reconciled:** the §4.2 `Authorize` doc-comment said `Authorize` is "called by every other service before reading or writing a resource", which could be read to imply `org`'s OWN writes route through it — they do NOT; reworded to "the canonical CROSS-SERVICE RBAC predicate … called by every OTHER service", with an explicit note that `CreateProject` / `AddMember` self-gate via the new `CallerUserID` `org.members` predicate (dormant) while `Authorize` remains the cross-service primitive OTHER services call. **NOT touched (separate ownership): `apps/api/org/org.go` (the gates + the new request fields) + `apps/api/workitems/workitems.go:109-117` (the FALSE "org writes are gated" auth-model doc-comment, which is the CODE's to correct) + tests — the implementation bead `unblock-tv8.86` (Greta) owns those on its branch.** **No DDL / migration / public-API change** — the gates are membership predicates + an `org.Authorize` call + (for `AddMember`) a role cap; the `org` schema (incl. `org.members`, `org.projects`) is UNCHANGED. **Root `docs/SPEC.md` is untouched** — its §5.6 RBAC prose (row-level filtering "applied uniformly to every read and write path") is STRENGTHENED, not contradicted; it carries NO claim that `org`'s own provisioning self-writes are already gated, so no contradiction exists there (verified). Spec status remains APPROVED.
 - 2026-06-15 — auth/BFF admin write-surface tenant gates (bead `unblock-tv8.85`, discovered-from the 2026-06-15 cross-tenant write-IDOR audit extended to the ADMIN/BFF surface the MCP-wire sweep — `.75`/`.77`/`.78`/`.80`/`.83`/`.84` — deliberately set aside; status remains APPROVED — this is an additive §10.1.1 gate-model extension closing TWO LATENT auth-surface IDORs, NOT a re-architecting). Two `private` Encore RPCs in `apps/api/auth/auth.go` write/modify `mcp.api_keys` rows scoped by `org_id` with NO caller-org ownership check: **(1) `auth.RevokeAPIKey`** — `UPDATE mcp.api_keys SET revoked_at=COALESCE(revoked_at,now()) WHERE id=$1` with no caller predicate (any tenant's key revocable by id); **(2) `auth.IssueAPIKey`** — the INSERT stamps `org_id` + `issued_to_user` straight from the wire with no check the caller owns `org_id` nor that `issued_to_user` is a member of `org_id`. NEITHER is reachable from the MCP agent wire today (no MCP tool maps to them; only test/seed callers, and the §11.1.1 E2E seed writes `mcp.api_keys` via direct INSERT) — they are LATENTLY exploitable cross-tenant once a future key-management BFF / web-admin surface is wired. **Locked contract (decided by Miguel — fix now via spec-first):** these RPCs carry NO caller identity today; the fix ADDS a caller-identity channel pinned from the resolved caller identity (the future BFF's session→user→org resolution, §4.3.2 / `auth.Validate` `TokenKind="session"`), NEVER from the wire — exactly the §10.1.1 internal-channel convention, NOT a wire argument. **RevokeAPIKey:** new `CallerOrgID` field; the UPDATE gains `AND ($caller='' OR org_id=$caller)` so a cross-tenant `key_id` affects zero rows → `NOT_FOUND` (existence not leaked); the `COALESCE` idempotency is PRESERVED. **IssueAPIKey:** new `CallerUserID` field (needed because the ownership check uses `org.Authorize`, which keys on the caller's user id); gate on BOTH (a) caller owns `org_id` via `org.Authorize(CallerUserID, <write action>, OrgID)` — `SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2` (`apps/api/org/org.go:520`) — and (b) `issued_to_user ∈ org.members(OrgID)`; a foreign `org_id` or a non-member `issued_to_user` → rejected (`NOT_FOUND` / appropriate error), nothing inserted. **Empty-caller NO-OP (dormant gate):** when the caller-identity field is empty (the trusted §11.1.1 E2E seed + integration / mcpaudit / perf tests, which pass no caller identity or seed `mcp.api_keys` via direct INSERT) the gate is skipped — DORMANT until the future key-management BFF / admin surface pins the caller identity; that future bead MUST pin it (else the no-op leaves it open). This mirrors the §10.1.1 empty-`CallerOrgID` no-op precedent (the MilestoneTree / item-milestone write-RPC pattern), adapted to the auth/BFF surface. Infra CONFIRMED present: `org.members` (migration `0030_org.up.sql:19`, cols org_id/user_id/role), `org.Authorize` (`org.go:520`, membership+role check), `org.AddMember` (`org.go:428`). Patched in lockstep: §4.1 `IssueAPIKey` doc-comment + `IssueAPIKeyRequest` (new `CallerUserID` field) and `RevokeAPIKey` doc-comment + `RevokeAPIKeyRequest` (new `CallerOrgID` field) — each annotated "pinned from the resolved caller identity; NEVER from the wire"; §4.3.2 (new note distinguishing the BFF session-resolution caller identity from the Bearer API-key Validate hot path); §10.1.1 (new "auth/BFF admin write surface" subsection + predicate table — `RevokeAPIKey` caller-org UPDATE predicate, `IssueAPIKey` `org.Authorize` ownership + `issued_to_user` membership — noting (a) NOT MCP-wire-reachable, caller identity pinned by the FUTURE BFF not the Bearer handler; (b) DORMANT empty-caller no-op until that surface is wired, the future bead MUST pin it; (c) cross-tenant probes → `NOT_FOUND`). **NOT touched (separate ownership): `apps/api/auth/auth.go` (the gates + the new request fields) + tests — the implementation bead `unblock-tv8.85` (Greta) owns those on its branch.** **No DDL / migration / public-API change** — the gates are query predicates + an `org.Authorize` call + a membership predicate; the `mcp.api_keys` schema is UNCHANGED. **Root `docs/SPEC.md` is untouched** — its §5.6 RBAC prose (row-level filtering "applied uniformly to every read and write path", `docs/SPEC.md:732`) is STRENGTHENED not contradicted, and its `mcp.api_keys` note (`docs/SPEC.md:1855`) already records `auth.IssueAPIKey` is exercised via direct-INSERT test seeds in P01 — consistent with the dormant-gate framing; no contradicting claim about these RPCs exists there (verified). Spec status remains APPROVED.
 - 2026-06-15 — `Update.milestone_id` write-scope tenant gate (bead `unblock-tv8.84`, discovered-from an adversarial completeness sweep during review of `.83` — which PROVED `.83`'s AC4 ("`create_milestone.project_id` is the LAST ungated selector") INCOMPLETE: `workitems.Update`'s wire-supplied `milestone_id` write was the residual ungated selector — proven by code read 2026-06-15; status remains APPROVED — this is an additive §10.1.1 gate-model extension closing the CRITICAL `Update.milestone_id` cross-tenant write IDOR, NOT a re-architecting). `workitems.Update` wrote the wire-supplied `milestone_id` into `workitems.items` with NO check that the milestone belongs to the caller's org — the `UPDATE`'s only tenant predicate gates the TARGET ITEM's org (`org_id = $caller`, bead `.77`), NOT the new `milestone_id`. Same IDOR class already closed for `.75` (`CreateLabel.project_id`), `.77` (`CreateMilestone.parent` + Update target-item seam), `.78` (`workitems.Create.*`), `.80` (`AppendComment.parent_id`), and `.83` (`create_milestone.project_id`). **Locked contract:** when the request sets a **non-empty** `milestone_id`, the `UPDATE` additionally requires `milestone_id IN (SELECT id FROM workitems.milestones WHERE org_id = $caller OR project_id IN (SELECT id FROM org.projects WHERE org_id = $caller))` — the org-XOR-project milestone predicate, mirroring the EXISTING sibling gates on the two other paths that write the same `items.milestone_id` column, `workitems.Create` and `AssignItem` (both already org-XOR-project gated): a foreign-but-existing `milestone_id` yields zero affected rows → `NOT_FOUND`, the item UNCHANGED, indistinguishable from a missing milestone. The **clear-to-null** path (`milestone_id = ""`) and the **nil = unchanged** path both satisfy the empty-`milestone_id` disjunct and carry NO milestone predicate — PRESERVED; the existing target-item `org_id = $caller` gate (`.77`) and the empty-`CallerOrgID` no-op are PRESERVED. Patched in lockstep: §10.1.1 write-surface predicate table (new `workitems.Update` `milestone_id` write-scope row, distinct from and additional to the existing target-item row); §4.4 `Update` RPC doc-comment (Tenant-gate block extended with the milestone-write paragraph — no struct/field change, `UpdateRequest` already carries `CallerOrgID` and `MilestoneID`); §6.2 Tool 5 `update` (gating prose extended to cover the `milestone_id` selector alongside the existing item gate — no wire change). **NOT touched (separate ownership): `apps/api/workitems/workitems.go` (the `Update` `WHERE`-clause milestone gate + the now-accurate doc-comment) + `apps/api/exitcriteriontest/write_surface_cross_tenant_test.go` (the missing owned-item + foreign-milestone subtest) — the implementation bead `unblock-tv8.84` (Greta) owns those on its branch.** **No DDL / migration / public-API / struct change** — the gate is a query predicate; the existence-only FK is untouched. **Root `docs/SPEC.md` is untouched** — no DDL change, and its §5.6 RBAC prose (row-level filtering applies "uniformly to every read and write path") is strengthened, not contradicted. Spec status remains APPROVED.
 - 2026-06-15 — `create_milestone.project_id` INSERT-scope tenant gate (bead `unblock-tv8.83`, discovered-from the live MCP sweep / `unblock-tv8.78`, proven live 2026-06-12; status remains APPROVED — this is an additive §10.1.1 gate-model extension closing the LAST ungated cross-reference write-IDOR in the family, `create_milestone.project_id`, NOT a re-architecting). `workitems.CreateMilestone` inserted the project-scoped milestone's wire-supplied `project_id` with NO check that it belongs to the caller's org — the same IDOR class already closed for `.75` (`CreateLabel.project_id`), `.77` (`CreateMilestone.parent_milestone_id`), `.78` (`workitems.Create.*`), and `.80` (`AppendComment.parent_id`). `create_milestone.project_id` was the one remaining selector. **Locked contract:** on the **project-scoped branch** (non-empty `project_id`), the milestone INSERT becomes a guarded `INSERT … SELECT` requiring `project_id IN (SELECT id FROM org.projects WHERE org_id = $caller)` — mirroring the EXISTING `CreateLabel` INSERT…SELECT precedent: a foreign-but-existing `project_id` yields zero source rows → `NOT_FOUND`, nothing inserted, indistinguishable from a missing project. The **org-scoped branch** (`org_id` set, `project_id` empty) carries no project predicate, and the **empty-`CallerOrgID` no-op IS preserved** (a DELIBERATE divergence from `CreateLabel`'s hard-reject — `CreateMilestone` has trusted internal / E2E-seed callers per §10.1.1). The already-gated `parent_milestone_id` parent-read seam (bead `unblock-tv8.77`) is preserved unchanged. Patched in lockstep: §10.1.1 write-surface predicate table (new `workitems.CreateMilestone` `project_id` INSERT-scope row); §6.2 Tool 16 `create_milestone` (gating prose extended to cover the `project_id` selector alongside the existing parent-read seam — no wire change); §4.4.1 `CreateMilestone` doc-comment (Tenant-gate block extended with the project-scoped INSERT…SELECT paragraph — no struct/field change, `CreateMilestoneRequest` already carries `CallerOrgID`). **NOT touched (separate ownership): `apps/api/workitems/workitems.go` (the guarded INSERT…SELECT) + tests — the implementation bead `unblock-tv8.83` (Greta) owns those on its branch.** **No DDL / migration / public-API / struct change** — the gate is a query predicate; the existence-only FK is untouched. **Root `docs/SPEC.md` is untouched** — no DDL change, and its §5.6 RBAC prose already states row-level filtering applies "uniformly to every read and write path" (strengthened, not contradicted). Spec status remains APPROVED.
@@ -612,8 +613,39 @@ package org
 //encore:api private method=POST path=/org.CreateOrganization
 func CreateOrganization(ctx context.Context, req CreateOrganizationRequest) (*Organization, error)
 
+// **Tenant gate (bead `unblock-tv8.86`).** This RPC INSERTs a `org.projects`
+// row under the wire-supplied `OrgID`. Pre-this-round the only guard was the
+// `org_id` FK → `NotFound`, which catches a NON-EXISTENT org but NOT a
+// FOREIGN EXISTING one — so a caller could create a project under any other
+// tenant's org (a WARNING-class cross-tenant write IDOR). It is NOT reachable
+// from the MCP agent wire today (no MCP tool maps to it; only test/seed
+// callers exist) — LATENTLY exploitable once a future key-management /
+// web-admin BFF is wired. The gate adds a `CallerUserID` channel pinned from
+// the resolved caller identity (the future BFF's session→user→org resolution,
+// §4.3.2), NEVER from the wire — exactly the §10.1.1 internal-channel
+// convention, NOT a wire argument. When `CallerUserID` is non-empty the RPC
+// requires the caller to be a write-capable member of `OrgID`
+// (`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2`, §4.2 /
+// `apps/api/org/org.go:520`) BEFORE the INSERT; a foreign / non-member
+// `OrgID` → `NOT_FOUND` (replacing the FK→`NotFound`, which only catches a
+// non-existent org), nothing inserted, existence not leaked. **Empty
+// `CallerUserID` is a NO-OP (dormant gate)** — the trusted §11.1.1 seed +
+// `org` / `rbactest` / `exitcriteriontest` / `perftest` callers pass no
+// caller identity, so the gate is skipped; DORMANT until the future BFF pins
+// `CallerUserID`; that future bead MUST pin it (else the no-op leaves it
+// open). Same empty-caller no-op precedent as `unblock-tv8.85` / the §10.1.1
+// item/milestone write-RPC pattern. NO `org` schema change is required — the
+// gate is a membership predicate.
+//
 //encore:api private method=POST path=/org.CreateProject
 func CreateProject(ctx context.Context, req CreateProjectRequest) (*Project, error)
+
+type CreateProjectRequest struct {
+    OrgID         string // ULID; the org the project is created under
+    Name          string
+    Slug          string
+    CallerUserID  string // ULID; pinned from the resolved caller identity (future BFF session→user→org resolution, §4.3.2); NEVER from the wire. Gate key for the org.members caller-membership predicate (bead unblock-tv8.86). Empty → dormant no-op (trusted §11.1.1 seed / org / rbactest / exitcriteriontest / perftest callers).
+}
 
 //encore:api private method=GET path=/org.GetOrganization/:id
 func GetOrganization(ctx context.Context, id string) (*Organization, error)
@@ -621,13 +653,57 @@ func GetOrganization(ctx context.Context, id string) (*Organization, error)
 //encore:api private method=GET path=/org.GetProject/:id
 func GetProject(ctx context.Context, id string) (*Project, error)
 
+// **Tenant gate (bead `unblock-tv8.86`) — CRITICAL privilege escalation.**
+// This RPC INSERTs an `org.members` row from the wire-supplied `OrgID`,
+// `UserID`, and `Role` with ZERO caller-ownership check — `callerIdentity`
+// feeds only the `invited_by` audit column, NEVER authorization — and `Role`
+// has no cap. So a caller could mint themselves (or anyone) as `owner` of ANY
+// existing org: a CRITICAL cross-tenant privilege escalation. It is NOT
+// reachable from the MCP agent wire today (no MCP tool maps to it; only
+// test/seed callers exist) — LATENTLY exploitable once a future
+// key-management / web-admin BFF is wired. The gate adds a `CallerUserID`
+// channel pinned from the resolved caller identity (the future BFF's
+// session→user→org resolution, §4.3.2), NEVER from the wire — exactly the
+// §10.1.1 internal-channel convention, NOT a wire argument. When
+// `CallerUserID` is non-empty the RPC enforces BOTH: (a) the caller holds an
+// admin/owner `org.members` row in `OrgID`
+// (`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2`, §4.2 /
+// `apps/api/org/org.go:520`) BEFORE the INSERT; and (b) the granted `Role` is
+// CAPPED at the caller's effective role — a caller cannot grant a role above
+// their own. A foreign / non-member `OrgID`, an unauthorised (non-admin)
+// caller, or an over-grant → `NOT_FOUND` / appropriate error, nothing
+// inserted, existence not leaked. **Empty `CallerUserID` is a NO-OP (dormant
+// gate)** — the trusted §11.1.1 seed + `org` / `rbactest` /
+// `exitcriteriontest` / `perftest` callers pass no caller identity, so the
+// gate is skipped; DORMANT until the future BFF pins `CallerUserID`; that
+// future bead MUST pin it (else the no-op leaves the priv-esc open). Same
+// empty-caller no-op precedent as `unblock-tv8.85` / the §10.1.1
+// item/milestone write-RPC pattern. NO `org` schema change is required — the
+// gate is a membership predicate + a role cap.
+//
 //encore:api private method=POST path=/org.AddMember
 func AddMember(ctx context.Context, req AddMemberRequest) error
 
-// Authorize is the canonical RBAC predicate. Called by every other service
-// before reading or writing a resource. Returns nil on permit;
-// ErrForbidden on deny. The org_id of the resource is matched against the
-// identity's org_id; cross-tenant calls are rejected here.
+type AddMemberRequest struct {
+    OrgID         string // ULID; the org the member is added to
+    UserID        string // ULID; the user being added
+    Role          string // role granted — CAPPED at the caller's effective role when CallerUserID is non-empty (bead unblock-tv8.86)
+    CallerUserID  string // ULID; pinned from the resolved caller identity (future BFF session→user→org resolution, §4.3.2); NEVER from the wire. Gate key for the org.members caller-admin predicate + role cap (bead unblock-tv8.86); also feeds the invited_by audit column. Empty → dormant no-op (trusted §11.1.1 seed / org / rbactest / exitcriteriontest / perftest callers).
+}
+
+// Authorize is the canonical CROSS-SERVICE RBAC predicate. Called by every
+// OTHER service before reading or writing a resource it owns. Returns nil on
+// permit; ErrForbidden on deny. The org_id of the resource is matched against
+// the identity's org_id; cross-tenant calls are rejected here.
+//
+// NOTE (bead `unblock-tv8.86`): the `org` service's OWN tenant-scoped write
+// RPCs (`CreateProject`, `AddMember`) do NOT route through `Authorize` — they
+// self-gate via the new `CallerUserID` `org.members` membership predicate
+// documented on each RPC above (dormant until the future BFF pins the caller).
+// `Authorize` remains the cross-service primitive that OTHER services call;
+// it is NOT the gate for `org`'s own provisioning writes. (Bootstrapping
+// writes — `CreateOrganization`, where the caller BECOMES the owner — carry
+// no membership gate by design and are correctly out of scope.)
 //
 //encore:api private method=POST path=/org.Authorize
 func Authorize(ctx context.Context, req AuthorizeRequest) error
@@ -640,6 +716,13 @@ type AuthorizeRequest struct {
     ProjectID  string // optional
 }
 ```
+
+> **Future RPC note (bead `unblock-tv8.86`):** `org.project_members` has no
+> write RPC yet (seed-only). A future `AddProjectMember`-style RPC will need
+> the IDENTICAL caller-membership gate (`CallerUserID` `org.members` /
+> `org.project_members` predicate, dormant empty-caller no-op) before it
+> INSERTs a project-membership row from the wire — else it reopens the same
+> IDOR class on the project-membership surface.
 
 ### 4.3 `mcp` service
 
@@ -3862,25 +3945,58 @@ writes `mcp.api_keys` via direct INSERT), so the IDORs they close are
 This is the same IDOR class as `.75` / `.77` / `.78` / `.80` / `.83` / `.84`,
 on the ADMIN/BFF surface instead of the MCP wire.
 
+**Org-provisioning write surface (bead `unblock-tv8.86`).** The 2026-06-15
+admin/BFF surface IDOR sweep that produced `.85` set aside the SIBLING
+org-provisioning RPCs on this same admin surface; this round adds them. Two
+`private` `org` RPCs (`apps/api/org/org.go`, §4.2) write tenant-scoped rows
+from the wire with NO caller-ownership check: **(1) `org.AddMember`** —
+INSERTs an `org.members` row from the wire-supplied `OrgID`/`UserID`/`Role`
+with ZERO caller check (`callerIdentity` feeds only the `invited_by` audit
+column, never authorization) and NO `Role` cap → a CRITICAL cross-tenant
+privilege escalation (a caller could mint itself `owner` of ANY org);
+**(2) `org.CreateProject`** — INSERTs an `org.projects` row under the
+wire-supplied `OrgID` guarded only by the FK→`NotFound`, which catches a
+NON-EXISTENT org but NOT a FOREIGN existing one (a WARNING-class write IDOR).
+Like the `auth` rows, NEITHER is MCP-wire-reachable today (no MCP tool maps to
+them; only test/seed callers), so both IDORs are **LATENT** — exploitable
+cross-tenant only once a future key-management / web-admin BFF is wired. Same
+IDOR class + dormant-gate pattern as `.85`, on the org-provisioning surface.
+**Bootstrapping writes are correctly OUT of scope:** `org.CreateOrganization`
+(the caller BECOMES the owner) and `auth.ExchangeOAuthCode` / `auth.Validate`
+(identity establishment) carry no membership gate by design.
+
 | RPC (auth/BFF admin) | Predicate form |
 |---|---|
 | `auth.RevokeAPIKey` (§4.1) | the UPDATE gains `id=$1 AND ($caller='' OR org_id=$caller)`, with `$caller` = the new `CallerOrgID` channel (pinned from the resolved session identity, §4.3.2, NEVER from the wire). A cross-tenant `KeyID` affects zero rows → `NOT_FOUND` (existence not leaked); the `COALESCE` idempotency is preserved. |
 | `auth.IssueAPIKey` (§4.1) | gate on BOTH (a) caller-owns-org — `org.Authorize` keyed on the new `CallerUserID` channel (`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2`, §4.2 / `apps/api/org/org.go:520`) — and (b) `IssuedToUser ∈ org.members(OrgID)` (membership predicate; infra: `org.members` per migration `0030`, `org.AddMember` §4.2). A foreign `OrgID` or a non-member `IssuedToUser` → rejected (`NOT_FOUND` / appropriate error), nothing inserted, existence not leaked. |
+| `org.AddMember` (§4.2) — **CRITICAL priv-esc** (bead `unblock-tv8.86`) | the INSERT of an `org.members` row from the wire-supplied `OrgID`/`UserID`/`Role` gains the new `CallerUserID` channel (pinned from the resolved session identity, §4.3.2, NEVER from the wire — `callerIdentity` previously fed only the `invited_by` audit column, never authorization). When `$caller` is non-empty the RPC requires BOTH (a) the caller holds an **admin/owner** `org.members` row in `OrgID` (`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2`, §4.2 / `apps/api/org/org.go:520`) AND (b) the granted `Role` is **capped at the caller's effective role** (no granting above one's own). A foreign / non-member `OrgID`, an unauthorised (non-admin) caller, or an over-grant → `NOT_FOUND` / appropriate error, nothing inserted, existence not leaked. Closes a CRITICAL cross-tenant privilege-escalation (a caller could mint itself `owner` of ANY org). |
+| `org.CreateProject` (§4.2) (bead `unblock-tv8.86`) | the INSERT of an `org.projects` row under the wire-supplied `OrgID` gains the new `CallerUserID` channel (pinned from the resolved session identity, §4.3.2, NEVER from the wire). When `$caller` is non-empty the RPC requires the caller to be a **write-capable member** of `OrgID` (`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2`, §4.2 / `apps/api/org/org.go:520`) before the INSERT. A foreign / non-member `OrgID` → `NOT_FOUND`, **replacing the bare FK→`NotFound`** (which only caught a non-existent org, not a foreign existing one), nothing inserted, existence not leaked. |
 
-Both take the **empty-caller NO-OP form** — `RevokeAPIKey`'s `$caller=''`
-disjunct and `IssueAPIKey`'s empty-`CallerUserID` skip — exactly the
-empty-`CallerOrgID` no-op precedent ratified above (the item/milestone
-write-RPC pattern), NOT the `CreateLabel` hard-reject: the trusted §11.1.1
-E2E seed + integration / mcpaudit / perf tests pass no caller identity (or
-seed `mcp.api_keys` via direct INSERT). The gate is therefore **DORMANT until
-the future key-management BFF / admin surface is wired**, and that future bead
-MUST pin the caller identity (`CallerOrgID` / `CallerUserID`) — else the no-op
-leaves the IDOR open. Cross-tenant probes return `NOT_FOUND`, never leaking
-existence. **NO `mcp.api_keys` schema / DDL / migration change** — the gates
-are a query predicate + an `org.Authorize` call + a membership predicate; the
-`mcp.api_keys` schema is unchanged. The load-bearing code lives in
-`apps/api/auth/auth.go` (`IssueAPIKey` / `RevokeAPIKey` + the new request
-fields), updated in lockstep on the implementation bead's branch.
+All four take the **empty-caller NO-OP form** — `RevokeAPIKey`'s `$caller=''`
+disjunct, and the empty-`CallerUserID` skip on `IssueAPIKey` / `org.AddMember`
+/ `org.CreateProject` — exactly the empty-`CallerOrgID` no-op precedent
+ratified above (the item/milestone write-RPC pattern), NOT the `CreateLabel`
+hard-reject: the trusted §11.1.1 E2E seed + integration / mcpaudit / perf
+tests pass no caller identity (or seed `mcp.api_keys` via direct INSERT), and
+the trusted §11.1.1 seed + `org` / `rbactest` / `exitcriteriontest` /
+`perftest` callers drive the `org` RPCs with no caller identity. The gate is
+therefore **DORMANT until the future key-management BFF / admin surface is
+wired**, and that future bead MUST pin the caller identity
+(`CallerOrgID` / `CallerUserID`) — else the no-op leaves the IDOR (and, for
+`org.AddMember`, the priv-esc) open. Cross-tenant probes return `NOT_FOUND`,
+never leaking existence. **NO `mcp.api_keys` NOR `org` schema / DDL / migration
+change** — the gates are query predicates + an `org.Authorize` call +
+membership predicates + (for `org.AddMember`) a role cap; the `mcp.api_keys`
+and `org` schemas are unchanged. The infra all CONFIRMED present:
+`org.members` (migration `0030`), `org.Authorize` (`org.go:520`, the
+`SELECT role FROM org.members WHERE org_id=$1 AND user_id=$2` membership/role
+check), and the org service owns the `org` schema (direct read OK). The
+load-bearing code lives in `apps/api/auth/auth.go` (`IssueAPIKey` /
+`RevokeAPIKey` + the new request fields) and `apps/api/org/org.go`
+(`AddMember` / `CreateProject` gates + the new `CallerUserID` request fields),
+updated in lockstep on the implementation bead's branch. (`org.project_members`
+has no write RPC yet — seed-only; a future `AddProjectMember`-style RPC will
+need the IDENTICAL caller-membership gate, noted in §4.2.)
 
 The load-bearing description of this write-gate model lives in the
 `apps/api/workitems/workitems.go` auth-model doc-comment (§10.1 read-side


### PR DESCRIPTION
## unblock-tv8.86: org-provisioning write-surface tenant gates

`org.AddMember` and `org.CreateProject` wrote tenant-scoped rows (`org.members`, `org.projects`) straight from the wire with no caller-ownership check — a latent cross-tenant write IDOR, and for `AddMember` a CRITICAL privilege escalation (any caller could mint itself `owner` of any org). Latent today (tests-only callers); exploitable once a key-management/web-admin BFF is wired.

### What was done
- **org.AddMember**: new off-wire `CallerUserID` channel (pinned from resolved identity, NEVER the wire); when non-empty require caller to hold an admin/owner `org.members` row in `OrgID` AND cap granted `Role` at caller's effective role. Foreign/non-admin → `NotFound`; over-grant → `PermissionDenied`; nothing inserted.
- **org.CreateProject**: new `CallerUserID` channel; when non-empty require caller to be a write-capable member of `OrgID`; foreign/non-member → `NotFound` (replacing the FK→`NotFound` that only caught a non-existent org).
- New `orgMemberRole` helper reads `org.members` directly (org owns the schema); reuses existing `roleStrength`/`rolePermits`.
- **AC3**: corrected the false `workitems.go` doc-comment that claimed org writes gate on a `CallerOrgID` channel that never existed.
- Empty-`CallerUserID` no-op preserves the §11.1.1 seed + org/rbactest/exitcriteriontest/perftest callers. **Gate DORMANT** until a future BFF pins `CallerUserID` — that future bead MUST pin it.
- No DDL/migration/schema change.

### Files changed
- `apps/api/org/org.go`
- `apps/api/org/caller_gate_test.go` (new — 10 cross-tenant negative + positive tests)
- `apps/api/workitems/workitems.go` (doc-comment correction)

### Decisions
- Over-grant → `PermissionDenied` (authz failure); non-member/non-admin/foreign-org → `NotFound` (existence not leaked).

### Deviations
None — implemented as spec (§4.2 + §10.1.1, landed on main as f6d5d3b).

### Tests
`encore test ./...` green (incl. 10 new gate tests); `go vet ./...`, JSON snake_case tag gate, `gofmt`, `encore check` all clean.