### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,9 @@ target/
 *.swp
 *~
 
+# Claude Code harness — isolated agent worktrees (transient checkouts, never committed).
+# Scoped to the worktrees dir only: the tracked .claude/agents/ and .claude/settings.json stay versioned.
+/.claude/worktrees/
+
 # Archived pre-rewrite reference material (not part of the workspace)
 temp


### PR DESCRIPTION
Adds `/.claude/worktrees/` to `.gitignore`.

**Why:** the harness creates isolated agent worktrees under `.claude/worktrees/`; they are transient checkouts that showed up as untracked `?? .claude/worktrees/...` entries in `git status` (surfaced during T1.7). A careless `git add -A` could stage a nested worktree checkout into a commit.

**Scoped, not blanket:** ignores only the worktrees dir. Verified `git ls-files .claude/` keeps `.claude/agents/*.md` (12) + `.claude/settings.json` tracked, and `git check-ignore` confirms:
- `.claude/worktrees/agent-abc/foo.rs` → matched (`/.claude/worktrees/`)
- `.claude/settings.json`, `.claude/agents/*.md` → NOT matched (stay versioned)

One-line change; no code touched.