### PR TITLE
unblock-8xb.7: Migrations 0150 + 0170 — sanitiser_events table + DROP webhook_secret_enc

### DIFF
--- a/apps/api/db/migrations/0150_memory_sanitiser_events.up.sql
+++ b/apps/api/db/migrations/0150_memory_sanitiser_events.up.sql
@@ -1,0 +1,26 @@
+-- AR-14: audit every secret-sanitiser hit. Added in P02 (no P01 DDL).
+-- One row per sanitiser match (a single remember may produce N rows).
+-- Canonical DDL: docs/specs/02-spec-backend-complete.md §3.1(a) (bead unblock-8xb.7).
+-- Forward-only: no .down.sql (the entire P01+P02 set is up-only — CG-13).
+CREATE TABLE memory.sanitiser_events (
+    id              text         PRIMARY KEY,                 -- ULID
+    entry_id        text         REFERENCES memory.entries(id) ON DELETE CASCADE,
+                                                              -- nullable: a periodic re-scan hit
+                                                              -- (AR-14) or a sanitiser hit on a
+                                                              -- providers payload records NULL here
+    scope           text,                                    -- 'org'|'project'|'user' for memory hits; NULL for providers hits
+    org_id          text         REFERENCES org.organizations(id) ON DELETE CASCADE,
+    pattern_id      text         NOT NULL,                    -- stable id from the §5.4.1 registry, e.g. 'github_pat'
+    category        text         NOT NULL,                    -- 'credential' | 'pii' (coarse class)
+    source          text         NOT NULL,                    -- 'memory_write' | 'memory_rescan' | 'providers_payload'
+    redaction_count integer      NOT NULL DEFAULT 1,          -- matches collapsed under one (pattern, field)
+    detected_at     timestamptz  NOT NULL DEFAULT now(),
+    CONSTRAINT sanitiser_events_category_chk
+        CHECK (category IN ('credential', 'pii')),
+    CONSTRAINT sanitiser_events_source_chk
+        CHECK (source IN ('memory_write', 'memory_rescan', 'providers_payload'))
+);
+CREATE INDEX sanitiser_events_entry_idx ON memory.sanitiser_events (entry_id);
+CREATE INDEX sanitiser_events_org_detected_idx
+    ON memory.sanitiser_events (org_id, detected_at DESC);
+CREATE INDEX sanitiser_events_pattern_idx ON memory.sanitiser_events (pattern_id);

--- a/apps/api/db/migrations/0170_providers_drop_webhook_secret.up.sql
+++ b/apps/api/db/migrations/0170_providers_drop_webhook_secret.up.sql
@@ -1,0 +1,9 @@
+-- C1 / Q7 (RESOLVED 2026-06-16 = DROP). Under the confirmed GitHub-App path
+-- the webhook secret is app-level (one secret for all installs); HMAC
+-- verifies against the Encore secret GITHUB_APP_WEBHOOK_SECRET, NOT a
+-- per-install column. providers.installations is an empty stub
+-- pre-production, so the drop is safe. Re-added by a future migration when
+-- the OAuth-app / GitLab per-install fallback ships (v1.1). 0060 NOT edited.
+-- Canonical DDL: docs/specs/02-spec-backend-complete.md §3.1(d) (bead unblock-8xb.7).
+-- Forward-only: no .down.sql (the entire P01+P02 set is up-only — CG-13).
+ALTER TABLE providers.installations DROP COLUMN webhook_secret_enc;


### PR DESCRIPTION
## unblock-8xb.7: Migrations 0150 + 0170

Two forward-only P02 migrations per docs/specs/02-spec-backend-complete.md §3.1(a) and §3.1(d).

### What was done
- `0150_memory_sanitiser_events.up.sql` — AR-14 audit table `memory.sanitiser_events` (9 columns, 2 CHECK constraints, 3 explicit indexes). `entry_id`/`scope`/`org_id` nullable to serve memory writes, providers payloads, and the AR-14 re-scan.
- `0170_providers_drop_webhook_secret.up.sql` — `ALTER TABLE providers.installations DROP COLUMN webhook_secret_enc` (C1/Q7 = DROP; HMAC verifies the app-level Encore secret only). `installation_id_enc` remains the sole `*_enc` column.

No `.down.sql` (P01+P02 set is up-only, CG-13). `0060`/`0090` unmodified.

### Files changed
- `apps/api/db/migrations/0150_memory_sanitiser_events.up.sql` (new)
- `apps/api/db/migrations/0170_providers_drop_webhook_secret.up.sql` (new)

### Decisions
None — DDL transcribed verbatim from spec.

### Deviations
None — implemented as spec.

### Verification
`encore test ./org/...` passes (fresh cluster migration replay). Live dev DB after migration run: `schema_migrations` at version 170 clean; `sanitiser_events` present with 3 indexes + 2 CHECKs; `webhook_secret_enc` removed.