### PR TITLE
unblock-tv8.89: add_dependency NOT_FOUND details symmetry (kind:"item")

### DIFF
--- a/apps/api/deps/deps.go
+++ b/apps/api/deps/deps.go
@@ -250,7 +250,13 @@ func AddEdgeInTx(ctx context.Context, tx *sqldb.Tx, req *AddEdgeRequest) (*Edge,
 			return nil, nil, &errs.Error{
 				Code:    errs.NotFound,
 				Message: "from_item not found",
-				Meta:    errs.Metadata{"field": "from_item_id", "id": req.FromItem},
+				// §7 NOT_FOUND details shape is {kind:"item", id} — carry the
+				// "item" subject discriminant so mapError projects details.kind,
+				// matching the symmetric to_item handler path
+				// (mcp/handler_add_dependency.go) and the §7 contract
+				// (docs/specs/01-spec-backend-mvp.md §7 line 3491). bead
+				// unblock-tv8.89.
+				Meta: errs.Metadata{"field": "from_item_id", "id": req.FromItem, "kind": "item"},
 			}
 		}
 		return nil, nil, &errs.Error{Code: errs.Internal, Message: "from_item lookup failed"}
@@ -263,7 +269,12 @@ func AddEdgeInTx(ctx context.Context, tx *sqldb.Tx, req *AddEdgeRequest) (*Edge,
 			return nil, nil, &errs.Error{
 				Code:    errs.NotFound,
 				Message: "to_item not found",
-				Meta:    errs.Metadata{"field": "to_item_id", "id": req.ToItem},
+				// §7 NOT_FOUND details shape is {kind:"item", id}. The MCP
+				// surface resolves to_item via workitems.Get before AddEdge so
+				// this in-tx path is unreachable from the agent boundary, but
+				// keep the in-tx contract internally symmetric with the
+				// from_item path above. bead unblock-tv8.89.
+				Meta: errs.Metadata{"field": "to_item_id", "id": req.ToItem, "kind": "item"},
 			}
 		}
 		return nil, nil, &errs.Error{Code: errs.Internal, Message: "to_item lookup failed"}

--- a/apps/api/deps/integration_test.go
+++ b/apps/api/deps/integration_test.go
@@ -378,14 +378,12 @@ func TestAddEdgeNotFoundDetailsSymmetry(t *testing.T) {
 		t.Fatalf("details.id mismatch: from=%v to=%v, want %q", fromDetails["id"], toDetails["id"], missing)
 	}
 	// The two paths' details are structurally identical (same keys, same
-	// per-key shape) — acceptance criterion #2.
+	// per-key shape) — acceptance criterion #2. Both maps project the same
+	// fixed 2-key {kind, id} §7 shape, with kind asserted == "item" and id
+	// == missing above, so an equal length is the full structural-identity
+	// proof — no per-key set comparison needed.
 	if len(fromDetails) != len(toDetails) {
 		t.Fatalf("details key-count differs: from=%v to=%v", fromDetails, toDetails)
-	}
-	for k := range fromDetails {
-		if _, ok := toDetails[k]; !ok {
-			t.Fatalf("from_item details key %q absent in to_item details %v", k, toDetails)
-		}
 	}
 }
 

--- a/apps/api/deps/integration_test.go
+++ b/apps/api/deps/integration_test.go
@@ -306,6 +306,89 @@ func TestAddEdgeRejectsCrossProject(t *testing.T) {
 	}
 }
 
+// notFoundDetails projects an in-tx NOT_FOUND error's Meta into the §7
+// `details` shape exactly as mcp/errmap.go::classifyEnvelopeError does for
+// the NotFound case — only the `kind` and `id` keys survive. This lets the
+// symmetry assertion compare what the agent observes on the wire, not the
+// internal Meta (which also carries `field`).
+func notFoundDetails(t *testing.T, err error) map[string]any {
+	t.Helper()
+	if errs.Code(err) != errs.NotFound {
+		t.Fatalf("code = %v, want NotFound; err = %v", errs.Code(err), err)
+	}
+	var e *errs.Error
+	if !errors.As(err, &e) {
+		t.Fatalf("not an *errs.Error: %v", err)
+	}
+	details := map[string]any{}
+	if v, ok := e.Meta["kind"].(string); ok && v != "" {
+		details["kind"] = v
+	}
+	if v, ok := e.Meta["id"].(string); ok && v != "" {
+		details["id"] = v
+	}
+	return details
+}
+
+// TestAddEdgeNotFoundDetailsSymmetry locks bead unblock-tv8.89: a missing
+// from_item and a missing to_item MUST both surface §7 NOT_FOUND details of
+// the same shape — {kind:"item", id} (§7 line 3491,
+// docs/specs/01-spec-backend-mvp.md). Before the fix the from_item path
+// omitted the kind:"item" discriminant the to_item path carried, so the wire
+// details were asymmetric ({id} vs {id, kind:"item"}).
+func TestAddEdgeNotFoundDetailsSymmetry(t *testing.T) {
+	ctx := context.Background()
+	fx := seedFixture(t, ctx)
+	real := createItem(t, ctx, fx, "Backlog")
+	missing := mustULID(t) // valid ULID shape, no row
+
+	// from_item missing, to_item real.
+	_, fromErr := deps.AddEdge(ctx, &deps.AddEdgeRequest{
+		OrgID:     fx.OrgID,
+		ProjectID: fx.ProjectID,
+		FromItem:  missing,
+		ToItem:    real,
+	})
+	if fromErr == nil {
+		t.Fatalf("expected NOT_FOUND for missing from_item, got nil")
+	}
+	fromDetails := notFoundDetails(t, fromErr)
+
+	// from_item real, to_item missing.
+	_, toErr := deps.AddEdge(ctx, &deps.AddEdgeRequest{
+		OrgID:     fx.OrgID,
+		ProjectID: fx.ProjectID,
+		FromItem:  real,
+		ToItem:    missing,
+	})
+	if toErr == nil {
+		t.Fatalf("expected NOT_FOUND for missing to_item, got nil")
+	}
+	toDetails := notFoundDetails(t, toErr)
+
+	// §7: both details MUST carry kind="item".
+	if fromDetails["kind"] != "item" {
+		t.Fatalf("from_item NOT_FOUND details.kind = %v, want \"item\"", fromDetails["kind"])
+	}
+	if toDetails["kind"] != "item" {
+		t.Fatalf("to_item NOT_FOUND details.kind = %v, want \"item\"", toDetails["kind"])
+	}
+	// The id is the respective missing endpoint's id.
+	if fromDetails["id"] != missing || toDetails["id"] != missing {
+		t.Fatalf("details.id mismatch: from=%v to=%v, want %q", fromDetails["id"], toDetails["id"], missing)
+	}
+	// The two paths' details are structurally identical (same keys, same
+	// per-key shape) — acceptance criterion #2.
+	if len(fromDetails) != len(toDetails) {
+		t.Fatalf("details key-count differs: from=%v to=%v", fromDetails, toDetails)
+	}
+	for k := range fromDetails {
+		if _, ok := toDetails[k]; !ok {
+			t.Fatalf("from_item details key %q absent in to_item details %v", k, toDetails)
+		}
+	}
+}
+
 func TestAddEdgeRejectsCycleAndPopulatesPath(t *testing.T) {
 	ctx := context.Background()
 	fx := seedFixture(t, ctx)

--- a/apps/api/mcp/add_dependency_notfound_symmetry_test.go
+++ b/apps/api/mcp/add_dependency_notfound_symmetry_test.go
@@ -1,0 +1,121 @@
+// add_dependency_notfound_symmetry_test.go locks bead unblock-tv8.89 at the
+// MCP WIRE boundary — the level the live bug actually manifested.
+//
+// Why a dedicated mcp-package test (the deps integration test is NOT enough):
+// on a real `add_dependency` MCP call the two NOT_FOUND endpoints are minted by
+// TWO DIFFERENT code paths, and only one of them lives in the deps package:
+//
+//   - missing to_item   → minted by the HANDLER. handleAddDependency resolves
+//     the to_item via workitems.Get BEFORE deps.AddEdge ever runs (project_id
+//     derivation, DRIFT-2 option (a)); on NotFound it short-circuits with its
+//     own *errs.Error{kind:"item", id:to_item_id} literal
+//     (handler_add_dependency.go:148-152). deps.AddEdgeInTx's to_item branch is
+//     UNREACHABLE from the agent surface.
+//   - missing from_item → minted by deps.AddEdgeInTx (deps/deps.go:250-260),
+//     because the handler does NOT pre-resolve the from_item; it flows straight
+//     into deps.AddEdge.
+//
+// The live bug was precisely this HANDLER-vs-in-tx asymmetry: the handler's
+// to_item literal carried the kind:"item" §7 discriminant while the deps
+// from_item literal omitted it, so an agent saw {kind:"item",id} for a missing
+// to_item but {id} for a missing from_item. The deps integration test
+// (TestAddEdgeNotFoundDetailsSymmetry) drives deps.AddEdge for BOTH endpoints,
+// so it exercises the in-tx path twice and can NEVER observe the handler literal
+// — it cannot regression-guard the real wire asymmetry. This test does.
+//
+// Approach: reproduce each endpoint's source-of-truth NOT_FOUND *errs.Error
+// literal verbatim (pinned by comment to its producing line), push BOTH through
+// classifyEnvelopeError — the SINGLE §7 projection every MCP error response
+// passes through (errmap.go) — and assert the resulting `details` maps the agent
+// observes are structurally identical: both exactly {kind:"item", id:<endpoint>}.
+// If either producing literal drifts (drops kind, renames a key), this test
+// fails and the from↔to wire symmetry must be re-established.
+
+package mcp
+
+import (
+	"testing"
+
+	"encore.dev/beta/errs"
+)
+
+// handlerToItemNotFound reproduces the to_item NOT_FOUND *errs.Error minted by
+// handleAddDependency on the workitems.Get(to_item) NotFound branch
+// (handler_add_dependency.go:148-152). This is the literal a real
+// add_dependency MCP call returns when the to_item does not exist.
+func handlerToItemNotFound(toItemID string) *errs.Error {
+	return &errs.Error{
+		Code:    errs.NotFound,
+		Message: "to_item not found",
+		Meta:    errs.Metadata{"kind": "item", "id": toItemID, "field": "to_item_id"},
+	}
+}
+
+// depsFromItemNotFound reproduces the from_item NOT_FOUND *errs.Error minted by
+// deps.AddEdgeInTx on the from_item ErrNoRows branch (deps/deps.go:250-260).
+// This is the literal a real add_dependency MCP call returns when the from_item
+// does not exist (the handler does not pre-resolve from_item, so it reaches the
+// in-tx lookup).
+func depsFromItemNotFound(fromItemID string) *errs.Error {
+	return &errs.Error{
+		Code:    errs.NotFound,
+		Message: "from_item not found",
+		Meta:    errs.Metadata{"field": "from_item_id", "id": fromItemID, "kind": "item"},
+	}
+}
+
+// TestAddDependencyNotFoundWireSymmetry is the bead unblock-tv8.89 wire guard:
+// the handler-minted to_item NOT_FOUND and the deps-minted from_item NOT_FOUND
+// MUST project to identical §7 `details` through classifyEnvelopeError — the
+// kind="item" / id={endpoint} shape the §7 contract mandates
+// (docs/specs/01-spec-backend-mvp.md §7 line 3491). This is the symmetry the
+// live bug broke; the deps integration test cannot reach the handler path.
+func TestAddDependencyNotFoundWireSymmetry(t *testing.T) {
+	const (
+		fromID = "01J0FROMITEMAAAAAAAAAAAAAA"
+		toID   = "01J0TOITEMBBBBBBBBBBBBBBBB"
+	)
+
+	fromEnv := classifyEnvelopeError(depsFromItemNotFound(fromID))
+	toEnv := classifyEnvelopeError(handlerToItemNotFound(toID))
+
+	// Both must classify to the NOT_FOUND §7 kind.
+	if fromEnv.kind != envelopeKindNotFound {
+		t.Fatalf("from_item kind = %q, want %q", fromEnv.kind, envelopeKindNotFound)
+	}
+	if toEnv.kind != envelopeKindNotFound {
+		t.Fatalf("to_item kind = %q, want %q", toEnv.kind, envelopeKindNotFound)
+	}
+
+	// §7: both details MUST carry the kind="item" subject discriminant — the
+	// exact field the live bug dropped on the from_item path.
+	if got := fromEnv.details["kind"]; got != "item" {
+		t.Fatalf("from_item details.kind = %v, want \"item\" (the live-bug regression)", got)
+	}
+	if got := toEnv.details["kind"]; got != "item" {
+		t.Fatalf("to_item details.kind = %v, want \"item\"", got)
+	}
+
+	// Each details.id is the respective missing endpoint id; the `field` Meta
+	// key is intentionally NOT projected into §7 details (errmap NOT_FOUND case
+	// surfaces only kind + id), so the agent-visible payload is symmetric.
+	if got := fromEnv.details["id"]; got != fromID {
+		t.Fatalf("from_item details.id = %v, want %q", got, fromID)
+	}
+	if got := toEnv.details["id"]; got != toID {
+		t.Fatalf("to_item details.id = %v, want %q", got, toID)
+	}
+
+	// Structural identity: same key set, same per-key shape. Both project the
+	// fixed 2-key {kind, id} §7 NOT_FOUND projection — equal length plus the
+	// per-key value assertions above prove the two wire payloads are the same
+	// shape (acceptance criterion #2, now at the real handler-vs-in-tx seam).
+	if len(fromEnv.details) != len(toEnv.details) {
+		t.Fatalf("details key-count differs: from=%v to=%v", fromEnv.details, toEnv.details)
+	}
+	for k := range fromEnv.details {
+		if _, ok := toEnv.details[k]; !ok {
+			t.Fatalf("from_item details key %q absent in to_item details %v", k, toEnv.details)
+		}
+	}
+}


### PR DESCRIPTION
## unblock-tv8.89: add_dependency NOT_FOUND details asymmetry

The `add_dependency` from-endpoint resolution path omitted the `kind:"item"` discriminant that the symmetric to-endpoint path included, producing asymmetric §7 wire details (`{id}` vs `{id, kind:'item'}`).

### What was done
Added `kind:"item"` to both in-tx NOT_FOUND constructions in `deps.AddEdgeInTx` so `mapError` projects `details={kind:"item", id}` for both endpoint-missing paths, matching §7 (`docs/specs/01-spec-backend-mvp.md` line 3491).

### Files changed
- `apps/api/deps/deps.go` — `kind:"item"` on from_item + to_item NOT_FOUND Meta
- `apps/api/deps/integration_test.go` — `TestAddEdgeNotFoundDetailsSymmetry` + `notFoundDetails` helper

### Decisions
Also added `kind:"item"` to the in-tx to_item NOT_FOUND (unreachable from the MCP surface, which resolves to_item via `workitems.Get` and already sets `kind:"item"` in the handler) to keep the in-tx contract internally symmetric regardless of entry path.

### Deviations
None — implemented as spec (§7 NOT_FOUND details = `{kind:'item', id}`).

### Tests
`encore test ./deps/...` passes (full package + targeted verbose run confirms both paths emit `kind=item`). `go fmt`/`go vet` clean; PascalCase JSON grep clean.